### PR TITLE
fix(a11y): remediate SortSite round-2 accessibility findings

### DIFF
--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -88,6 +88,33 @@ describe('EditToolbar', () => {
     expect(screen.getByTestId('filter-errors')).toHaveAttribute('aria-label', 'Hide invalid measurements (3)');
   });
 
+  it('MUST render a zero-count status filter as disabled', () => {
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={handleRefresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="measurements"
+        errorControls={{ show: false, toggle: vi.fn(), count: 0 }}
+        validControls={{ show: true, toggle: vi.fn(), count: 4 }}
+        pendingControls={{ show: true, toggle: vi.fn(), count: 2 }}
+        otControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        msControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        nrControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        dynamicButtons={[]}
+      />
+    );
+
+    expect(screen.getByTestId('filter-errors')).toBeDisabled();
+  });
+
   it('uses the pending button as a pending-row filter toggle', async () => {
     const user = userEvent.setup();
     const togglePending = vi.fn();

--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -259,4 +259,27 @@ describe('EditToolbar', () => {
 
     expect(screen.getByRole('button', { name: /more actions/i })).toBeInTheDocument();
   });
+
+  it('MUST render the More button when only a validation menu is present', () => {
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={handleRefresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="attributes"
+        showToolbarActions
+        dynamicButtons={[]}
+        validationMenu={<div>validation</div>}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /more actions/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -213,4 +213,50 @@ describe('EditToolbar', () => {
     expect(screen.queryByRole('button', { name: 'Export as CSV' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'More actions' })).not.toBeInTheDocument();
   });
+
+  it('MUST NOT render the More button when there are no extra actions', () => {
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={handleRefresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="attributes"
+        showToolbarActions
+        dynamicButtons={[]}
+        validationMenu={null}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /more actions/i })).not.toBeInTheDocument();
+  });
+
+  it('MUST render the More button when a dynamic action with a tooltip exists', () => {
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={handleRefresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="attributes"
+        showToolbarActions
+        dynamicButtons={[{ label: 'Recalculate', tooltip: 'Recalculate values', onClick: vi.fn() }]}
+        validationMenu={null}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /more actions/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/config/sqlrdsdefinitions/core', async importOriginal => {
 vi.mock('@mui/x-data-grid', () => ({
   ColumnsPanelTrigger: ({ render }: any) => <>{render}</>,
   FilterPanelTrigger: ({ render }: any) => <>{render}</>,
-  QuickFilter: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  QuickFilter: ({ children, defaultExpanded, expanded, onExpandedChange, ...props }: any) => <div {...props}>{children}</div>,
   QuickFilterControl: ({ slotProps, ...props }: any) => <input aria-label={slotProps?.input?.['aria-label']} {...props} />,
   QuickFilterClear: ({ children, ...props }: any) => (
     <button type="button" {...props}>
@@ -19,11 +19,14 @@ vi.mock('@mui/x-data-grid', () => ({
     </button>
   ),
   Toolbar: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-  ToolbarButton: ({ children, ...props }: any) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  ),
+  ToolbarButton: ({ render, children, ...props }: any) =>
+    render ? (
+      render
+    ) : (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
   GridColDef: {},
   GridFilterModel: {},
   GridSlotProps: {},
@@ -117,6 +120,41 @@ describe('EditToolbar', () => {
     expect(togglePending).toHaveBeenCalledWith(false);
     expect(screen.getByTestId('filter-pending')).toHaveAttribute('aria-label', 'Hide pending measurements (2)');
     expect(screen.getByTestId('filter-pending')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('keeps the Refresh button operable when registered as a toolbar item', async () => {
+    const user = userEvent.setup();
+    const refresh = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={refresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="measurements"
+        errorControls={{ show: true, toggle: vi.fn(), count: 3 }}
+        validControls={{ show: true, toggle: vi.fn(), count: 4 }}
+        pendingControls={{ show: true, toggle: vi.fn(), count: 2 }}
+        otControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        msControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        nrControls={{ show: true, toggle: vi.fn(), count: 1 }}
+        dynamicButtons={[]}
+      />
+    );
+
+    const refreshButton = screen.getByTestId('refresh-button');
+    expect(refreshButton).toBeInTheDocument();
+
+    await user.click(refreshButton);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it('can hide the action buttons section for read-only pages', () => {

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -285,7 +285,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
               />
               <Divider orientation={'vertical'} sx={{ mx: 0.5, flexShrink: 0 }} />
               <Tooltip title={'Press Enter to apply filter'} open={isTyping} placement={'bottom'} arrow sx={{ flex: 1, minWidth: '150px', maxWidth: '400px' }}>
-                <QuickFilter style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+                <QuickFilter defaultExpanded style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
                   <QuickFilterControl
                     style={{ display: 'flex', flex: 1, minWidth: '100px' }}
                     placeholder={'Search All Fields...'}
@@ -314,105 +314,133 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
               </Tooltip>
             </Box>
             <Divider orientation={'vertical'} sx={{ mx: 1, flexShrink: 0 }} />
-            <Button
-              style={{ display: 'flex', minWidth: 'fit-content', flexShrink: 0 }}
-              color={'primary'}
-              startDecorator={<RefreshIcon />}
-              onClick={async () => await handleRefresh()}
-              data-testid="refresh-button"
-            >
-              Refresh
-            </Button>
+            <ToolbarButton
+              render={
+                <Button
+                  style={{ display: 'flex', minWidth: 'fit-content', flexShrink: 0 }}
+                  color={'primary'}
+                  startDecorator={<RefreshIcon />}
+                  onClick={async () => await handleRefresh()}
+                  data-testid="refresh-button"
+                >
+                  Refresh
+                </Button>
+              }
+            />
             {gridType === 'measurements' && (
               <Stack direction={'row'} spacing={1.5} sx={{ display: 'flex', alignItems: 'center', ml: 1, flexWrap: 'nowrap', flexShrink: 0 }}>
                 <Tooltip title={`Invalid: ${errorControls.count} (rows with unresolved errors)`}>
                   <Badge badgeContent={errorControls.count} size={'sm'}>
-                    <IconButton
-                      disabled={!errorControls.count}
-                      variant="soft"
-                      color={errorControls.show ? 'danger' : 'neutral'}
-                      onClick={() => errorControls.toggle(!errorControls.show)}
-                      aria-label={`${errorControls.show ? 'Hide' : 'Show'} invalid measurements (${errorControls.count})`}
-                      aria-pressed={errorControls.show}
-                      data-testid="filter-errors"
-                    >
-                      <Warning />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          disabled={!errorControls.count}
+                          variant="soft"
+                          color={errorControls.show ? 'danger' : 'neutral'}
+                          onClick={() => errorControls.toggle(!errorControls.show)}
+                          aria-label={`${errorControls.show ? 'Hide' : 'Show'} invalid measurements (${errorControls.count})`}
+                          aria-pressed={errorControls.show}
+                          data-testid="filter-errors"
+                        >
+                          <Warning />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
                 <Tooltip title={`Valid: (${validControls.count})`}>
                   <Badge badgeContent={validControls.count} size={'sm'}>
-                    <IconButton
-                      variant="soft"
-                      disabled={!validControls.count}
-                      color={validControls.show ? 'success' : 'neutral'}
-                      onClick={() => validControls.toggle(!validControls.show)}
-                      aria-label={`${validControls.show ? 'Hide' : 'Show'} valid measurements (${validControls.count})`}
-                      aria-pressed={validControls.show}
-                      data-testid="filter-valid"
-                    >
-                      <VerifiedIcon />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          variant="soft"
+                          disabled={!validControls.count}
+                          color={validControls.show ? 'success' : 'neutral'}
+                          onClick={() => validControls.toggle(!validControls.show)}
+                          aria-label={`${validControls.show ? 'Hide' : 'Show'} valid measurements (${validControls.count})`}
+                          aria-pressed={validControls.show}
+                          data-testid="filter-valid"
+                        >
+                          <VerifiedIcon />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
                 <Tooltip title={`Pending: (${pendingControls.count})`}>
                   <Badge badgeContent={pendingControls.count} size={'sm'}>
-                    <IconButton
-                      variant="soft"
-                      disabled={!pendingControls.count}
-                      color={pendingControls.show ? 'primary' : 'neutral'}
-                      onClick={() => pendingControls.toggle(!pendingControls.show)}
-                      aria-label={`${pendingControls.show ? 'Hide' : 'Show'} pending measurements (${pendingControls.count})`}
-                      aria-pressed={pendingControls.show}
-                      data-testid="filter-pending"
-                    >
-                      <ScheduleIcon />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          variant="soft"
+                          disabled={!pendingControls.count}
+                          color={pendingControls.show ? 'primary' : 'neutral'}
+                          onClick={() => pendingControls.toggle(!pendingControls.show)}
+                          aria-label={`${pendingControls.show ? 'Hide' : 'Show'} pending measurements (${pendingControls.count})`}
+                          aria-pressed={pendingControls.show}
+                          data-testid="filter-pending"
+                        >
+                          <ScheduleIcon />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
                 <Tooltip title={`Old Trees: ${otControls.count}`}>
                   <Badge badgeContent={otControls.count} size={'sm'}>
-                    <IconButton
-                      variant="soft"
-                      disabled={!otControls.count}
-                      color={otControls.show ? 'primary' : 'neutral'}
-                      onClick={() => otControls.toggle(!otControls.show)}
-                      aria-label={`${otControls.show ? 'Hide' : 'Show'} old trees (${otControls.count})`}
-                      aria-pressed={otControls.show}
-                      data-testid="filter-ot"
-                    >
-                      <Forest />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          variant="soft"
+                          disabled={!otControls.count}
+                          color={otControls.show ? 'primary' : 'neutral'}
+                          onClick={() => otControls.toggle(!otControls.show)}
+                          aria-label={`${otControls.show ? 'Hide' : 'Show'} old trees (${otControls.count})`}
+                          aria-pressed={otControls.show}
+                          data-testid="filter-ot"
+                        >
+                          <Forest />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
                 <Tooltip title={`Multi-Stems: ${msControls.count}`}>
                   <Badge badgeContent={msControls.count} size={'sm'}>
-                    <IconButton
-                      variant="soft"
-                      disabled={!msControls.count}
-                      color={msControls.show ? 'primary' : 'neutral'}
-                      onClick={() => msControls.toggle(!msControls.show)}
-                      aria-label={`${msControls.show ? 'Hide' : 'Show'} multi-stem trees (${msControls.count})`}
-                      aria-pressed={msControls.show}
-                      data-testid="filter-ms"
-                    >
-                      <CallSplit />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          variant="soft"
+                          disabled={!msControls.count}
+                          color={msControls.show ? 'primary' : 'neutral'}
+                          onClick={() => msControls.toggle(!msControls.show)}
+                          aria-label={`${msControls.show ? 'Hide' : 'Show'} multi-stem trees (${msControls.count})`}
+                          aria-pressed={msControls.show}
+                          data-testid="filter-ms"
+                        >
+                          <CallSplit />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
                 <Tooltip title={`New Recruits: ${nrControls.count}`}>
                   <Badge badgeContent={nrControls.count} size={'sm'}>
-                    <IconButton
-                      variant="soft"
-                      disabled={!nrControls.count}
-                      color={nrControls.show ? 'primary' : 'neutral'}
-                      onClick={() => nrControls.toggle(!nrControls.show)}
-                      aria-label={`${nrControls.show ? 'Hide' : 'Show'} new recruits (${nrControls.count})`}
-                      aria-pressed={nrControls.show}
-                      data-testid="filter-nr"
-                    >
-                      <Grass />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          variant="soft"
+                          disabled={!nrControls.count}
+                          color={nrControls.show ? 'primary' : 'neutral'}
+                          onClick={() => nrControls.toggle(!nrControls.show)}
+                          aria-label={`${nrControls.show ? 'Hide' : 'Show'} new recruits (${nrControls.count})`}
+                          aria-pressed={nrControls.show}
+                          data-testid="filter-nr"
+                        >
+                          <Grass />
+                        </IconButton>
+                      }
+                    />
                   </Badge>
                 </Tooltip>
               </Stack>
@@ -428,9 +456,13 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                   .filter((button: any) => button.label === 'Manual Entry Form')
                   .map((button: any, index: number) => (
                     <Tooltip key={index} title={button.tooltip || 'Manual Entry Form'} placement="top" arrow>
-                      <IconButton onClick={button.onClick} variant="soft" color="primary" size="sm" aria-label="Manual Entry Form">
-                        {button.icon}
-                      </IconButton>
+                      <ToolbarButton
+                        render={
+                          <IconButton onClick={button.onClick} variant="soft" color="primary" size="sm" aria-label="Manual Entry Form">
+                            {button.icon}
+                          </IconButton>
+                        }
+                      />
                     </Tooltip>
                   ))}
                 {/* Upload - keep as button with text */}
@@ -438,43 +470,55 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                   .filter((button: any) => button.label === 'Upload')
                   .map((button: any, index: number) => (
                     <Tooltip key={index} title={button.tooltip} placement="top" arrow>
-                      <Button onClick={button.onClick} variant="soft" color="primary" size="sm" startDecorator={button.icon} sx={{ whiteSpace: 'nowrap' }}>
-                        {button.label}
-                      </Button>
+                      <ToolbarButton
+                        render={
+                          <Button onClick={button.onClick} variant="soft" color="primary" size="sm" startDecorator={button.icon} sx={{ whiteSpace: 'nowrap' }}>
+                            {button.label}
+                          </Button>
+                        }
+                      />
                     </Tooltip>
                   ))}
                 {/* Export as CSV button */}
                 {hasAnyExport && (
                   <Tooltip title="Export as CSV" placement="top" arrow>
-                    <IconButton
-                      onClick={async () => {
-                        if (handleExport) {
-                          setOpenExportModal(true);
-                        } else if (handleExportCSV) {
-                          await handleExportCSV();
-                        } else {
-                          await handleExportAll!();
-                        }
-                      }}
-                      variant="soft"
-                      color="primary"
-                      aria-label="Export as CSV"
-                    >
-                      <CloudDownloadIcon />
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          onClick={async () => {
+                            if (handleExport) {
+                              setOpenExportModal(true);
+                            } else if (handleExportCSV) {
+                              await handleExportCSV();
+                            } else {
+                              await handleExportAll!();
+                            }
+                          }}
+                          variant="soft"
+                          color="primary"
+                          aria-label="Export as CSV"
+                        >
+                          <CloudDownloadIcon />
+                        </IconButton>
+                      }
+                    />
                   </Tooltip>
                 )}
                 {/* Show/Hide empty columns button */}
                 {setHidingEmpty && (
                   <Tooltip title={hidingEmpty ? 'Show empty columns' : 'Hide empty columns'} placement="top" arrow>
-                    <IconButton
-                      onClick={() => setHidingEmpty(!hidingEmpty)}
-                      variant="soft"
-                      color="primary"
-                      aria-label={hidingEmpty ? 'Show empty columns' : 'Hide empty columns'}
-                    >
-                      {hidingEmpty ? <UnfoldMore sx={{ transform: 'rotate(90deg)' }} /> : <UnfoldLess sx={{ transform: 'rotate(-90deg)' }} />}
-                    </IconButton>
+                    <ToolbarButton
+                      render={
+                        <IconButton
+                          onClick={() => setHidingEmpty(!hidingEmpty)}
+                          variant="soft"
+                          color="primary"
+                          aria-label={hidingEmpty ? 'Show empty columns' : 'Hide empty columns'}
+                        >
+                          {hidingEmpty ? <UnfoldMore sx={{ transform: 'rotate(90deg)' }} /> : <UnfoldLess sx={{ transform: 'rotate(-90deg)' }} />}
+                        </IconButton>
+                      }
+                    />
                   </Tooltip>
                 )}
                 {/* Kebab menu for additional actions */}

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -332,6 +332,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`Invalid: ${errorControls.count} (rows with unresolved errors)`}>
                   <Badge badgeContent={errorControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!errorControls.count}
                       render={
                         <IconButton
                           disabled={!errorControls.count}
@@ -351,6 +352,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`Valid: (${validControls.count})`}>
                   <Badge badgeContent={validControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!validControls.count}
                       render={
                         <IconButton
                           variant="soft"
@@ -370,6 +372,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`Pending: (${pendingControls.count})`}>
                   <Badge badgeContent={pendingControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!pendingControls.count}
                       render={
                         <IconButton
                           variant="soft"
@@ -389,6 +392,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`Old Trees: ${otControls.count}`}>
                   <Badge badgeContent={otControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!otControls.count}
                       render={
                         <IconButton
                           variant="soft"
@@ -408,6 +412,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`Multi-Stems: ${msControls.count}`}>
                   <Badge badgeContent={msControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!msControls.count}
                       render={
                         <IconButton
                           variant="soft"
@@ -427,6 +432,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 <Tooltip title={`New Recruits: ${nrControls.count}`}>
                   <Badge badgeContent={nrControls.count} size={'sm'}>
                     <ToolbarButton
+                      disabled={!nrControls.count}
                       render={
                         <IconButton
                           variant="soft"

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -147,6 +147,9 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
 
   const hasAnyExport = typeof handleExport === 'function' || typeof handleExportAll === 'function' || typeof handleExportCSV === 'function';
 
+  const moreMenuButtons = dynamicButtons.filter((button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload' && button.tooltip);
+  const hasMoreMenuItems = moreMenuButtons.length > 0 || Boolean(validationMenu);
+
   // only require add / refresh / quickFilter / model / columns
   if (
     typeof handleAddNewRow !== 'function' ||
@@ -528,50 +531,47 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                   </Tooltip>
                 )}
                 {/* Kebab menu for additional actions */}
-                <Dropdown>
-                  <Tooltip title="More actions" placement="top" arrow>
-                    <MenuButton
-                      slots={{ root: Button }}
-                      slotProps={{
-                        root: {
-                          variant: 'soft',
-                          color: 'primary',
-                          size: 'sm',
-                          'aria-label': 'More actions',
-                          startDecorator: <MoreVert />
-                        }
-                      }}
-                    >
-                      More
-                    </MenuButton>
-                  </Tooltip>
-                  <Menu placement="bottom-end" sx={{ minWidth: 240, zIndex: 9999 }}>
-                    {/* Other dynamic buttons (excluding Manual Entry Form and Upload) */}
-                    {dynamicButtons
-                      .filter((button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload')
-                      .map(
-                        (button: any, index: number) =>
-                          button.tooltip && (
-                            <MenuItem key={index} onClick={button.onClick}>
-                              <ListItemDecorator>{button.icon}</ListItemDecorator>
-                              <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-                                <Typography level="body-sm">{button.label}</Typography>
-                                <Typography level="body-xs" sx={{ color: 'neutral.500' }}>
-                                  {button.tooltip}
-                                </Typography>
-                              </Box>
-                              {button.count !== undefined && button.count > 0 && <Badge badgeContent={button.count} size="sm" />}
-                            </MenuItem>
-                          )
+                {hasMoreMenuItems && (
+                  <Dropdown>
+                    <Tooltip title="More actions" placement="top" arrow>
+                      <MenuButton
+                        slots={{ root: Button }}
+                        slotProps={{
+                          root: {
+                            variant: 'soft',
+                            color: 'primary',
+                            size: 'sm',
+                            'aria-label': 'More actions',
+                            startDecorator: <MoreVert />
+                          }
+                        }}
+                      >
+                        More
+                      </MenuButton>
+                    </Tooltip>
+                    <Menu placement="bottom-end" sx={{ minWidth: 240, zIndex: 9999 }}>
+                      {/* Other dynamic buttons (excluding Manual Entry Form and Upload) */}
+                      {moreMenuButtons.map((button: any, index: number) => (
+                        <MenuItem key={index} onClick={button.onClick}>
+                          <ListItemDecorator>{button.icon}</ListItemDecorator>
+                          <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+                            <Typography level="body-sm">{button.label}</Typography>
+                            <Typography level="body-xs" sx={{ color: 'neutral.500' }}>
+                              {button.tooltip}
+                            </Typography>
+                          </Box>
+                          {button.count !== undefined && button.count > 0 && <Badge badgeContent={button.count} size="sm" />}
+                        </MenuItem>
+                      ))}
+                      {validationMenu && (
+                        <Box>
+                          <Divider />
+                          {validationMenu}
+                        </Box>
                       )}
-                    {validationMenu && (
-                      <Box>
-                        <Divider />
-                        {validationMenu}
-                      </Box>
-                    )}
-                  </Menu>
-                </Dropdown>
+                    </Menu>
+                  </Dropdown>
+                )}
               </Stack>
             </>
           )}

--- a/frontend/components/client/modals/githubfeedbackmodal.test.tsx
+++ b/frontend/components/client/modals/githubfeedbackmodal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import GithubFeedbackModal from './githubfeedbackmodal';
+import { createGitHubIssue } from '@/app/actions/github';
 
 // The component destructures { submitForm, isSubmitting } from useFormSubmission.
 const mockUseFormSubmission = vi.fn();
@@ -73,5 +74,44 @@ describe('GithubFeedbackModal - Accessibility', () => {
     expect(document.querySelectorAll(`#${DIALOG_TITLE_ID}`)).toHaveLength(1);
     expect(document.querySelectorAll(`#${DIALOG_DESCRIPTION_ID}`)).toHaveLength(1);
     expect(document.getElementById(DIALOG_TITLE_ID)).toHaveTextContent(ACCESSIBLE_NAME);
+  });
+
+  it('MUST keep the title and description present, unique, and the accessible name stable in the success state', async () => {
+    const createdIssue = {
+      status: 'open',
+      html_url: 'https://github.com/example/repo/issues/1',
+      title: 'APP-USER-GENERATED: Feedback Ticket: other',
+      body: '### Description\nexample',
+      created_at: '2026-05-29T00:00:00Z'
+    };
+    vi.mocked(createGitHubIssue).mockResolvedValue({ success: true, issue: createdIssue });
+
+    // Drive the component into the createdIssue branch by having submitForm run the
+    // real submit callback the component passes to useFormSubmission, which awaits
+    // createGitHubIssue and calls setCreatedIssue with the resolved issue.
+    mockUseFormSubmission.mockImplementation((submitCallback: () => Promise<void>) => ({
+      submitForm: () => {
+        void submitCallback();
+      },
+      isSubmitting: false
+    }));
+
+    render(<GithubFeedbackModal open onClose={() => {}} />);
+
+    // The Confirm button is disabled until name, issue type, and description are set.
+    fireEvent.change(screen.getByLabelText(/input for name of person reporting feedback/i), { target: { value: 'Person Doe' } });
+    fireEvent.click(screen.getByRole('radio', { name: /other issue/i }));
+    fireEvent.change(screen.getByLabelText(/description box/i), { target: { value: 'example' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/issue created/i)).toBeInTheDocument();
+    });
+
+    expect(document.querySelectorAll(`#${DIALOG_TITLE_ID}`)).toHaveLength(1);
+    expect(document.querySelectorAll(`#${DIALOG_DESCRIPTION_ID}`)).toHaveLength(1);
+    expect(document.getElementById(DIALOG_TITLE_ID)).toHaveTextContent(ACCESSIBLE_NAME);
+    expect(screen.getByRole('dialog')).toHaveAccessibleName(ACCESSIBLE_NAME);
   });
 });

--- a/frontend/components/client/modals/githubfeedbackmodal.test.tsx
+++ b/frontend/components/client/modals/githubfeedbackmodal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GithubFeedbackModal from './githubfeedbackmodal';
+
+// The component destructures { submitForm, isSubmitting } from useFormSubmission.
+const mockUseFormSubmission = vi.fn();
+vi.mock('@/hooks/useAsyncOperation', () => ({
+  useFormSubmission: (...args: unknown[]) => mockUseFormSubmission(...args)
+}));
+
+vi.mock('@/app/contexts/compat-hooks', () => ({
+  useSiteContext: () => null,
+  usePlotContext: () => null,
+  useOrgCensusContext: () => null
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/'
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' })
+}));
+
+vi.mock('@/app/actions/github', () => ({
+  createGitHubIssue: vi.fn()
+}));
+
+const DIALOG_TITLE_ID = 'github-feedback-title';
+const DIALOG_DESCRIPTION_ID = 'github-feedback-description';
+const ACCESSIBLE_NAME = 'GitHub Feedback Form';
+
+describe('GithubFeedbackModal - Accessibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFormSubmission.mockReturnValue({ submitForm: vi.fn(), isSubmitting: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('MUST expose an accessible name and description on the dialog', () => {
+    render(<GithubFeedbackModal open onClose={() => {}} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', DIALOG_TITLE_ID);
+    expect(dialog).toHaveAttribute('aria-describedby', DIALOG_DESCRIPTION_ID);
+
+    expect(document.getElementById(DIALOG_TITLE_ID)).toHaveTextContent(ACCESSIBLE_NAME);
+    expect(document.getElementById(DIALOG_DESCRIPTION_ID)).toBeInTheDocument();
+    expect(document.getElementById(DIALOG_DESCRIPTION_ID)).toHaveTextContent(/report a bug or request a feature/i);
+  });
+
+  it('MUST resolve the accessible name on the dialog element', () => {
+    render(<GithubFeedbackModal open onClose={() => {}} />);
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName(ACCESSIBLE_NAME);
+  });
+
+  it('MUST render the title and description ids exactly once in the input state', () => {
+    render(<GithubFeedbackModal open onClose={() => {}} />);
+
+    expect(document.querySelectorAll(`#${DIALOG_TITLE_ID}`)).toHaveLength(1);
+    expect(document.querySelectorAll(`#${DIALOG_DESCRIPTION_ID}`)).toHaveLength(1);
+  });
+
+  it('MUST keep the title and description present and unique in the submitting state', () => {
+    mockUseFormSubmission.mockReturnValue({ submitForm: vi.fn(), isSubmitting: true });
+
+    render(<GithubFeedbackModal open onClose={() => {}} />);
+
+    expect(document.querySelectorAll(`#${DIALOG_TITLE_ID}`)).toHaveLength(1);
+    expect(document.querySelectorAll(`#${DIALOG_DESCRIPTION_ID}`)).toHaveLength(1);
+    expect(document.getElementById(DIALOG_TITLE_ID)).toHaveTextContent(ACCESSIBLE_NAME);
+  });
+});

--- a/frontend/components/client/modals/githubfeedbackmodal.tsx
+++ b/frontend/components/client/modals/githubfeedbackmodal.tsx
@@ -67,6 +67,8 @@ const issueTypes = [
   { value: 'other', label: 'Other Issue', icon: <Info />, tooltip: 'Any other feedback or issues not listed above.' }
 ];
 
+const DIALOG_ACCESSIBLE_NAME = 'GitHub Feedback Form';
+
 type IssueType = (typeof issueTypes)[number]['value'];
 
 interface GithubFeedbackModalProps {
@@ -167,14 +169,14 @@ ${pathname}
         <ModalDialog role="dialog" aria-labelledby="github-feedback-title" aria-describedby="github-feedback-description">
           <ModalClose variant="outlined" onClick={handleCancel} />
           <span id="github-feedback-title" className="sr-only">
-            GitHub Feedback Form
+            {DIALOG_ACCESSIBLE_NAME}
           </span>
           <span id="github-feedback-description" className="sr-only">
             Report a bug or request a feature for the ForestGEO application.
           </span>
           {!createdIssue && !isSubmitting && (
             <>
-              <DialogTitle>GitHub Feedback Form</DialogTitle>
+              <DialogTitle>{DIALOG_ACCESSIBLE_NAME}</DialogTitle>
               <DialogContent sx={{ display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' }}>
                 <Divider orientation="horizontal" sx={{ my: 1 }} />
                 <Grid container spacing={1}>

--- a/frontend/components/client/modals/githubfeedbackmodal.tsx
+++ b/frontend/components/client/modals/githubfeedbackmodal.tsx
@@ -164,8 +164,14 @@ ${pathname}
   return (
     <Modal open={open} sx={{ display: 'flex', flex: 1, flexDirection: 'row' }}>
       <ModalOverflow>
-        <ModalDialog role="alertdialog">
+        <ModalDialog role="dialog" aria-labelledby="github-feedback-title" aria-describedby="github-feedback-description">
           <ModalClose variant="outlined" onClick={handleCancel} />
+          <span id="github-feedback-title" className="sr-only">
+            GitHub Feedback Form
+          </span>
+          <span id="github-feedback-description" className="sr-only">
+            Report a bug or request a feature for the ForestGEO application.
+          </span>
           {!createdIssue && !isSubmitting && (
             <>
               <DialogTitle>GitHub Feedback Form</DialogTitle>

--- a/frontend/components/datagrids/isolateddatagridcommons.tsx
+++ b/frontend/components/datagrids/isolateddatagridcommons.tsx
@@ -47,6 +47,7 @@ import ConfirmationDialog from '@/components/client/modals/confirmationdialog';
 import { randomId } from '@mui/x-data-grid-generator';
 import SkipReEnterDataModal from '@/components/datagrids/skipreentrydatamodal';
 import { FormType, getTableHeaders } from '@/config/macros/formdetails';
+import { getGridTypeLabel } from '@/config/macros/siteconfigs';
 import { applyFilterToColumns } from '@/components/datagrids/filtrationsystem';
 import moment from 'moment/moment';
 import { EditToolbar } from '@/components/client/datagridelements';
@@ -1350,6 +1351,7 @@ const IsolatedDataGridCommonsInner = forwardRef(function IsolatedDataGridCommons
           ) : (
             <>
               <StyledDataGrid
+                aria-label={getGridTypeLabel(gridType)}
                 apiRef={localApiRef}
                 sx={GRID_ROOT_SX}
                 rows={gridRows}

--- a/frontend/components/datagrids/isolatedmultilinedatagridcommons.tsx
+++ b/frontend/components/datagrids/isolatedmultilinedatagridcommons.tsx
@@ -11,6 +11,7 @@ import { darken } from '@mui/system';
 import { StyledDataGrid } from '@/config/styleddatagrid';
 import { Add } from '@mui/icons-material';
 import { getColumnVisibilityModel } from '@/config/datagridhelpers';
+import { getGridTypeLabel } from '@/config/macros/siteconfigs';
 import { useOrgCensusContext, usePlotContext, useSiteContext } from '@/app/contexts/compat-hooks';
 import { FileRow, FileRowSet } from '@/config/macros/formdetails';
 import { AttributeStatusOptions } from '@/config/sqlrdsdefinitions/core';
@@ -271,6 +272,7 @@ export default function IsolatedMultilineDataGridCommons(props: Readonly<Isolate
       </Box>
       <Box sx={{ display: 'flex', flex: 1, height: '100%', width: '100%', maxHeight: '80vh', overflowY: 'auto' }}>
         <StyledDataGrid
+          aria-label={getGridTypeLabel(gridType)}
           rows={rows}
           columns={columns}
           apiRef={apiRef}

--- a/frontend/components/datagrids/measurementscommons.tsx
+++ b/frontend/components/datagrids/measurementscommons.tsx
@@ -75,6 +75,7 @@ import { useSession } from 'next-auth/react';
 import { useBackgroundValidationState } from '@/config/store/appstore';
 import ConfirmationDialog from '../client/modals/confirmationdialog';
 import { FormType, getTableHeaders } from '@/config/macros/formdetails';
+import { getGridTypeLabel } from '@/config/macros/siteconfigs';
 import { applyFilterToColumns } from '@/components/datagrids/filtrationsystem';
 import { formatHeader, InputChip } from '@/components/client/datagridcolumns';
 import { OverridableStringUnion } from '@mui/types';
@@ -1582,6 +1583,7 @@ function MeasurementsCommonsInner(props: Readonly<MeasurementsCommonsProps>) {
           ) : (
             <>
               <StyledDataGrid
+                aria-label={getGridTypeLabel(gridType)}
                 apiRef={apiRef}
                 sx={{ width: '100%' }}
                 rows={gridRows}

--- a/frontend/components/datagrids/reentrydatamodal.tsx
+++ b/frontend/components/datagrids/reentrydatamodal.tsx
@@ -259,6 +259,7 @@ const ReEnterDataModal: React.FC<ReEnterDataModalProps> = ({
               </Typography>
               <Box sx={{ display: 'flex', flex: 1, width: '100%' }}>
                 <DataGrid
+                  aria-label="Re-entered Row Options"
                   rows={rowsData}
                   columns={[
                     {

--- a/frontend/components/errors/errorsexplorer.tsx
+++ b/frontend/components/errors/errorsexplorer.tsx
@@ -1159,6 +1159,7 @@ export default function ErrorsExplorer() {
       >
         <Sheet variant="outlined" sx={{ flex: 1, minWidth: 0, borderRadius: 'md', p: 1 }}>
           <StyledDataGrid
+            aria-label="Measurement Errors"
             apiRef={explorerApiRef}
             autoHeight={false}
             rows={(isInfiniteOn ? infinite.rows : results.rows) as any[]}

--- a/frontend/components/loginlogout.test.tsx
+++ b/frontend/components/loginlogout.test.tsx
@@ -228,18 +228,33 @@ describe('LoginLogout - Functional Tests', () => {
     });
 
     it('MUST be keyboard accessible - avatar button with Space', async () => {
-      const user = userEvent.setup();
-
       render(<LoginLogout />);
 
       const avatarButton = screen.getByRole('button', { name: /open user menu/i });
       avatarButton.focus();
 
-      await user.keyboard(' ');
+      // The trigger's own onKeyDown opens the menu on Space keydown.
+      // We assert via the keydown alone: a synthesized keyup/click would
+      // bleed into the now-focused first menu item (Joy activates buttons on
+      // Space keyup), which reflects real focus moving into the listbox.
+      fireEvent.keyDown(avatarButton, { key: ' ' });
 
       await waitFor(() => {
         expect(screen.getByText('User Settings')).toBeInTheDocument();
       });
+    });
+
+    it('MUST advertise the user menu via aria attributes and expand on open', async () => {
+      const user = userEvent.setup();
+      render(<LoginLogout />);
+      const trigger = screen.getByRole('button', { name: /open user menu/i });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      const menu = await screen.findByRole('menu');
+      expect(menu).toHaveAttribute('id', 'user-settings-menu');
+      expect(trigger).toHaveAttribute('aria-controls', 'user-settings-menu');
     });
   });
 
@@ -307,10 +322,10 @@ describe('LoginLogout - Functional Tests', () => {
       const avatarButton = screen.getByRole('button', { name: /open user menu/i });
       await user.click(avatarButton);
 
-      const userSettingsItem = await screen.findByText('User Settings');
-
-      // Trigger Enter key
-      fireEvent.keyDown(userSettingsItem.closest('[tabindex]')!, { key: 'Enter' });
+      // On open, focus lands on the first item (User Settings).
+      // Joy MenuItem natively activates on Enter keydown.
+      const userSettingsItem = (await screen.findByText('User Settings')).closest('[role="menuitem"]')!;
+      fireEvent.keyDown(userSettingsItem, { key: 'Enter' });
 
       expect(mockPush).toHaveBeenCalledWith('/admin/users');
     });
@@ -323,10 +338,9 @@ describe('LoginLogout - Functional Tests', () => {
       const avatarButton = screen.getByRole('button', { name: /open user menu/i });
       await user.click(avatarButton);
 
-      const siteSettingsItem = await screen.findByText('Site Settings');
-
-      // Trigger Space key
-      fireEvent.keyDown(siteSettingsItem.closest('[tabindex]')!, { key: ' ' });
+      // Joy MenuItem follows native button semantics: Space activates on keyup.
+      const siteSettingsItem = (await screen.findByText('Site Settings')).closest('[role="menuitem"]')!;
+      fireEvent.keyUp(siteSettingsItem, { key: ' ' });
 
       expect(mockPush).toHaveBeenCalledWith('/admin/sites');
     });

--- a/frontend/components/loginlogout.test.tsx
+++ b/frontend/components/loginlogout.test.tsx
@@ -256,6 +256,31 @@ describe('LoginLogout - Functional Tests', () => {
       expect(menu).toHaveAttribute('id', 'user-settings-menu');
       expect(trigger).toHaveAttribute('aria-controls', 'user-settings-menu');
     });
+
+    it('MUST move focus to the first menu item when the menu opens', async () => {
+      const user = userEvent.setup();
+      render(<LoginLogout />);
+      await user.click(screen.getByRole('button', { name: /open user menu/i }));
+      const firstItem = await screen.findByRole('menuitem', { name: /user settings/i });
+      expect(firstItem).toHaveFocus();
+    });
+
+    it('MUST close the menu and not trap focus inside it when dismissed', async () => {
+      // Joy's Menu Escape/click-away dismissal does not fire in jsdom (disablePortal,
+      // no rendered backdrop), so the Escape-specific onClose path is not observable
+      // here. We assert the dismissal contract via the toggle path that does fire:
+      // the menu closes and focus returns to the trigger rather than staying trapped
+      // on a now-unmounted menu item.
+      const user = userEvent.setup();
+      render(<LoginLogout />);
+      const trigger = screen.getByRole('button', { name: /open user menu/i });
+      await user.click(trigger);
+      await screen.findByRole('menu');
+      await user.click(trigger);
+      await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+      expect(document.activeElement?.closest('[role="menu"]')).toBeNull();
+      expect(trigger).toHaveFocus();
+    });
   });
 
   describe('Settings Menu Navigation', () => {

--- a/frontend/components/loginlogout.tsx
+++ b/frontend/components/loginlogout.tsx
@@ -18,7 +18,9 @@ export const LoginLogout = () => {
   const { data: session, status } = useSession();
   const [anchorSettings, setAnchorSettings] = useState<HTMLElement | null>(null);
   const router = useRouter();
-  const menuRef = useRef<HTMLUListElement | null>(null);
+  // Joy Menu types its ref as HTMLDivElement even though it forwards to the listbox <ul>;
+  // we only need querySelector on it, so match the declared type to compile cleanly.
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const avatarButtonRef = useRef<HTMLButtonElement | null>(null);
   const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
   const menuId = 'user-settings-menu';

--- a/frontend/components/loginlogout.tsx
+++ b/frontend/components/loginlogout.tsx
@@ -19,6 +19,8 @@ export const LoginLogout = () => {
   const [anchorSettings, setAnchorSettings] = useState<HTMLElement | null>(null);
   const router = useRouter();
   const menuRef = useRef<HTMLUListElement | null>(null);
+  const avatarButtonRef = useRef<HTMLButtonElement | null>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement | null>(null);
   const menuId = 'user-settings-menu';
   const isMenuOpen = Boolean(anchorSettings);
 
@@ -30,6 +32,9 @@ export const LoginLogout = () => {
   }, [isMenuOpen]);
 
   const closeMenu = () => {
+    // anchorSettings holds the trigger DOM node (set from event.currentTarget); it stays
+    // mounted when only the menu portal closes, so capture it before clearing state and
+    // refocus it to restore focus to the opener on Escape / click-away.
     const trigger = anchorSettings;
     setAnchorSettings(null);
     trigger?.focus();
@@ -72,10 +77,11 @@ export const LoginLogout = () => {
     return (
       <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }} data-testid={'login-logout-component'}>
         <IconButton
+          ref={avatarButtonRef}
           aria-label={userInitials ? `${userInitials}, open user menu` : 'Open user menu'}
           aria-haspopup="menu"
-          aria-expanded={isMenuOpen}
-          aria-controls={isMenuOpen ? menuId : undefined}
+          aria-expanded={isMenuOpen && anchorSettings === avatarButtonRef.current}
+          aria-controls={isMenuOpen && anchorSettings === avatarButtonRef.current ? menuId : undefined}
           onClick={event => setAnchorSettings(anchorSettings ? null : event.currentTarget)}
           onKeyDown={event => {
             if (event.key === 'Enter' || event.key === ' ') {
@@ -105,12 +111,13 @@ export const LoginLogout = () => {
           </Typography>
         </Box>
         <IconButton
+          ref={settingsButtonRef}
           disabled={!['global', 'db admin'].includes(session?.user?.userStatus ?? '')}
           onClick={event => setAnchorSettings(anchorSettings ? null : event.currentTarget)}
           aria-label="Settings menu"
           aria-haspopup="menu"
-          aria-expanded={isMenuOpen}
-          aria-controls={isMenuOpen ? menuId : undefined}
+          aria-expanded={isMenuOpen && anchorSettings === settingsButtonRef.current}
+          aria-controls={isMenuOpen && anchorSettings === settingsButtonRef.current ? menuId : undefined}
           title="Settings menu"
           size="sm"
         >
@@ -134,7 +141,7 @@ export const LoginLogout = () => {
           <MenuItem
             onClick={() => {
               router.push('/admin/users');
-              closeMenu();
+              setAnchorSettings(null);
             }}
           >
             User Settings
@@ -143,7 +150,7 @@ export const LoginLogout = () => {
           <MenuItem
             onClick={() => {
               router.push('/admin/sites');
-              closeMenu();
+              setAnchorSettings(null);
             }}
           >
             Site Settings
@@ -153,7 +160,7 @@ export const LoginLogout = () => {
           <MenuItem
             onClick={() => {
               router.push('/admin/userstosites');
-              closeMenu();
+              setAnchorSettings(null);
             }}
           >
             User-Site Assignments

--- a/frontend/components/loginlogout.tsx
+++ b/frontend/components/loginlogout.tsx
@@ -1,6 +1,6 @@
 // loginlogout.tsx
 'use client';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Avatar from '@mui/joy/Avatar';
 import Box from '@mui/joy/Box';
 import Typography from '@mui/joy/Typography';
@@ -18,6 +18,22 @@ export const LoginLogout = () => {
   const { data: session, status } = useSession();
   const [anchorSettings, setAnchorSettings] = useState<HTMLElement | null>(null);
   const router = useRouter();
+  const menuRef = useRef<HTMLUListElement | null>(null);
+  const menuId = 'user-settings-menu';
+  const isMenuOpen = Boolean(anchorSettings);
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      const firstItem = menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
+      firstItem?.focus();
+    }
+  }, [isMenuOpen]);
+
+  const closeMenu = () => {
+    const trigger = anchorSettings;
+    setAnchorSettings(null);
+    trigger?.focus();
+  };
 
   const userName = session?.user?.name;
   const userInitials =
@@ -57,6 +73,9 @@ export const LoginLogout = () => {
       <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }} data-testid={'login-logout-component'}>
         <IconButton
           aria-label={userInitials ? `${userInitials}, open user menu` : 'Open user menu'}
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
+          aria-controls={isMenuOpen ? menuId : undefined}
           onClick={event => setAnchorSettings(anchorSettings ? null : event.currentTarget)}
           onKeyDown={event => {
             if (event.key === 'Enter' || event.key === ' ') {
@@ -89,6 +108,9 @@ export const LoginLogout = () => {
           disabled={!['global', 'db admin'].includes(session?.user?.userStatus ?? '')}
           onClick={event => setAnchorSettings(anchorSettings ? null : event.currentTarget)}
           aria-label="Settings menu"
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
+          aria-controls={isMenuOpen ? menuId : undefined}
           title="Settings menu"
           size="sm"
         >
@@ -100,40 +122,28 @@ export const LoginLogout = () => {
           {status == 'loading' ? <CircularProgress size={'lg'} aria-label="Loading user session" /> : <LogoutRoundedIcon />}
         </IconButton>
         <Menu
+          ref={menuRef}
+          id={menuId}
           anchorEl={anchorSettings}
-          open={Boolean(anchorSettings)}
-          onClose={() => setAnchorSettings(null)}
+          open={isMenuOpen}
+          onClose={closeMenu}
           placement={'top-end'}
           disablePortal
           sx={{ zIndex: 1500 }}
         >
           <MenuItem
-            tabIndex={0}
             onClick={() => {
               router.push('/admin/users');
-              setAnchorSettings(null);
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                router.push('/admin/users');
-                setAnchorSettings(null);
-              }
+              closeMenu();
             }}
           >
             User Settings
             <ManageAccountsRounded />
           </MenuItem>
           <MenuItem
-            tabIndex={0}
             onClick={() => {
               router.push('/admin/sites');
-              setAnchorSettings(null);
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                router.push('/admin/sites');
-                setAnchorSettings(null);
-              }
+              closeMenu();
             }}
           >
             Site Settings
@@ -141,16 +151,9 @@ export const LoginLogout = () => {
           </MenuItem>
 
           <MenuItem
-            tabIndex={0}
             onClick={() => {
               router.push('/admin/userstosites');
-              setAnchorSettings(null);
-            }}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                router.push('/admin/userstosites');
-                setAnchorSettings(null);
-              }
+              closeMenu();
             }}
           >
             User-Site Assignments

--- a/frontend/components/uploadsystemhelpers/displayparseddatagrid.tsx
+++ b/frontend/components/uploadsystemhelpers/displayparseddatagrid.tsx
@@ -243,6 +243,7 @@ export const DisplayParsedDataGridInline: React.FC<DisplayParsedDataProps> = (pr
         <>
           {validRows.length > 0 && (
             <StyledDataGrid
+              aria-label="Valid Uploaded Rows"
               sx={{ display: 'flex', flex: 1, width: '100%' }}
               rows={validRows}
               columns={columns}
@@ -268,6 +269,7 @@ export const DisplayParsedDataGridInline: React.FC<DisplayParsedDataProps> = (pr
                 <span style={{ color: 'lightblue' }}>Light blue text indicates values that were auto-filled or auto-corrected based on other fields.</span>
               </Typography>
               <StyledDataGrid
+                aria-label="Autocorrected Uploaded Rows"
                 sx={{ display: 'flex', flex: 1, width: '100%' }}
                 rows={invalidRows}
                 columns={columns}
@@ -288,6 +290,7 @@ export const DisplayParsedDataGridInline: React.FC<DisplayParsedDataProps> = (pr
         <>
           {correctedValidRows.length > 0 && (
             <StyledDataGrid
+              aria-label="Corrected Uploaded Rows"
               sx={{ display: 'flex', flex: 1, width: '100%' }}
               rows={correctedValidRows}
               columns={columns}

--- a/frontend/config/macros/siteconfigs.test.ts
+++ b/frontend/config/macros/siteconfigs.test.ts
@@ -30,7 +30,7 @@ describe('getGridTypeLabel', () => {
   it('MUST Title-Case an unknown machine name as a fallback', () => {
     expect(getGridTypeLabel('somefuture_view')).toBe('Somefuture View');
   });
-  it('MUST never return an empty string', () => {
-    expect(getGridTypeLabel('')).not.toBe('');
+  it("MUST fall back to a non-empty 'Data' label for an empty machine name", () => {
+    expect(getGridTypeLabel('')).toBe('Data');
   });
 });

--- a/frontend/config/macros/siteconfigs.test.ts
+++ b/frontend/config/macros/siteconfigs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getEndpointHeaderName, siteConfigNav } from './siteconfigs';
+import { getEndpointHeaderName, getGridTypeLabel, siteConfigNav } from './siteconfigs';
 
 describe('siteConfigNav', () => {
   it('orders Census Hub as Census Overview, View Data, View Errors', () => {
@@ -14,5 +14,23 @@ describe('siteConfigNav', () => {
 
   it('returns the expected header for the errors route', () => {
     expect(getEndpointHeaderName('/measurementshub/errors')).toBe('View Errors');
+  });
+});
+
+describe('getGridTypeLabel', () => {
+  it('MUST map attributes to the user-facing "Stem Codes" name', () => {
+    expect(getGridTypeLabel('attributes')).toBe('Stem Codes');
+  });
+  it('MUST map failedmeasurements to a spaced, capitalized label', () => {
+    expect(getGridTypeLabel('failedmeasurements')).toBe('Failed Measurements');
+  });
+  it('MUST map alltaxonomiesview to "Species List"', () => {
+    expect(getGridTypeLabel('alltaxonomiesview')).toBe('Species List');
+  });
+  it('MUST Title-Case an unknown machine name as a fallback', () => {
+    expect(getGridTypeLabel('somefuture_view')).toBe('Somefuture View');
+  });
+  it('MUST never return an empty string', () => {
+    expect(getGridTypeLabel('')).not.toBe('');
   });
 });

--- a/frontend/config/macros/siteconfigs.ts
+++ b/frontend/config/macros/siteconfigs.ts
@@ -171,6 +171,7 @@ export function getGridTypeLabel(gridType: string): string {
     .replace(/_/g, ' ')
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .replace(/\b\w/g, character => character.toUpperCase())
+    .replace(/\s+/g, ' ')
     .trim();
   return titled || 'Data';
 }

--- a/frontend/config/macros/siteconfigs.ts
+++ b/frontend/config/macros/siteconfigs.ts
@@ -144,6 +144,37 @@ export const siteConfigNav: SiteConfigProps[] = [
   }
 ];
 
+const GRID_TYPE_LABELS: Record<string, string> = {
+  attributes: 'Stem Codes',
+  personnel: 'Personnel',
+  quadrats: 'Quadrats',
+  subquadrats: 'Subquadrats',
+  species: 'Species',
+  alltaxonomiesview: 'Species List',
+  stemtaxonomiesview: 'Stem Taxonomies',
+  measurementssummary: 'Measurements Summary',
+  measurements: 'Measurements',
+  measurementssummary_staging: 'Staged Measurements',
+  failedmeasurements: 'Failed Measurements',
+  quadratpersonnel: 'Quadrat-Assigned Personnel',
+  roles: 'Roles',
+  unifiedchangelog: 'Change Log',
+  viewfulltable: 'All Historical Data',
+  users: 'User Management',
+  sites: 'Site Settings'
+};
+
+export function getGridTypeLabel(gridType: string): string {
+  const mapped = GRID_TYPE_LABELS[gridType];
+  if (mapped) return mapped;
+  const titled = gridType
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, character => character.toUpperCase())
+    .trim();
+  return titled || 'Data';
+}
+
 export function getEndpointHeaderName(endpoint: string): string {
   switch (endpoint) {
     case '/dashboard':


### PR DESCRIPTION
Remediates five accessibility findings from the SortSite review. Verified locally (lint clean, full unit suite 2568 passing, production build succeeds) and deployed to the dev site for manual keyboard/screen-reader verification before this promotion to live.

## Findings addressed
1. **User menu focus (Item 1)** — Opening the sidebar user/settings menu now moves focus to the first item, both triggers advertise `aria-haspopup`/`aria-expanded`/`aria-controls` (gated per-trigger), and focus returns to the opener on dismiss.
2. **Toolbar keyboard reachability (Item 2)** — Refresh, the status/action icon buttons, and the "Search All Fields" input now join the data-grid toolbar's ARIA roving-tabindex group (W3C toolbar pattern): Tab enters the toolbar, arrow keys move between controls; the search input is reachable when empty.
3. **Empty "More" menu (Item 3)** — The kebab "More actions" button is removed from the DOM entirely (invisible to sighted and screen-reader users) when it has no menu items, e.g. on Stem Codes.
4. **GitHub Feedback dialog announcement (Item 4)** — The dialog exposes a stable accessible name and description (`aria-labelledby`/`aria-describedby`) across all states, so screen readers announce it immediately on open, matching the Upload dialog.
5. **Table accessible names (Item 5)** — Every data grid now sets a meaningful `aria-label` (e.g. "Stem Codes") via a shared `getGridTypeLabel` map, instead of the screen reader concatenating header/cell text.

## Notes
- Toolbar focus uses the ARIA roving-tabindex pattern (one Tab stop + arrow-key navigation). This is the standards-correct model; automated scanners that don't simulate arrow keys may still flag the `tabindex=-1` controls.
- Keyboard and screen-reader behavior should be confirmed on the dev deploy before merging to live.