### PR TITLE
test(ci): stabilize arcgis preflight + sidebar e2e assertions (PR #338 follow-up)

### DIFF
--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -1120,7 +1120,15 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     const validRow = { MyX: '12.5', tag: 'T1', spcode: 'abc', quadrat: 'q1', ly: '3.0', date: '2023-05-17' };
     // papaparse parks an over-wide line's leftover cell under `__parsed_extra` (an array). The server
     // must reject this row, not key the leftover as a normalized `parsedextra` column on the upload.
-    const raggedRow = { MyX: '13.0', tag: 'T9', spcode: 'def', quadrat: 'q2', ly: '4.0', date: '2023-05-18', __parsed_extra: ['leftover'] } as unknown as Record<string, string>;
+    const raggedRow = {
+      MyX: '13.0',
+      tag: 'T9',
+      spcode: 'def',
+      quadrat: 'q2',
+      ly: '4.0',
+      date: '2023-05-18',
+      __parsed_extra: ['leftover']
+    } as unknown as Record<string, string>;
 
     mockConnectionManager.executeQuery
       .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
@@ -1173,9 +1181,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce(undefined);
 
-    const res = (await POST(
-      makeRawRowsRequest([rawRow], { csvHeaders: headersWithIgnoredLx, mapping: lxRenamedMapping(headersWithIgnoredLx) })
-    ))!;
+    const res = (await POST(makeRawRowsRequest([rawRow], { csvHeaders: headersWithIgnoredLx, mapping: lxRenamedMapping(headersWithIgnoredLx) })))!;
 
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/frontend/cypress/e2e/column-mapping/arcgis-preflight-mapping.cy.ts
+++ b/frontend/cypress/e2e/column-mapping/arcgis-preflight-mapping.cy.ts
@@ -157,14 +157,14 @@ describe('ArcGIS pre-flight mapping journey', () => {
     // The first pre-flight fires automatically on mount.
     cy.wait('@preflight');
 
-    // Entering the mapping-required phase renders the alert AND auto-opens the mapping
-    // dialog (reducer MAPPING_REQUIRED -> dialogOpen: true). The "Map columns" button is
-    // the re-open affordance after a cancel; here the dialog is already open. We assert
-    // the affordance exists, then drive the open dialog directly.
-    cy.get(MAPPING_REQUIRED_ALERT, { timeout: 15000 }).should('be.visible');
+    // Entering the mapping-required phase renders the background alert AND auto-opens the
+    // mapping dialog (reducer MAPPING_REQUIRED -> dialogOpen: true). The modal can cover
+    // the alert, so assert the active state via existence plus the visible dialog message.
+    cy.get(MAPPING_REQUIRED_ALERT, { timeout: 15000 }).should('exist');
     cy.get(OPEN_MAPPING_BUTTON).should('exist');
 
     cy.get(MAPPING_DIALOG).should('be.visible');
+    cy.contains(MAPPING_DIALOG, PREFLIGHT_ERROR_MESSAGE).should('be.visible');
     cy.get(SHEET_ROLE_SELECT_TREES).should('be.visible');
     cy.get(SHEET_ROLE_SELECT_STEMS).should('be.visible');
 
@@ -211,11 +211,12 @@ describe('ArcGIS pre-flight mapping journey', () => {
     uploadWorkbookAndEnterPreflight();
 
     // The dialog auto-opens on the mapping-required phase (see test above); assert the
-    // re-open affordance exists, then read the already-open dialog.
-    cy.get(MAPPING_REQUIRED_ALERT, { timeout: 15000 }).should('be.visible');
+    // background affordance exists, then read the already-open visible dialog.
+    cy.get(MAPPING_REQUIRED_ALERT, { timeout: 15000 }).should('exist');
     cy.get(OPEN_MAPPING_BUTTON).should('exist');
 
     cy.get(MAPPING_DIALOG).should('be.visible');
+    cy.contains(MAPPING_DIALOG, PREFLIGHT_ERROR_MESSAGE).should('be.visible');
 
     // Sheet-role selects render the recovered assignments, not empty placeholders.
     cy.get(SHEET_ROLE_SELECT_TREES).should('contain.text', TREES_SHEET_NAME);

--- a/frontend/cypress/support/test-data-helpers.ts
+++ b/frontend/cypress/support/test-data-helpers.ts
@@ -415,7 +415,8 @@ Cypress.Commands.add('openSidebarLink', (sectionLabel: string, linkLabel: string
 
   const expectedRoute = routeSuffixForSidebarLink(sectionLabel, linkLabel);
   if (expectedRoute) {
-    cy.url().should('include', expectedRoute);
+    // Cold Next route compilation in CI can exceed Cypress's default 4s retry window.
+    cy.url({ timeout: 15000 }).should('include', expectedRoute);
   }
 });
 


### PR DESCRIPTION
## Summary

Post-merge CI-stability follow-up to #338. Three test-only changes:

- **arcgis-preflight e2e**: the mapping-required phase auto-opens the mapping modal, which covers the background `arcgis-mapping-required` alert — so asserting the alert is *visible* was wrong/flaky. Assert it `exist`s instead, and add a positive assertion that the open dialog shows the preflight error message (`serverError` renders in a danger Alert inside the dialog).
- **openSidebarLink helper**: allow 15s for the URL assertion, since cold Next route compilation in CI can exceed Cypress's default 4s retry window.
- **sqlpacketload route test**: reflow the ragged-row fixture for readability (no behavior change).

## Verification (local)

- `build:check` (prettier + lint) ✅
- cycle gate 33/33 ✅, any-escape gate 489/489 ✅
- `test:unit` — 2950 passed, 4 skipped ✅
- `arcgis-preflight-mapping.cy.ts` — 2/2 passing ✅
