### PR TITLE
fix(provisioning): split instrumentation so Edge bundle skips mysql2

### DIFF
--- a/frontend/instrumentation-node.ts
+++ b/frontend/instrumentation-node.ts
@@ -1,0 +1,32 @@
+/**
+ * Node-runtime instrumentation. Imported dynamically from `instrumentation.ts`
+ * only when `process.env.NEXT_RUNTIME === 'nodejs'` so the Edge bundle never
+ * pulls in mysql2 (which depends on `net`/`tls`/`timers`/`fs`/`path`).
+ *
+ * Splitting this out is the pattern recommended by the Next.js instrumentation
+ * docs for runtime-conditional side effects.
+ *
+ * Responsibilities:
+ *   - Install SIGTERM/SIGINT handlers in the provisioning worker so a graceful
+ *     shutdown stops heartbeats (rows go stale, next process recovers them).
+ *   - Pick up any `running` provisioning runs whose worker heartbeat went
+ *     silent — these are orphans from a previous process that crashed or was
+ *     SIGKILLed.
+ */
+import ailogger from '@/ailogger';
+import { getPoolMonitorInstance } from '@/config/poolmonitorsingleton';
+import { installShutdownHandler, pickupStaleRuns } from '@/lib/provisioning/worker';
+
+void (async () => {
+  try {
+    const pool = getPoolMonitorInstance().pool;
+    installShutdownHandler(pool);
+    const picked = await pickupStaleRuns(pool);
+    if (picked.length > 0) {
+      ailogger.info('provisioning.worker.startup', { pickedUpRuns: picked });
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    ailogger.warn('provisioning.worker.startup_failed', { errorMessage });
+  }
+})();

--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -1,43 +1,12 @@
 /**
- * Next.js instrumentation hook. Runs once per Node.js process at startup.
- *
- * Responsibilities:
- *   - Install SIGTERM/SIGINT handlers in the provisioning worker so a graceful
- *     shutdown stops heartbeats (rows go stale, next process recovers them).
- *   - Pick up any `running` provisioning runs whose worker heartbeat went
- *     silent — these are orphans from a previous process that crashed or was
- *     SIGKILLed.
- *
- * Edge runtime: the hook also runs in the Edge runtime; we skip there because
- * mysql2 is Node-only.
+ * Next.js instrumentation hook. Runs once per process at startup, in BOTH the
+ * Node and Edge runtimes. We only need to install provisioning hooks in Node,
+ * and the Node-only work transitively imports mysql2 which has no Edge build —
+ * so the dynamic import of the Node implementation must be gated by runtime
+ * and live in a separate file that the Edge bundle never resolves.
  */
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
-
-  let ailogger: typeof import('@/ailogger').default | null = null;
-  try {
-    const aiModule = await import('@/ailogger');
-    ailogger = aiModule.default;
-  } catch {
-    // ailogger init can fail in early bootstrap (e.g., AppInsights not ready);
-    // proceed without it so worker pickup can still run.
-  }
-
-  try {
-    const { pickupStaleRuns, installShutdownHandler } = await import('@/lib/provisioning/worker');
-    const { getPoolMonitorInstance } = await import('@/config/poolmonitorsingleton');
-    const pool = getPoolMonitorInstance().pool;
-    installShutdownHandler(pool);
-    const picked = await pickupStaleRuns(pool);
-    if (picked.length > 0 && ailogger) {
-      ailogger.info('provisioning.worker.startup', { pickedUpRuns: picked });
-    }
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
-    if (ailogger) {
-      ailogger.warn('provisioning.worker.startup_failed', { errorMessage });
-    } else {
-      console.warn('[instrumentation] provisioning worker startup failed:', errorMessage);
-    }
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./instrumentation-node');
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #330. The development deploy pipeline failed after the merge because Next.js bundles `instrumentation.ts` for **both** the Node and Edge runtimes. The original file gated all work behind `process.env.NEXT_RUNTIME === 'nodejs'`, but webpack still resolved the transitive imports for the Edge bundle — which has no `fs` / `path` / `net` / `tls` / `timers`. See the failing run: https://github.com/Smithsonian/ForestGEO/actions/runs/25877453186

Fix follows Next.js's recommended pattern:

- `instrumentation.ts` is now a thin shim that only runs `await import('./instrumentation-node')` when `NEXT_RUNTIME === 'nodejs'`
- `instrumentation-node.ts` (new) holds all the actual work — pool init, `installShutdownHandler`, `pickupStaleRuns`, ailogger calls

Verified locally with `NEXT_PUBLIC_E2E_TESTING=false npm run build` — clean.