### PR TITLE
FrontEnd: Fix "npm prepare" script

### DIFF
--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -32,7 +32,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "prepare": "cd .. && husky install frontend/.husky",
+    "prepare": "cd .. && husky install FrontEnd/.husky",
     "format": "prettier --write src",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint-fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",


### PR DESCRIPTION
It appears when the frontend was renamed to "FrontEnd" the script wasn't updated.