### PR TITLE
Fix run-migrations.sh dropping -sN flag to mysql

### DIFF
--- a/frontend/db-migrations/unified-measurements-migrations/run-migrations.sh
+++ b/frontend/db-migrations/unified-measurements-migrations/run-migrations.sh
@@ -129,7 +129,7 @@ if [[ -n "$DB_PASSWORD" ]]; then
 fi
 
 run_sql() {
-    mysql "${MYSQL_BASE_ARGS[@]}" "$SCHEMA" -e "$1"
+    mysql "${MYSQL_BASE_ARGS[@]}" "${@:2}" "$SCHEMA" -e "$1"
 }
 
 run_sql_file() {


### PR DESCRIPTION
## Summary

`run_sql` was declared as:

```bash
run_sql() {
    mysql "${MYSQL_BASE_ARGS[@]}" "$SCHEMA" -e "$1"
}
```

It only forwards `$1` to mysql, silently dropping any additional arguments. `is_already_applied` relies on `-sN` to get a bare count:

```bash
count=$(run_sql "SELECT COUNT(*) FROM $MIGRATION_TRACKING_TABLE WHERE migration_file='$file' AND status='applied'" -sN 2>/dev/null)
[[ "$count" == "1" ]]
```

Without `-sN`, mysql returns a tabular box (`+--------+ | COUNT(*) | ...`), so `count` never equals `"1"`. Every migration is reported pending — including ones already in `_migration_log`. On an already-migrated schema a non-dry run would attempt to re-apply all 38 migrations and fail on the first conflicting DDL.

Fix: forward all extra arguments (`${@:2}`) before the schema name so flags like `-sN` reach mysql. The same pattern also exists in `restore_backup` (lines 246, 257), which benefits from the same fix.

## Verified

Dry-run against `forestgeo_harvard` (already at migration 49 after today's patch) before the fix listed all 38 as pending; after the fix it reports "All migrations already applied. Nothing to do."

## Test plan

- [ ] `./run-migrations.sh forestgeo_testing_mason --dry-run` reports zero pending on an up-to-date schema.
- [ ] `./run-migrations.sh <fresh schema> --dry-run` still correctly lists all migrations as pending.