### PR TITLE
feat: PublishedStemID capture, inheritance & conflict handling

### DIFF
--- a/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.test.ts
+++ b/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.test.ts
@@ -87,6 +87,7 @@ function mockUnresolvedRows(count: number) {
     MeasuredHOM: 1.3,
     MeasurementDate: '2024-01-01',
     RawCodes: idx === 0 ? 'AL' : null,
+    RawPublishedStemID: idx === 0 ? 5001 : null,
     RawComments: null
   }));
 }
@@ -345,9 +346,11 @@ describe('reingest API routes', () => {
 
       expect(insertCall).toBeDefined();
       expect(insertCall[0]).toContain('Codes');
+      expect(insertCall[0]).toContain('PublishedStemID');
       const valuesParam = insertCall[1]?.[0];
       expect(Array.isArray(valuesParam)).toBe(true);
       expect(valuesParam[0][13]).toBe('AL'); // Codes value preserved in insert payload
+      expect(valuesParam[0][15]).toBe(5001); // RawPublishedStemID value preserved in insert payload
     });
   });
 });

--- a/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.test.ts
+++ b/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.test.ts
@@ -4,6 +4,20 @@ import { NextResponse } from 'next/server';
 import { GET, POST } from './route';
 import ConnectionManager from '@/config/connectionmanager';
 
+// Sentinel values placed only on the first mock row so we can assert they survive the staging INSERT.
+const FIRST_ROW_RAW_CODES = 'AL';
+const FIRST_ROW_RAW_PUBLISHED_STEM_ID = 5001;
+
+// Reads the column position out of the staging INSERT's own column list, so payload assertions
+// track the real layout instead of hard-coded offsets that break silently on column reordering.
+function stagingInsertColumnIndex(insertSQL: string, columnName: string): number {
+  const columnList = insertSQL.match(/temporarymeasurements\s*\(([^)]+)\)/i)?.[1] ?? '';
+  return columnList
+    .split(',')
+    .map(column => column.trim())
+    .indexOf(columnName);
+}
+
 const { authMock, assertSchemaAccessMock } = vi.hoisted(() => ({
   authMock: vi.fn(),
   assertSchemaAccessMock: vi.fn()
@@ -86,8 +100,8 @@ function mockUnresolvedRows(count: number) {
     MeasuredDBH: 12.3,
     MeasuredHOM: 1.3,
     MeasurementDate: '2024-01-01',
-    RawCodes: idx === 0 ? 'AL' : null,
-    RawPublishedStemID: idx === 0 ? 5001 : null,
+    RawCodes: idx === 0 ? FIRST_ROW_RAW_CODES : null,
+    RawPublishedStemID: idx === 0 ? FIRST_ROW_RAW_PUBLISHED_STEM_ID : null,
     RawComments: null
   }));
 }
@@ -349,8 +363,14 @@ describe('reingest API routes', () => {
       expect(insertCall[0]).toContain('PublishedStemID');
       const valuesParam = insertCall[1]?.[0];
       expect(Array.isArray(valuesParam)).toBe(true);
-      expect(valuesParam[0][13]).toBe('AL'); // Codes value preserved in insert payload
-      expect(valuesParam[0][15]).toBe(5001); // RawPublishedStemID value preserved in insert payload
+
+      const codesIndex = stagingInsertColumnIndex(String(insertCall[0]), 'Codes');
+      const publishedStemIdIndex = stagingInsertColumnIndex(String(insertCall[0]), 'PublishedStemID');
+      expect(codesIndex).toBeGreaterThanOrEqual(0);
+      expect(publishedStemIdIndex).toBeGreaterThanOrEqual(0);
+
+      expect(valuesParam[0][codesIndex]).toBe(FIRST_ROW_RAW_CODES); // Codes value preserved in insert payload
+      expect(valuesParam[0][publishedStemIdIndex]).toBe(FIRST_ROW_RAW_PUBLISHED_STEM_ID); // RawPublishedStemID preserved
     });
   });
 });

--- a/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.ts
+++ b/frontend/app/api/reingest/[schema]/[plotID]/[censusID]/route.ts
@@ -31,6 +31,7 @@ interface ReingestionSourceRow {
   MeasurementDate: string | null;
   RawCodes: string | null;
   RawComments: string | null;
+  RawPublishedStemID: number | null;
 }
 
 interface ReingestionRowMapping {
@@ -129,7 +130,8 @@ async function getFailedMeasurementRows(
        cm.MeasuredHOM,
        cm.MeasurementDate,
        cm.RawCodes,
-       cm.RawComments
+       cm.RawComments,
+       cm.RawPublishedStemID
      FROM ??.coremeasurements cm
      JOIN ??.census c ON c.CensusID = cm.CensusID
      WHERE c.PlotID = ?
@@ -188,13 +190,14 @@ async function moveFailedToTemporary(
     row.MeasuredHOM,
     row.MeasurementDate,
     row.RawCodes,
-    row.RawComments
+    row.RawComments,
+    row.RawPublishedStemID
   ]);
 
   const insertTempSQL = safeFormatQuery(
     schema,
     `INSERT INTO ??.temporarymeasurements
-      (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments)
+      (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
      VALUES ?`
   );
   const insertResult: any = await connectionManager.executeQuery(insertTempSQL, [values], transactionID);
@@ -275,6 +278,7 @@ async function createReingestionSnapshotTables(connectionManager: any, schema: s
       RawX DECIMAL(12, 6) NULL,
       RawY DECIMAL(12, 6) NULL,
       RawCodes VARCHAR(255) NULL,
+      RawPublishedStemID INT UNSIGNED NULL,
       RawComments VARCHAR(255) NULL,
       IsActive TINYINT(1) NOT NULL
     )`,
@@ -287,7 +291,7 @@ async function createReingestionSnapshotTables(connectionManager: any, schema: s
     `INSERT INTO reingestion_results
       (OriginalID, CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
        Description, UserDefinedFields, RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY,
-       RawCodes, RawComments, IsActive)
+       RawCodes, RawPublishedStemID, RawComments, IsActive)
      SELECT
        rm.OriginalID,
        cm_new.CensusID,
@@ -305,6 +309,7 @@ async function createReingestionSnapshotTables(connectionManager: any, schema: s
        cm_new.RawX,
        cm_new.RawY,
        cm_new.RawCodes,
+       cm_new.RawPublishedStemID,
        cm_new.RawComments,
        cm_new.IsActive
      FROM ??.coremeasurements cm_new
@@ -411,6 +416,7 @@ async function reconcileReingestionRows(
            orig.RawX = rr.RawX,
            orig.RawY = rr.RawY,
            orig.RawCodes = rr.RawCodes,
+           orig.RawPublishedStemID = rr.RawPublishedStemID,
            orig.RawComments = rr.RawComments,
            orig.IsActive = rr.IsActive`
     );

--- a/frontend/app/api/reingestsinglefailure/[schema]/[targetRowID]/route.test.ts
+++ b/frontend/app/api/reingestsinglefailure/[schema]/[targetRowID]/route.test.ts
@@ -83,6 +83,7 @@ describe('reingestsinglefailure API route', () => {
           RawX: 1.23,
           RawY: 4.56,
           RawCodes: 'AL',
+          RawPublishedStemID: 5001,
           RawComments: null,
           IsActive: 1
         }
@@ -111,6 +112,8 @@ describe('reingestsinglefailure API route', () => {
 
     const syncCall = calls.find((call: any[]) => String(call[0]).includes('SET orig.CensusID'));
     expect(syncCall).toBeDefined();
+    expect(String(syncCall?.[0])).toContain('orig.RawPublishedStemID');
+    expect(syncCall?.[1]).toContain(5001);
     expect(String(syncCall?.[0])).not.toContain('orig.UploadFileID');
     expect(String(syncCall?.[0])).not.toContain('orig.UploadBatchID');
     expect(String(syncCall?.[0])).not.toContain('orig.SourceRowIndex');

--- a/frontend/app/api/reingestsinglefailure/[schema]/[targetRowID]/route.ts
+++ b/frontend/app/api/reingestsinglefailure/[schema]/[targetRowID]/route.ts
@@ -51,7 +51,7 @@ export async function GET(
     shiftQuery = safeFormatQuery(
       schema,
       `INSERT INTO ??.temporarymeasurements
-        (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments)
+        (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
        SELECT
          ? AS FileID,
          ? AS BatchID,
@@ -67,7 +67,8 @@ export async function GET(
          cm.MeasuredHOM,
          cm.MeasurementDate,
          cm.RawCodes,
-         cm.RawComments
+         cm.RawComments,
+         cm.RawPublishedStemID
        FROM ??.coremeasurements cm
        JOIN ??.census c ON c.CensusID = cm.CensusID
        WHERE cm.CoreMeasurementID = ?
@@ -121,6 +122,7 @@ export async function GET(
          RawX,
          RawY,
          RawCodes,
+         RawPublishedStemID,
          RawComments,
          IsActive
        FROM ??.coremeasurements
@@ -157,6 +159,7 @@ export async function GET(
            orig.RawX = ?,
            orig.RawY = ?,
            orig.RawCodes = ?,
+           orig.RawPublishedStemID = ?,
            orig.RawComments = ?,
            orig.IsActive = ?
        WHERE orig.CoreMeasurementID = ?`
@@ -237,6 +240,7 @@ export async function GET(
         snapshot.RawX,
         snapshot.RawY,
         snapshot.RawCodes,
+        snapshot.RawPublishedStemID,
         snapshot.RawComments,
         snapshot.IsActive,
         targetMeasurementID

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -1215,4 +1215,54 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     );
     expect(insertCall[1].slice(0, 6)).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_SESSION_ID, 'csv', TEST_PLOT_ID, TEST_CENSUS_ID]);
   });
+
+  it('raises an INVALID_PUBLISHED_STEMID warning alert when a present PublishedStemID cannot be parsed (ingests NULL, not silent)', async () => {
+    // The row is otherwise valid, so it ingests; its StemID value "5,001" is unparseable and is coerced
+    // to NULL. The upload must record a visible warning rather than silently discarding the SI identifier.
+    const field = (canonicalField: string, sourceColumns: string[]): ColumnMapping['fields'][number] => ({ canonicalField, sourceColumns, scope: 'file' });
+    const headersWithStemId = [...RESOLUTION_CSV_HEADERS, 'StemID'];
+    const mappingWithPublishedStemId: ColumnMapping = {
+      version: 1,
+      format: SourceFormat.csv,
+      fields: [
+        field('tag', ['tag']),
+        field('spcode', ['spcode']),
+        field('quadrat', ['quadrat']),
+        field('lx', ['MyX']),
+        field('ly', ['ly']),
+        field('date', ['date']),
+        field('publishedstemid', ['StemID'])
+      ],
+      headerSignature: headerSignature(headersWithStemId)
+    };
+    const rawRow = { MyX: '12.5', tag: 'T1', spcode: 'abc', quadrat: 'q1', ly: '3.0', date: '2023-05-17', StemID: '5,001' };
+
+    mockConnectionManager.executeQuery
+      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
+      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
+      .mockResolvedValueOnce([{ count: 1 }])
+      .mockResolvedValueOnce([{ count: 0 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ affectedRows: 0 })
+      .mockResolvedValueOnce(undefined) // INSERT IGNORE temporarymeasurements
+      .mockResolvedValueOnce(undefined) // INSERT uploadintegrityalerts (INVALID_PUBLISHED_STEMID)
+      .mockResolvedValueOnce([{ count: 1 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(undefined);
+
+    const res = (await POST(makeRawRowsRequest([rawRow], { csvHeaders: headersWithStemId, mapping: mappingWithPublishedStemId })))!;
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.insertedCount).toBe(1);
+
+    const alertCall = mockConnectionManager.executeQuery.mock.calls.find(
+      (call: any[]) => String(call[0]).includes('uploadintegrityalerts') && String(call[0]).includes('INVALID_PUBLISHED_STEMID')
+    );
+    expect(alertCall).toBeDefined();
+    // Severity is a warning (row still ingested) and the offending value is captured in the message.
+    expect(String(alertCall[0])).toContain("'warning'");
+    const alertMessage = String(alertCall[1].find((param: unknown) => typeof param === 'string' && param.includes('coercedToNullCount')));
+    expect(alertMessage).toContain('5,001');
+  });
 });

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -98,8 +98,8 @@ vi.mock('mysql2/promise', () => ({
   })
 }));
 
-/** Number of columns in the temporarymeasurements INSERT (FileID through Comments) */
-const TEMP_MEASUREMENT_COLUMNS_PER_ROW = 17;
+/** Number of columns in the temporarymeasurements INSERT (FileID through PublishedStemID) */
+const TEMP_MEASUREMENT_COLUMNS_PER_ROW = 18;
 
 const TEST_SESSION_ID = 'session-1';
 const TEST_PLOT_ID = 22;

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -935,8 +935,9 @@ export async function POST(request: NextRequest) {
               ],
               transactionID
             );
-          } catch (alertError: any) {
-            ailogger.error(`Failed to log INVALID_PUBLISHED_STEMID alert for ${fileName}-${batchID}: ${alertError.message}`);
+          } catch (alertError: unknown) {
+            const message = alertError instanceof Error ? alertError.message : String(alertError);
+            ailogger.error(`Failed to log INVALID_PUBLISHED_STEMID alert for ${fileName}-${batchID}: ${message}`);
           }
         }
 

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -28,6 +28,7 @@ import {
   ensureTemporaryMeasurementsSourceFormatColumn,
   findDroppedMeasurementCandidates,
   insertTemporaryMeasurementsInBatches,
+  isUnsignedIntFieldInvalid,
   type DroppedMeasurementRow
 } from '@/lib/ingestion/temporary-measurements';
 
@@ -889,6 +890,55 @@ export async function POST(request: NextRequest) {
           resolvedCensusID,
           transactionID
         );
+
+        // A present-but-unparseable PublishedStemID is coerced to NULL at staging so the row still
+        // ingests, but the SI-assigned identifier the upload carried is lost. Surface it as a
+        // visible warning alert rather than dropping it silently.
+        const invalidPublishedStemIdRows = chunkRows
+          .map((row, index) => ({ value: row.publishedstemid, sourceRowIndex: index + 1 }))
+          .filter(candidate => isUnsignedIntFieldInvalid(candidate.value));
+
+        if (invalidPublishedStemIdRows.length > 0) {
+          ailogger.warn(
+            `Coerced ${invalidPublishedStemIdRows.length} unparseable PublishedStemID value(s) to NULL for ${fileName}-${batchID}; ` +
+              `the SI-assigned identifier was not stored for those rows.`
+          );
+          try {
+            const publishedStemIdAlertSQL = format(
+              `INSERT INTO ??.uploadintegrityalerts
+               (uploadId, fileID, batchID, plotID, censusID, type, message, severity,
+                sourceRecords, processedRecords, failedRecords, missingRecords)
+               VALUES (?, ?, ?, ?, ?, 'INVALID_PUBLISHED_STEMID', ?, 'warning', ?, ?, ?, ?)`,
+              [schema]
+            );
+            const publishedStemIdAlertMessage = JSON.stringify({
+              coercedToNullCount: invalidPublishedStemIdRows.length,
+              sample: invalidPublishedStemIdRows.slice(0, 10).map(candidate => ({
+                sourceRowIndex: candidate.sourceRowIndex,
+                value: `${candidate.value}`
+              })),
+              note: 'PublishedStemID values that are present but not a positive integer were stored as NULL; the row was still ingested.'
+            });
+            await connectionManager.executeQuery(
+              publishedStemIdAlertSQL,
+              [
+                buildUploadId(schema, resolvedPlotID, resolvedCensusID, fileName, batchID, 'invalid-published-stemid'),
+                fileName,
+                batchID,
+                resolvedPlotID,
+                resolvedCensusID,
+                publishedStemIdAlertMessage,
+                expectedRowCount,
+                expectedRowCount,
+                0,
+                0
+              ],
+              transactionID
+            );
+          } catch (alertError: any) {
+            ailogger.error(`Failed to log INVALID_PUBLISHED_STEMID alert for ${fileName}-${batchID}: ${alertError.message}`);
+          }
+        }
 
         // CRITICAL FIX: Verify expected vs actual row count to detect silent data loss from INSERT IGNORE
         const postInsertResult = await connectionManager.executeQuery(countSQL, [fileName, batchID], transactionID);

--- a/frontend/config/macros/formdetails.ts
+++ b/frontend/config/macros/formdetails.ts
@@ -110,6 +110,11 @@ export const TableHeadersByFormType: Record<FormType, { label: string; explanati
     { label: 'date', explanation: 'The date of the measurement', category: 'required' },
     { label: 'codes', explanation: 'The attribute codes associated with the measurement and stem', category: 'optional' },
     { label: 'comments', explanation: 'Comments about the measurement', category: 'optional' }, // optional - users should be able to submit comments if needed
+    {
+      label: 'publishedstemid',
+      explanation: 'The Smithsonian/SI-assigned stem identifier (StemID). Present only for previously-published stems; leave blank for new stems.',
+      category: 'optional'
+    },
     { label: 'errors', explanation: 'Validation errors detected for this measurement', category: 'optional' }
   ]
 };

--- a/frontend/db-migrations/unified-measurements-migrations/60_add_published_stemid.sql
+++ b/frontend/db-migrations/unified-measurements-migrations/60_add_published_stemid.sql
@@ -1,0 +1,46 @@
+-- =====================================================================================
+-- Migration Script 60: Add PublishedStemID storage columns
+-- =====================================================================================
+-- Purpose:
+--   Adds SI-assigned PublishedStemID to stems + failed-row provenance RawPublishedStemID
+--   to coremeasurements. Nullable/additive/no-backfill. Idempotent via information_schema guards.
+-- =====================================================================================
+
+SET @schema_name := DATABASE();
+
+SET @has_col := (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @schema_name AND TABLE_NAME = 'stems' AND COLUMN_NAME = 'PublishedStemID');
+SET @ddl := IF(@has_col = 0,
+    'ALTER TABLE stems ADD COLUMN PublishedStemID int unsigned NULL AFTER StemCrossID', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = @schema_name AND TABLE_NAME = 'stems' AND INDEX_NAME = 'idx_stems_publishedstemid');
+SET @ddl := IF(@has_idx = 0,
+    'CREATE INDEX idx_stems_publishedstemid ON stems (PublishedStemID)', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_col := (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @schema_name AND TABLE_NAME = 'coremeasurements' AND COLUMN_NAME = 'RawPublishedStemID');
+SET @ddl := IF(@has_col = 0,
+    'ALTER TABLE coremeasurements ADD COLUMN RawPublishedStemID int unsigned NULL AFTER RawCodes', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_col := (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = @schema_name AND TABLE_NAME = 'temporarymeasurements' AND COLUMN_NAME = 'PublishedStemID');
+SET @ddl := IF(@has_col = 0,
+    'ALTER TABLE temporarymeasurements ADD COLUMN PublishedStemID int unsigned NULL AFTER Comments', 'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+INSERT IGNORE INTO measurement_errors (ErrorSource, ErrorCode, ErrorMessage)
+VALUES ('ingestion', 'PUBLISHED_STEMID_CONFLICT', 'Uploaded PublishedStemID conflicts with an existing stem identity');
+
+SELECT 'Migration 60 complete: PublishedStemID columns, index, and conflict error seed ensured.' AS Status;

--- a/frontend/db-migrations/unified-measurements-migrations/run-branch-refresh.sh
+++ b/frontend/db-migrations/unified-measurements-migrations/run-branch-refresh.sh
@@ -75,6 +75,7 @@ POST_STORED_PROCEDURE_MIGRATIONS=(
     "56_relax_edit_operations_target_id.sql"
     "57_backfill_measurementssummary_stemguid.sql"
     "58_refresh_rawcodes_empty_token_handling.sql"
+    "60_add_published_stemid.sql"
 )
 
 REQUIRED_BASE_TABLES=(

--- a/frontend/db-migrations/unified-measurements-migrations/run-migrations.sh
+++ b/frontend/db-migrations/unified-measurements-migrations/run-migrations.sh
@@ -70,6 +70,7 @@ ORDERED_MIGRATIONS=(
     "56_relax_edit_operations_target_id.sql"
     "57_backfill_measurementssummary_stemguid.sql"
     "58_refresh_rawcodes_empty_token_handling.sql"
+    "60_add_published_stemid.sql"
 )
 
 # ---------------------------------------------------------------------------

--- a/frontend/lib/arcgis/schema.ts
+++ b/frontend/lib/arcgis/schema.ts
@@ -52,6 +52,17 @@ export const ARCGIS_SCHEMA: ArcgisFieldDef[] = [
     category: 'required'
   },
   { field: 'StemTag', aliases: ['StemTag'], scope: 'both', required: true, help: 'Stem tag for the row.', category: 'required' },
+  {
+    // SI-assigned published stem identifier carried in the ArcGIS forms. Distinct from the Esri
+    // `GlobalID` (which is ArcPro-generated and not census-stable, so never mapped to identity).
+    // Aliases are the source header(s) ArcPro exports; adjust once the exact form column is confirmed.
+    field: 'publishedstemid',
+    aliases: ['StemID', 'PublishedStemID', 'SI_StemID'],
+    scope: 'both',
+    required: false,
+    help: 'SI-assigned published stem identifier, when present. Optional; blank for sites that have not been issued one.',
+    category: 'optional'
+  },
   { field: 'spcode', aliases: ['spcode'], scope: 'both', required: true, help: 'Species code.', category: 'required' },
   {
     field: 'DBH_CURRENT',

--- a/frontend/lib/arcgis/transform.test.ts
+++ b/frontend/lib/arcgis/transform.test.ts
@@ -241,4 +241,39 @@ describe('cellToString numeric formatting (via transformArcgisWorkbook)', () => 
     expect(rows[0].tag).toBe('1234567890123456');
     expect(rows[0].stemtag).toBe('9007199254740991');
   });
+
+  describe('PublishedStemID capture', () => {
+    it('captures a tree-sheet StemID onto the canonical row as publishedstemid', () => {
+      const { rows } = transformArcgisWorkbook({ trees: [tree({ publishedstemid: '5001' })], stems: [] });
+      expect(rows[0].publishedstemid).toBe('5001');
+    });
+
+    it('captures the stem-sheet StemID from the stem row, not the parent tree', () => {
+      // The joined stem inherits coordinates from the parent but its published id is its own.
+      const { rows } = transformArcgisWorkbook({
+        trees: [tree({ publishedstemid: '5001' })],
+        stems: [stem({ publishedstemid: '5002' })]
+      });
+      const joinedStem = rows.find(r => r.stemtag === '100-2');
+      expect(joinedStem?.publishedstemid).toBe('5002');
+    });
+
+    it("captures an orphan stem's StemID", () => {
+      const { rows } = transformArcgisWorkbook({ trees: [], stems: [stem({ ParentGlobalID: 'MISSING', publishedstemid: '5003' })] });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].publishedstemid).toBe('5003');
+    });
+
+    it('preserves an exact integer StemID without significant-digit rounding', () => {
+      const { rows } = transformArcgisWorkbook({ trees: [tree({ publishedstemid: 4294967295 as unknown as string })], stems: [] });
+      expect(rows[0].publishedstemid).toBe('4294967295');
+    });
+
+    it('emits null publishedstemid when the StemID column is absent or blank', () => {
+      const { rows } = transformArcgisWorkbook({ trees: [tree({ publishedstemid: '' })], stems: [] });
+      expect(rows[0].publishedstemid).toBeNull();
+      const { rows: rowsNoCol } = transformArcgisWorkbook({ trees: [tree()], stems: [] });
+      expect(rowsNoCol[0].publishedstemid).toBeNull();
+    });
+  });
 });

--- a/frontend/lib/arcgis/transform.ts
+++ b/frontend/lib/arcgis/transform.ts
@@ -84,6 +84,7 @@ interface CanonicalInput {
   date: string | null;
   codes: string;
   comments: string | null;
+  publishedstemid: string | null;
 }
 
 // Canonical fields the bulkingestionprocess stored procedure treats as required (recording a
@@ -105,7 +106,8 @@ function toFileRow(input: CanonicalInput): FileRow {
     hom: input.hom,
     date: input.date,
     codes: input.codes,
-    comments: input.comments
+    comments: input.comments,
+    publishedstemid: input.publishedstemid
   };
 }
 
@@ -209,7 +211,8 @@ export function transformArcgisWorkbook({ trees, stems }: ArcgisWorkbook): Trans
       hom: decimalCellToString(field(tree, 'HOM')),
       date: dateToIso(field(tree, 'Date_measured')),
       codes: joinCodes(tree),
-      comments: cellToString(field(tree, 'notes'))
+      comments: cellToString(field(tree, 'notes')),
+      publishedstemid: cellToString(field(tree, 'publishedstemid'))
     });
     collectMissingRequired(row, 'trees', rowIndex, globalId);
     rows.push(row);
@@ -258,7 +261,8 @@ export function transformArcgisWorkbook({ trees, stems }: ArcgisWorkbook): Trans
         hom: decimalCellToString(field(stem, 'HOM')),
         date: dateToIso(field(stem, 'Date_measured')),
         codes: joinCodes(stem),
-        comments: cellToString(field(stem, 'notes'))
+        comments: cellToString(field(stem, 'notes')),
+        publishedstemid: cellToString(field(stem, 'publishedstemid'))
       });
       collectMissingRequired(orphanRow, 'stems', rowIndex, stemGlobalId);
       rows.push(orphanRow);
@@ -306,7 +310,8 @@ export function transformArcgisWorkbook({ trees, stems }: ArcgisWorkbook): Trans
       hom: decimalCellToString(field(stem, 'HOM')),
       date: dateToIso(field(stem, 'Date_measured')),
       codes: joinCodes(stem),
-      comments: cellToString(field(stem, 'notes'))
+      comments: cellToString(field(stem, 'notes')),
+      publishedstemid: cellToString(field(stem, 'publishedstemid'))
     });
     collectMissingRequired(row, 'stems', rowIndex, stemGlobalId);
     rows.push(row);

--- a/frontend/lib/arcgis/workbook-reader.test.ts
+++ b/frontend/lib/arcgis/workbook-reader.test.ts
@@ -35,6 +35,22 @@ describe('readArcgisWorkbook', () => {
     expect(stems[0].ParentGlobalID).toBe('G1');
   });
 
+  it('canonicalizes a StemID header to the publishedstemid key on both sheets', async () => {
+    const treeHeader = [...TREE_HEADER, 'StemID'];
+    const stemHeader = [...STEM_HEADER, 'StemID'];
+    const buffer = await buildWorkbook({
+      trees: [treeHeader, ['G1', 'A25', '100', '100', 'QURU', '12.3', '1.3', 'ok', 46036, '5.1', '6.2', 'M', 'NA', '5001']],
+      stems: [stemHeader, ['G1', 'S1', 'A25', '100', '100-2', 'QURU', '4.4', '1.3', '', 46036, 'A', 'NA', '5002']]
+    });
+
+    const { trees, stems } = await readArcgisWorkbook(buffer);
+
+    // The raw 'StemID' header is exposed under the canonical FileRow key, never the raw string.
+    expect(trees[0].publishedstemid).toBe('5001');
+    expect(trees[0].StemID).toBeUndefined();
+    expect(stems[0].publishedstemid).toBe('5002');
+  });
+
   it('treats empty cells as null', async () => {
     const buffer = await buildWorkbook({
       trees: [TREE_HEADER, ['G1', '', '100', '100', 'QURU', '12.3', '1.3', '', 46036, '5.1', '6.2', '', '']],

--- a/frontend/lib/column-mapping/fields.test.ts
+++ b/frontend/lib/column-mapping/fields.test.ts
@@ -13,9 +13,22 @@ describe('normalizeHeader', () => {
 describe('canonicalFieldsFor(csv)', () => {
   const fields = canonicalFieldsFor(SourceFormat.csv);
 
-  it('lists the 11 CSV import fields', () => {
+  it('lists the 12 CSV import fields', () => {
     // Order matches TableHeadersByFormType[measurements] (registry is source of truth; export-only fields excluded).
-    expect(fields.map(f => f.canonicalField)).toEqual(['tag', 'stemtag', 'spcode', 'quadrat', 'lx', 'ly', 'dbh', 'hom', 'date', 'codes', 'comments']);
+    expect(fields.map(f => f.canonicalField)).toEqual([
+      'tag',
+      'stemtag',
+      'spcode',
+      'quadrat',
+      'lx',
+      'ly',
+      'dbh',
+      'hom',
+      'date',
+      'codes',
+      'comments',
+      'publishedstemid'
+    ]);
   });
 
   it('marks tag/spcode/quadrat/lx/ly/date required and the rest optional', () => {

--- a/frontend/lib/column-mapping/fields.test.ts
+++ b/frontend/lib/column-mapping/fields.test.ts
@@ -81,6 +81,21 @@ describe('aliasesFor(csv)', () => {
     expect(csv['hom']).toEqual(expect.arrayContaining(['hom', 'height', 'heightofmeasurement']));
     expect(csv['stemtag']).toEqual(expect.arrayContaining(['stemtag', 'stem']));
   });
+
+  it('aliases only unambiguous SI headers to publishedstemid', () => {
+    const csv = aliasesFor(SourceFormat.csv);
+    expect(csv['publishedstemid']).toEqual(expect.arrayContaining(['publishedstemid', 'si_stemid', 'ctfs_stemid']));
+  });
+
+  it("does NOT alias a bare stemid/StemID header to publishedstemid (collides with the app's own StemGUID export label)", () => {
+    // The measurements grid and CSV/form exports label internal StemGUID as "stemID"; auto-mapping that
+    // header to publishedstemid on re-upload would feed StemGUID into the SI identifier. See fields.ts.
+    const csv = aliasesFor(SourceFormat.csv);
+    for (const aliases of Object.values(csv)) {
+      expect(aliases).not.toContain(normalizeHeader('StemID'));
+      expect(aliases).not.toContain('stemid');
+    }
+  });
 });
 
 describe('legacyCsvHeaderKey', () => {

--- a/frontend/lib/column-mapping/fields.ts
+++ b/frontend/lib/column-mapping/fields.ts
@@ -31,12 +31,13 @@ const CSV_ALIASES: Record<string, string[]> = {
   date: ['date', 'measurementdate', 'dateof'],
   codes: ['codes', 'code', 'attributes', 'attributecodes'],
   comments: ['comments', 'comment', 'description', 'notes'],
-  // In MEASUREMENT uploads, a `StemID` header is the Smithsonian/SI-assigned stem identifier
-  // and maps to `publishedstemid`. This is deliberately scoped to the measurement flow: revision
-  // uploads have their own header normalizer (revisionfileparse.ts:normalizeRevisionHeader) where
-  // `StemID`/`StemGUID` mean the app's internal `StemGUID` — that path does not use these aliases,
-  // so the two meanings never collide. ArcGIS `GlobalID` is intentionally NOT mapped here.
-  publishedstemid: ['publishedstemid', 'stemid', 'si_stemid', 'ctfs_stemid']
+  // `publishedstemid` is the Smithsonian/SI-assigned stem identifier. Only unambiguous headers are
+  // aliased. A bare `StemID`/`stemid` header is deliberately NOT aliased: ForestGEO labels its own
+  // internal `StemGUID` as `stemID` in the measurements grid and its CSV/form exports, so a re-uploaded
+  // app export would otherwise feed internal StemGUID values into PublishedStemID. A genuine SI file
+  // headed `StemID` can still be mapped by hand in the column-mapping UI. ArcGIS `GlobalID` is also
+  // intentionally NOT mapped here.
+  publishedstemid: ['publishedstemid', 'si_stemid', 'ctfs_stemid']
 };
 
 const CODE_AGGREGATE_FIELD = `${CODE_COLUMN_PREFIX}*`;

--- a/frontend/lib/column-mapping/fields.ts
+++ b/frontend/lib/column-mapping/fields.ts
@@ -30,7 +30,13 @@ const CSV_ALIASES: Record<string, string[]> = {
   hom: ['hom', 'height', 'heightofmeasurement'],
   date: ['date', 'measurementdate', 'dateof'],
   codes: ['codes', 'code', 'attributes', 'attributecodes'],
-  comments: ['comments', 'comment', 'description', 'notes']
+  comments: ['comments', 'comment', 'description', 'notes'],
+  // In MEASUREMENT uploads, a `StemID` header is the Smithsonian/SI-assigned stem identifier
+  // and maps to `publishedstemid`. This is deliberately scoped to the measurement flow: revision
+  // uploads have their own header normalizer (revisionfileparse.ts:normalizeRevisionHeader) where
+  // `StemID`/`StemGUID` mean the app's internal `StemGUID` — that path does not use these aliases,
+  // so the two meanings never collide. ArcGIS `GlobalID` is intentionally NOT mapped here.
+  publishedstemid: ['publishedstemid', 'stemid', 'si_stemid', 'ctfs_stemid']
 };
 
 const CODE_AGGREGATE_FIELD = `${CODE_COLUMN_PREFIX}*`;

--- a/frontend/lib/ingestion/temporary-measurements.test.ts
+++ b/frontend/lib/ingestion/temporary-measurements.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { isUnsignedIntFieldInvalid, MYSQL_UNSIGNED_INT_MAX, parseUnsignedIntField } from './temporary-measurements';
+
+describe('parseUnsignedIntField', () => {
+  it('parses positive integers within the MySQL unsigned range', () => {
+    expect(parseUnsignedIntField(5001)).toBe(5001);
+    expect(parseUnsignedIntField('5001')).toBe(5001);
+    expect(parseUnsignedIntField(MYSQL_UNSIGNED_INT_MAX)).toBe(MYSQL_UNSIGNED_INT_MAX);
+  });
+
+  it('returns null for absent or blank values', () => {
+    expect(parseUnsignedIntField(undefined)).toBeNull();
+    expect(parseUnsignedIntField(null)).toBeNull();
+    expect(parseUnsignedIntField('')).toBeNull();
+    expect(parseUnsignedIntField('   ')).toBeNull();
+  });
+
+  it('returns null for present-but-invalid values', () => {
+    expect(parseUnsignedIntField('5,001')).toBeNull();
+    expect(parseUnsignedIntField('STEM-5001')).toBeNull();
+    expect(parseUnsignedIntField('5001x')).toBeNull();
+    expect(parseUnsignedIntField(0)).toBeNull();
+    expect(parseUnsignedIntField(-1)).toBeNull();
+    expect(parseUnsignedIntField(12.3)).toBeNull();
+    expect(parseUnsignedIntField(MYSQL_UNSIGNED_INT_MAX + 1)).toBeNull();
+  });
+});
+
+describe('isUnsignedIntFieldInvalid', () => {
+  it('is false for absent/blank values (a missing PublishedStemID is legitimately optional)', () => {
+    expect(isUnsignedIntFieldInvalid(undefined)).toBe(false);
+    expect(isUnsignedIntFieldInvalid(null)).toBe(false);
+    expect(isUnsignedIntFieldInvalid('')).toBe(false);
+    expect(isUnsignedIntFieldInvalid('   ')).toBe(false);
+  });
+
+  it('is false for values that parse to a valid unsigned int', () => {
+    expect(isUnsignedIntFieldInvalid(5001)).toBe(false);
+    expect(isUnsignedIntFieldInvalid('5001')).toBe(false);
+  });
+
+  it('is true only for present values that cannot be stored as an unsigned int', () => {
+    // These are exactly the cases that were previously coerced to NULL and ingested silently.
+    expect(isUnsignedIntFieldInvalid('5,001')).toBe(true);
+    expect(isUnsignedIntFieldInvalid('STEM-5001')).toBe(true);
+    expect(isUnsignedIntFieldInvalid('5001x')).toBe(true);
+    expect(isUnsignedIntFieldInvalid(0)).toBe(true);
+    expect(isUnsignedIntFieldInvalid(-1)).toBe(true);
+    expect(isUnsignedIntFieldInvalid(12.3)).toBe(true);
+  });
+});

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -69,6 +69,16 @@ export function parseUnsignedIntField(value: unknown): number | null {
   return Number.isInteger(n) && n > 0 && n <= MYSQL_UNSIGNED_INT_MAX ? n : null;
 }
 
+/**
+ * True when a value is present and non-empty but does not parse to a valid unsigned int.
+ * Absent/blank values are legitimately optional and return false; only present-but-garbage
+ * values (e.g. "5,001", "STEM-5001") return true so callers can surface the coerced-to-NULL loss.
+ */
+export function isUnsignedIntFieldInvalid(value: unknown): boolean {
+  if (value === undefined || value === null || `${value}`.trim() === '') return false;
+  return parseUnsignedIntField(value) === null;
+}
+
 function collectMeasurementValidationIssues(row: FileRow): string[] {
   const issues: string[] = [];
   if (!row.tag || row.tag.trim() === '') issues.push('empty TreeTag');

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -59,6 +59,16 @@ export function normalizeMeasurementDate(value: unknown): string | null {
   return value ? moment(value).format('YYYY-MM-DD') : null;
 }
 
+// Maximum value of a MySQL INT UNSIGNED column (2^32 - 1).
+export const MYSQL_UNSIGNED_INT_MAX = 4294967295;
+
+/** Parses a value into a positive MySQL-unsigned-int, or null if absent/invalid. */
+export function parseUnsignedIntField(value: unknown): number | null {
+  if (value === undefined || value === null || `${value}`.trim() === '') return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 && n <= MYSQL_UNSIGNED_INT_MAX ? n : null;
+}
+
 function collectMeasurementValidationIssues(row: FileRow): string[] {
   const issues: string[] = [];
   if (!row.tag || row.tag.trim() === '') issues.push('empty TreeTag');
@@ -93,10 +103,11 @@ export function buildTemporaryMeasurementInsertParams(
   plotID: number,
   censusID: number
 ): (string | number | null)[] {
-  const { tag, stemtag, spcode, quadrat, lx, ly, dbh, hom, date, codes, comments } = row;
+  const { tag, stemtag, spcode, quadrat, lx, ly, dbh, hom, date, codes, comments, publishedstemid } = row;
   const formattedDate = normalizeMeasurementDate(date);
   const parsedLx = lx !== undefined && lx !== null && lx !== '' && !isNaN(Number(lx)) ? Number(lx) : null;
   const parsedLy = ly !== undefined && ly !== null && ly !== '' && !isNaN(Number(ly)) ? Number(ly) : null;
+  const parsedPublishedStemID = parseUnsignedIntField(publishedstemid);
 
   return [
     fileName,
@@ -115,7 +126,8 @@ export function buildTemporaryMeasurementInsertParams(
     hom ?? null,
     formattedDate,
     codes ?? null,
-    comments ?? null
+    comments ?? null,
+    parsedPublishedStemID
   ];
 }
 
@@ -133,14 +145,14 @@ export async function insertTemporaryMeasurementsInBatches(
 ): Promise<void> {
   const insertSQLPrefix = format(
     `INSERT IGNORE INTO ??.temporarymeasurements
-      (FileID, BatchID, SessionID, SourceFormat, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments)
+      (FileID, BatchID, SessionID, SourceFormat, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
       VALUES `,
     [schema]
   );
 
   for (let start = 0; start < rows.length; start += TEMP_MEASUREMENT_INSERT_BATCH_SIZE) {
     const slice = rows.slice(start, start + TEMP_MEASUREMENT_INSERT_BATCH_SIZE);
-    const placeholders = slice.map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).join(', ');
+    const placeholders = slice.map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).join(', ');
     const values = slice.flatMap(row => buildTemporaryMeasurementInsertParams(row, fileName, batchID, sessionId, sourceFormat, plotID, censusID));
     await connectionManager.executeQuery(`${insertSQLPrefix}${placeholders}`, values, transactionID);
   }

--- a/frontend/sqlscripting/storedprocedures.sql
+++ b/frontend/sqlscripting/storedprocedures.sql
@@ -2794,6 +2794,13 @@ BEGIN
         KEY idx_core_insert_failures_error (ErrorCode)
     );
 
+    -- PublishedStemID conflict detection runs four distinct checks, each flagging a different way an
+    -- uploaded id can be inconsistent. They share the INSERT-into-core_insert_failures boilerplate but
+    -- are deliberately separate because their joins and predicates differ:
+    --   1. Same uploaded id lands on more than one resolved StemCrossID in this batch.
+    --   2. One resolved StemCrossID receives more than one distinct uploaded id in this batch.
+    --   3. Resolved StemCrossID already has a different PublishedStemID from a prior census.
+    --   4. Uploaded id already belongs to a different StemCrossID elsewhere in the plot.
     CREATE TEMPORARY TABLE published_stemid_batch_id_conflicts AS
     SELECT rbr.PublishedStemID
     FROM resolved_batch_rows rbr
@@ -2877,6 +2884,12 @@ BEGIN
     WHERE rbr.PublishedStemID IS NOT NULL
       AND NOT (s_owner.StemCrossID <=> s_current.StemCrossID);
 
+    -- Final assignment: propagate the uploaded PublishedStemID across EVERY census row of the same
+    -- physical stem (matched by StemCrossID within this plot), not just the uploaded census. This is
+    -- intentional: PublishedStemID is cross-census stem-identity metadata, so once an upload supplies it
+    -- the whole StemCrossID history should carry it. `s_target.PublishedStemID IS NULL` makes this a
+    -- fill-only back-fill that never overwrites an existing value, and rows with a conflict failure
+    -- (present in core_insert_failures) are excluded so contested ids are never assigned.
     UPDATE stems s_target
     INNER JOIN census c_target
         ON c_target.CensusID = s_target.CensusID

--- a/frontend/sqlscripting/storedprocedures.sql
+++ b/frontend/sqlscripting/storedprocedures.sql
@@ -1605,7 +1605,7 @@ BEGIN
                 (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
                  Description, UploadFileID, UploadBatchID,
                  RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY,
-                 RawCodes, RawComments, SourceRowIndex, IsActive)
+                 RawCodes, RawPublishedStemID, RawComments, SourceRowIndex, IsActive)
             SELECT
                 (SELECT CensusID FROM temporarymeasurements WHERE FileID = vFileID AND BatchID = vBatchID LIMIT 1),
                 NULL, FALSE,
@@ -1613,11 +1613,14 @@ BEGIN
                 LEFT(CONCAT('SQL Exception: Error ', vErrorCode, ': ', LEFT(vErrorMessage, 150)), 255),
                 vFileID, vBatchID,
                 NULLIF(TreeTag, ''), NULLIF(StemTag, ''), NULLIF(SpeciesCode, ''), NULLIF(QuadratName, ''),
-                LocalX, LocalY, NULLIF(Codes, ''), NULLIF(Comments, ''),
+                LocalX, LocalY, NULLIF(Codes, ''), PublishedStemID, NULLIF(Comments, ''),
                 id, 1
             FROM temporarymeasurements
             WHERE FileID = vFileID AND BatchID = vBatchID
-            ON DUPLICATE KEY UPDATE IsValidated = FALSE, Description = VALUES(Description);
+            ON DUPLICATE KEY UPDATE
+                IsValidated = FALSE,
+                Description = VALUES(Description),
+                RawPublishedStemID = VALUES(RawPublishedStemID);
 
             -- Link to error log
             INSERT IGNORE INTO measurement_error_log (MeasurementID, ErrorID, IsResolved)
@@ -1637,6 +1640,7 @@ BEGIN
                 prev_match_ambiguities, tree_insert_candidates, tree_insert_failures,
                 current_tree_lookup, stem_resolution_rows, stem_insert_candidates,
                 unresolved_stem_rows, current_stem_lookup, resolved_batch_rows,
+                published_stemid_batch_id_conflicts, published_stemid_batch_group_conflicts,
                 core_insert_candidates, source_row_insert_conflicts, core_insert_failures, resolved_coremeasurements,
                 orphaned_rows, tempcodes, idf_first_occurrence, same_batch_species_conflicts,
                 species_mismatch_records, quadrat_mismatch_failures, coordinate_drift_failures;
@@ -1864,6 +1868,7 @@ BEGIN
         prev_match_ambiguities, tree_insert_candidates, tree_insert_failures,
         current_tree_lookup, stem_resolution_rows, stem_insert_candidates,
         unresolved_stem_rows, current_stem_lookup, resolved_batch_rows,
+        published_stemid_batch_id_conflicts, published_stemid_batch_group_conflicts,
         core_insert_candidates, source_row_insert_conflicts, core_insert_failures, resolved_coremeasurements,
         orphaned_rows, tempcodes, idf_first_occurrence, same_batch_species_conflicts,
         species_mismatch_records, quadrat_mismatch_failures, coordinate_drift_failures;
@@ -1969,7 +1974,7 @@ BEGIN
     SELECT MIN(id) AS id,
            COUNT(*) AS duplicate_count,
            FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode,
-           QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate,
+           QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, PublishedStemID,
            NULLIF(GROUP_CONCAT(DISTINCT CASE WHEN Codes IS NOT NULL AND TRIM(Codes) != '' THEN TRIM(Codes) END
                    ORDER BY Codes SEPARATOR ';'), '') AS Codes,
            NULLIF(GROUP_CONCAT(DISTINCT CASE WHEN Comments IS NOT NULL AND TRIM(Comments) != '' THEN TRIM(Comments) END
@@ -1980,7 +1985,7 @@ BEGIN
       -- is equivalent here but would mask the intent if future stages insert into it earlier
       AND id NOT IN (SELECT id FROM validation_failures)
     GROUP BY FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode,
-             QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate;
+             QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, PublishedStemID;
 
     CREATE INDEX idx_dup_filter_id ON initial_dup_filter (id);
     CREATE INDEX idx_dup_tree_species ON initial_dup_filter (TreeTag, SpeciesCode);
@@ -1999,6 +2004,7 @@ BEGIN
         AND COALESCE(tm.DBH, 0) = COALESCE(idf.DBH, 0)
         AND COALESCE(tm.HOM, 0) = COALESCE(idf.HOM, 0)
         AND COALESCE(tm.MeasurementDate, '1900-01-01') = COALESCE(idf.MeasurementDate, '1900-01-01')
+        AND tm.PublishedStemID <=> idf.PublishedStemID
     WHERE tm.id != idf.id AND idf.duplicate_count > 1;
 
     CREATE INDEX idx_duplicate_failures_id ON duplicate_failures (id);
@@ -2150,7 +2156,7 @@ BEGIN
            IFNULL(i.StemTag, '') AS StemTag, i.SpeciesCode, i.QuadratName,
            i.LocalX, i.LocalY,
            IFNULL(i.DBH, 0) AS DBH, IFNULL(i.HOM, 0) AS HOM,
-           i.MeasurementDate, i.Codes, i.Comments,
+           i.MeasurementDate, i.Codes, i.Comments, i.PublishedStemID,
            CASE
                WHEN tq.PlotID IS NULL
                    THEN CONCAT('Invalid quadrat name: "', i.QuadratName, '" not found in database')
@@ -2273,7 +2279,8 @@ BEGIN
                MIN(s.LocalX) AS PrevX,
                MIN(s.LocalY) AS PrevY,
                MIN(q.QuadratName) AS PrevQuadratName,
-               MIN(s.StemCrossID) AS PrevStemCrossID
+               MIN(s.StemCrossID) AS PrevStemCrossID,
+               MIN(s.PublishedStemID) AS PrevPublishedStemID
         FROM requested_prev_stems rps
         INNER JOIN trees t
             ON t.TreeTag = rps.TreeTag
@@ -2330,6 +2337,7 @@ BEGIN
             PrevY           DECIMAL(12,6) NULL,
             PrevQuadratName VARCHAR(255)  NULL,
             PrevStemCrossID INT           NULL,
+            PrevPublishedStemID INT UNSIGNED NULL,
             PRIMARY KEY (TreeTag, StemTag)
         );
 
@@ -2583,6 +2591,7 @@ BEGIN
            cf.MeasurementDate,
            cf.Codes,
            cf.Comments,
+           cf.PublishedStemID AS UploadedPublishedStemID,
            cf.QuadratID,
            cf.SpeciesID,
            cf.tree_state,
@@ -2590,7 +2599,11 @@ BEGIN
            CASE
                WHEN psl.MatchCount = 1 AND psl.PrevStemCrossID IS NOT NULL THEN psl.PrevStemCrossID
                ELSE NULL
-           END AS PrevStemCrossID
+           END AS PrevStemCrossID,
+           CASE
+               WHEN psl.MatchCount = 1 AND psl.PrevPublishedStemID IS NOT NULL THEN psl.PrevPublishedStemID
+               ELSE NULL
+           END AS PrevPublishedStemID
     FROM classified_filtered cf
     INNER JOIN current_tree_lookup ctl
         ON ctl.TreeTag = cf.TreeTag
@@ -2634,6 +2647,7 @@ BEGIN
            srr.QuadratID,
            srr.CensusID,
            srr.PrevStemCrossID AS StemCrossID,
+           srr.PrevPublishedStemID AS PublishedStemID,
            CASE
                WHEN TRIM(COALESCE(srr.StemTag, '')) = '' THEN NULL
                ELSE TRIM(srr.StemTag)
@@ -2645,11 +2659,9 @@ BEGIN
     CREATE INDEX idx_stem_insert_candidates_key
         ON stem_insert_candidates (TreeID, CensusID, StemTag);
 
-    -- Inline StemCrossID inheritance: set PrevStemCrossID at INSERT time for
-    -- stems that have an unambiguous match in the previous census. Existing
-    -- same-tree/same-stem rows are skipped explicitly and resolved below.
-    INSERT IGNORE INTO stems (TreeID, QuadratID, CensusID, StemCrossID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)
-    SELECT sic.TreeID, sic.QuadratID, sic.CensusID, sic.StemCrossID,
+    -- Inline StemCrossID/PublishedStemID inheritance: set the previous census's values at INSERT time for stems with an unambiguous previous-census match.
+    INSERT IGNORE INTO stems (TreeID, QuadratID, CensusID, StemCrossID, PublishedStemID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)
+    SELECT sic.TreeID, sic.QuadratID, sic.CensusID, sic.StemCrossID, sic.PublishedStemID,
            sic.StemTag, sic.LocalX, sic.LocalY, 0, NULL, 1
     FROM stem_insert_candidates sic
     LEFT JOIN stems s_existing
@@ -2657,6 +2669,17 @@ BEGIN
         AND s_existing.CensusID = sic.CensusID
         AND s_existing.StemTag <=> sic.StemTag
     WHERE s_existing.StemGUID IS NULL;
+
+    -- Catch-up fill for stems that already existed in the current census (skipped by INSERT IGNORE above).
+    -- Intentionally NOT batch-scoped: fills any current-census stem with an unambiguous previous-census value.
+    UPDATE stems s
+    INNER JOIN stem_insert_candidates sic
+        ON sic.TreeID = s.TreeID
+        AND sic.CensusID = s.CensusID
+        AND sic.StemTag <=> s.StemTag
+    SET s.PublishedStemID = sic.PublishedStemID
+    WHERE s.PublishedStemID IS NULL
+      AND sic.PublishedStemID IS NOT NULL;
 
     CREATE TEMPORARY TABLE current_stem_lookup AS
     SELECT DISTINCT srr.id,
@@ -2718,6 +2741,7 @@ BEGIN
            srr.MeasurementDate,
            srr.Codes,
            srr.Comments,
+           srr.UploadedPublishedStemID AS PublishedStemID,
            srr.QuadratID,
            srr.SpeciesID,
            srr.tree_state,
@@ -2728,6 +2752,7 @@ BEGIN
 
     CREATE INDEX idx_resolved_batch_rows_id ON resolved_batch_rows (id);
     CREATE INDEX idx_resolved_batch_rows_stem ON resolved_batch_rows (StemGUID);
+    CREATE INDEX idx_resolved_batch_rows_publishedstemid ON resolved_batch_rows (PublishedStemID);
 
     SET vTreeStemInsertMs = TIMESTAMPDIFF(MICROSECOND, vStageStart, NOW(6)) DIV 1000;
 
@@ -2761,6 +2786,105 @@ BEGIN
         PRIMARY KEY (SourceRowIndex, ErrorCode),
         KEY idx_core_insert_failures_error (ErrorCode)
     );
+
+    CREATE TEMPORARY TABLE published_stemid_batch_id_conflicts AS
+    SELECT rbr.PublishedStemID
+    FROM resolved_batch_rows rbr
+    INNER JOIN stems s_current
+        ON s_current.StemGUID = rbr.StemGUID
+    WHERE rbr.PublishedStemID IS NOT NULL
+      AND s_current.StemCrossID IS NOT NULL
+    GROUP BY rbr.PublishedStemID
+    HAVING COUNT(DISTINCT s_current.StemCrossID) > 1;
+
+    CREATE INDEX idx_published_stemid_batch_id_conflicts
+        ON published_stemid_batch_id_conflicts (PublishedStemID);
+
+    INSERT IGNORE INTO core_insert_failures (SourceRowIndex, ErrorCode, FailureReason)
+    SELECT rbr.id,
+           'PUBLISHED_STEMID_CONFLICT',
+           LEFT(CONCAT('PublishedStemID conflict: uploaded ID ', rbr.PublishedStemID,
+                       ' appears on multiple resolved stem identities in this batch'), 255)
+    FROM resolved_batch_rows rbr
+    INNER JOIN published_stemid_batch_id_conflicts conflicted_ids
+        ON conflicted_ids.PublishedStemID = rbr.PublishedStemID
+    WHERE rbr.PublishedStemID IS NOT NULL;
+
+    CREATE TEMPORARY TABLE published_stemid_batch_group_conflicts AS
+    SELECT s_current.StemCrossID
+    FROM resolved_batch_rows rbr
+    INNER JOIN stems s_current
+        ON s_current.StemGUID = rbr.StemGUID
+    WHERE rbr.PublishedStemID IS NOT NULL
+      AND s_current.StemCrossID IS NOT NULL
+    GROUP BY s_current.StemCrossID
+    HAVING COUNT(DISTINCT rbr.PublishedStemID) > 1;
+
+    CREATE INDEX idx_published_stemid_batch_group_conflicts
+        ON published_stemid_batch_group_conflicts (StemCrossID);
+
+    INSERT IGNORE INTO core_insert_failures (SourceRowIndex, ErrorCode, FailureReason)
+    SELECT rbr.id,
+           'PUBLISHED_STEMID_CONFLICT',
+           LEFT(CONCAT('PublishedStemID conflict: resolved StemCrossID ', s_current.StemCrossID,
+                       ' received multiple uploaded IDs in this batch'), 255)
+    FROM resolved_batch_rows rbr
+    INNER JOIN stems s_current
+        ON s_current.StemGUID = rbr.StemGUID
+    INNER JOIN published_stemid_batch_group_conflicts conflicted_groups
+        ON conflicted_groups.StemCrossID = s_current.StemCrossID
+    WHERE rbr.PublishedStemID IS NOT NULL;
+
+    INSERT IGNORE INTO core_insert_failures (SourceRowIndex, ErrorCode, FailureReason)
+    SELECT DISTINCT rbr.id,
+           'PUBLISHED_STEMID_CONFLICT',
+           LEFT(CONCAT('PublishedStemID conflict: resolved StemCrossID ', s_current.StemCrossID,
+                       ' already has PublishedStemID ', s_existing.PublishedStemID,
+                       ', uploaded ', rbr.PublishedStemID), 255)
+    FROM resolved_batch_rows rbr
+    INNER JOIN stems s_current
+        ON s_current.StemGUID = rbr.StemGUID
+    INNER JOIN stems s_existing
+        ON s_existing.StemCrossID = s_current.StemCrossID
+    INNER JOIN census c_existing
+        ON c_existing.CensusID = s_existing.CensusID
+        AND c_existing.PlotID = vCurrentPlotID
+    WHERE rbr.PublishedStemID IS NOT NULL
+      AND s_current.StemCrossID IS NOT NULL
+      AND s_existing.PublishedStemID IS NOT NULL
+      AND s_existing.PublishedStemID <> rbr.PublishedStemID;
+
+    INSERT IGNORE INTO core_insert_failures (SourceRowIndex, ErrorCode, FailureReason)
+    SELECT DISTINCT rbr.id,
+           'PUBLISHED_STEMID_CONFLICT',
+           LEFT(CONCAT('PublishedStemID conflict: uploaded ID ', rbr.PublishedStemID,
+                       ' is already assigned to another stem identity in this plot'), 255)
+    FROM resolved_batch_rows rbr
+    INNER JOIN stems s_current
+        ON s_current.StemGUID = rbr.StemGUID
+    INNER JOIN stems s_owner
+        ON s_owner.PublishedStemID = rbr.PublishedStemID
+    INNER JOIN census c_owner
+        ON c_owner.CensusID = s_owner.CensusID
+        AND c_owner.PlotID = vCurrentPlotID
+    WHERE rbr.PublishedStemID IS NOT NULL
+      AND NOT (s_owner.StemCrossID <=> s_current.StemCrossID);
+
+    UPDATE stems s_target
+    INNER JOIN census c_target
+        ON c_target.CensusID = s_target.CensusID
+        AND c_target.PlotID = vCurrentPlotID
+    INNER JOIN stems s_source
+        ON s_source.StemCrossID = s_target.StemCrossID
+    INNER JOIN resolved_batch_rows rbr
+        ON rbr.StemGUID = s_source.StemGUID
+    LEFT JOIN core_insert_failures cif
+        ON cif.SourceRowIndex = rbr.id
+    SET s_target.PublishedStemID = rbr.PublishedStemID
+    WHERE s_target.PublishedStemID IS NULL
+      AND rbr.PublishedStemID IS NOT NULL
+      AND s_source.StemCrossID IS NOT NULL
+      AND cif.SourceRowIndex IS NULL;
 
     INSERT IGNORE INTO core_insert_failures (SourceRowIndex, ErrorCode, FailureReason)
     SELECT rbr.id,
@@ -2834,7 +2958,7 @@ BEGIN
     INSERT IGNORE INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
                                   Description, UserDefinedFields, UploadFileID, UploadBatchID,
                                   RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY,
-                                  RawCodes, RawComments, SourceRowIndex, IsActive)
+                                  RawCodes, RawPublishedStemID, RawComments, SourceRowIndex, IsActive)
     SELECT cic.CensusID, cic.StemGUID, NULL,
            cic.MeasurementDate,
            NULLIF(cic.DBH, 0),
@@ -2851,7 +2975,7 @@ BEGIN
            vFileID,
            vBatchID,
            cic.TreeTag, cic.StemTag, cic.SpeciesCode, cic.QuadratName,
-           cic.LocalX, cic.LocalY, cic.Codes, cic.Comments,
+           cic.LocalX, cic.LocalY, cic.Codes, cic.PublishedStemID, cic.Comments,
            cic.id,
            1
     FROM core_insert_candidates cic
@@ -2923,13 +3047,13 @@ BEGIN
         (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
          Description, UploadFileID, UploadBatchID,
          RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY,
-         RawCodes, RawComments, SourceRowIndex, IsActive)
+         RawCodes, RawPublishedStemID, RawComments, SourceRowIndex, IsActive)
     SELECT vCurrentCensusID, NULL, FALSE,
            NULLIF(tm.MeasurementDate, '1900-01-01'), NULLIF(tm.DBH, 0), NULLIF(tm.HOM, 0),
            grouped_failures.FailureReason,
            vFileID, vBatchID,
            NULLIF(tm.TreeTag, ''), NULLIF(tm.StemTag, ''), NULLIF(tm.SpeciesCode, ''), NULLIF(tm.QuadratName, ''),
-           tm.LocalX, tm.LocalY, NULLIF(tm.Codes, ''), NULLIF(tm.Comments, ''),
+           tm.LocalX, tm.LocalY, NULLIF(tm.Codes, ''), tm.PublishedStemID, NULLIF(tm.Comments, ''),
            tm.id, 1
     FROM (
         SELECT SourceRowIndex,
@@ -2945,7 +3069,10 @@ BEGIN
     WHERE tm.FileID = vFileID
       AND tm.BatchID = vBatchID
       AND (cm_existing.CoreMeasurementID IS NULL OR cm_existing.StemGUID IS NULL)
-    ON DUPLICATE KEY UPDATE IsValidated = FALSE, Description = VALUES(Description);
+    ON DUPLICATE KEY UPDATE
+        IsValidated = FALSE,
+        Description = VALUES(Description),
+        RawPublishedStemID = VALUES(RawPublishedStemID);
 
     INSERT IGNORE INTO measurement_error_log (MeasurementID, ErrorID, IsResolved)
     SELECT DISTINCT cm.CoreMeasurementID, me.ErrorID, FALSE
@@ -3079,7 +3206,8 @@ BEGIN
         prev_match_ambiguities, tree_insert_candidates, tree_insert_failures,
         current_tree_lookup, stem_resolution_rows, stem_insert_candidates,
         unresolved_stem_rows, current_stem_lookup, resolved_batch_rows,
-        core_insert_candidates, core_insert_failures, resolved_coremeasurements,
+        published_stemid_batch_id_conflicts, published_stemid_batch_group_conflicts,
+        core_insert_candidates, source_row_insert_conflicts, core_insert_failures, resolved_coremeasurements,
         orphaned_rows, tempcodes, idf_first_occurrence, same_batch_species_conflicts,
         species_mismatch_records, quadrat_mismatch_failures, coordinate_drift_failures;
 
@@ -3138,6 +3266,7 @@ BEGIN
             prev_match_ambiguities, tree_insert_candidates, tree_insert_failures,
             current_tree_lookup, stem_resolution_rows, stem_insert_candidates,
             unresolved_stem_rows, current_stem_lookup, resolved_batch_rows,
+            published_stemid_batch_id_conflicts, published_stemid_batch_group_conflicts,
             core_insert_candidates, source_row_insert_conflicts, core_insert_failures, resolved_coremeasurements,
             orphaned_rows, tempcodes, idf_first_occurrence, same_batch_species_conflicts,
             species_mismatch_records, quadrat_mismatch_failures, coordinate_drift_failures;

--- a/frontend/sqlscripting/storedprocedures.sql
+++ b/frontend/sqlscripting/storedprocedures.sql
@@ -1974,7 +1974,13 @@ BEGIN
     SELECT MIN(id) AS id,
            COUNT(*) AS duplicate_count,
            FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode,
-           QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, PublishedStemID,
+           QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate,
+           -- PublishedStemID is intentionally NOT part of the dedup key: two otherwise-identical
+           -- rows (one carrying the SI-assigned id, its duplicate blank) must still collapse into a
+           -- single measurement. MAX() ignores NULLs, so the surviving row keeps a non-null id when
+           -- any duplicate supplied one. A genuine cross-stem conflict is caught later by the
+           -- PUBLISHED_STEMID_CONFLICT stage against resolved_batch_rows.
+           MAX(PublishedStemID) AS PublishedStemID,
            NULLIF(GROUP_CONCAT(DISTINCT CASE WHEN Codes IS NOT NULL AND TRIM(Codes) != '' THEN TRIM(Codes) END
                    ORDER BY Codes SEPARATOR ';'), '') AS Codes,
            NULLIF(GROUP_CONCAT(DISTINCT CASE WHEN Comments IS NOT NULL AND TRIM(Comments) != '' THEN TRIM(Comments) END
@@ -1985,7 +1991,7 @@ BEGIN
       -- is equivalent here but would mask the intent if future stages insert into it earlier
       AND id NOT IN (SELECT id FROM validation_failures)
     GROUP BY FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode,
-             QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, PublishedStemID;
+             QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate;
 
     CREATE INDEX idx_dup_filter_id ON initial_dup_filter (id);
     CREATE INDEX idx_dup_tree_species ON initial_dup_filter (TreeTag, SpeciesCode);
@@ -2004,7 +2010,8 @@ BEGIN
         AND COALESCE(tm.DBH, 0) = COALESCE(idf.DBH, 0)
         AND COALESCE(tm.HOM, 0) = COALESCE(idf.HOM, 0)
         AND COALESCE(tm.MeasurementDate, '1900-01-01') = COALESCE(idf.MeasurementDate, '1900-01-01')
-        AND tm.PublishedStemID <=> idf.PublishedStemID
+        -- PublishedStemID deliberately omitted here to match the dedup key above; including it would
+        -- leave the non-surviving row unmatched and let it slip through as a spurious MEASUREMENT_INSERT_SKIPPED.
     WHERE tm.id != idf.id AND idf.duplicate_count > 1;
 
     CREATE INDEX idx_duplicate_failures_id ON duplicate_failures (id);

--- a/frontend/sqlscripting/tablestructures.sql
+++ b/frontend/sqlscripting/tablestructures.sql
@@ -637,6 +637,7 @@ create table if not exists temporarymeasurements
     MeasurementDate date                                null,
     Codes           varchar(255)                        null,
     Comments        varchar(255)                        null,
+    PublishedStemID int unsigned                        null,
     UploadedAt      timestamp default CURRENT_TIMESTAMP null
 );
 
@@ -733,6 +734,7 @@ create table if not exists stems
     QuadratID       int                  null,
     CensusID        int                  null,
     StemCrossID     int                  null,
+    PublishedStemID int unsigned         null,
     StemTag         varchar(10)          default '' not null,
     LocalX          decimal(12, 6)       null,
     LocalY          decimal(12, 6)       null,
@@ -776,6 +778,7 @@ create table if not exists coremeasurements
     RawX              decimal(12, 6)          null,
     RawY              decimal(12, 6)          null,
     RawCodes          varchar(255)            null,
+    RawPublishedStemID int unsigned           null,
     RawComments       varchar(255)            null,
     SourceRowIndex    int                     null,
     IsActive          tinyint(1) default 1    not null,
@@ -898,6 +901,7 @@ values ('ingestion', 'MISSING_FIELD_TREETAG', 'Missing required field: TreeTag')
        ('ingestion', 'TREE_RESOLUTION_FAILED', 'Tree resolution failed after tree materialization'),
        ('ingestion', 'STEM_TREE_RESOLUTION_FAILED', 'Stem resolution failed because no active tree matched'),
        ('ingestion', 'STEM_RESOLUTION_FAILED', 'Stem resolution failed after stem materialization'),
+       ('ingestion', 'PUBLISHED_STEMID_CONFLICT', 'Uploaded PublishedStemID conflicts with an existing stem identity'),
        ('ingestion', 'MEASUREMENT_INSERT_SKIPPED', 'Measurement insert skipped during core materialization'),
        ('ingestion', 'DUPLICATE_TAG_CONFLICT', 'Conflicting duplicate TreeTag/StemTag rows detected in upload batch'),
        ('ingestion', 'DUPLICATE_TAG_CONFLICT_EXISTING', 'Conflicting TreeTag/StemTag matches existing census measurement'),
@@ -1001,6 +1005,9 @@ create index idx_stems_census_tree_tag_active
 
 create index ix_stems_treeid_stemtag_quadratid
     on stems (TreeID, StemTag, QuadratID);
+
+create index idx_stems_publishedstemid
+    on stems (PublishedStemID);
 
 create index idx_speciesid
     on trees (SpeciesID);

--- a/frontend/tests/integration/arcgis-import.integration.test.ts
+++ b/frontend/tests/integration/arcgis-import.integration.test.ts
@@ -446,6 +446,71 @@ describe('ArcGIS xlsx import (end-to-end)', () => {
     expect(await countStagedRows(seeded.fileName, batchID)).toBe(0);
   });
 
+  it('captures a StemID column from the ArcGIS workbook all the way to stems.PublishedStemID', async () => {
+    const schema = config.database;
+    const plotID = testData.plots[0].plotID;
+    const censusID = testData.census[0].censusID;
+    const speciesCode = testData.species[0].SpeciesCode;
+    const quadratName = testData.quadrats[0].QuadratName;
+    const dateSerial = 46036;
+    const treePublishedStemId = 7001;
+    const stemPublishedStemId = 7002;
+
+    // Both sheets carry a StemID column; the tree-sheet id belongs to the primary stem, the
+    // stem-sheet id to the additional stem.
+    const TREE_HEADER = ['GlobalID', 'quadrat', 'tag', 'StemTag', 'spcode', 'DBH_CURRENT', 'HOM', 'notes', 'Date_measured', 'lx', 'ly', 'COD_M', 'StemID'];
+    const STEM_HEADER = [
+      'ParentGlobalID',
+      'GlobalID',
+      'quadrat',
+      'tag',
+      'StemTag',
+      'spcode',
+      'DBH_CURRENT',
+      'HOM',
+      'notes',
+      'Date_measured',
+      'COD_A',
+      'StemID'
+    ];
+    const buffer = await buildWorkbook({
+      trees: [
+        TREE_HEADER,
+        ['GP1', quadratName, 'PSID400', 'PSID400', speciesCode, 11.1, 1.3, 'primary', dateSerial, 1.111111, 2.222222, 'M', treePublishedStemId]
+      ],
+      stems: [STEM_HEADER, ['GP1', 'SP1', quadratName, 'PSID400', 'PSID400-2', speciesCode, 3.3, 1.3, '', dateSerial, 'A', stemPublishedStemId]]
+    });
+    const result = transformArcgisWorkbook(await readArcgisWorkbook(buffer));
+
+    // FileID is varchar(36); keep the generated name within that width.
+    const fileName = `arcgis-psid-${Date.now()}.xlsx`;
+    const importReference = await createArcgisImportSession({ schema, plotID, censusID, userId: AUTH_USER_EMAIL, fileName, result });
+    const batchID = `arcgis_psid_${Date.now()}`;
+
+    const response = await commitPOST(
+      buildCommitRequest(
+        { schema, plotID, censusID, importSessionId: importReference.importSessionId, fileName, batchID, uploadMode: UploadMode.REVISIONS },
+        'upload-session-arcgis-publishedstemid'
+      )
+    );
+    expect(response.status).toBe(HTTPResponses.OK);
+
+    const ingestion = await runBulkIngestion(connection, fileName, batchID);
+    expect(ingestion.batch_failed).toBe(false);
+
+    const [stemRows] = await connection.query<RowDataPacket[]>(
+      `SELECT s.StemTag, s.PublishedStemID
+         FROM stems s
+         INNER JOIN coremeasurements cm ON cm.StemGUID = s.StemGUID
+        WHERE cm.UploadFileID = ? AND cm.UploadBatchID = ?
+        ORDER BY s.StemTag`,
+      [fileName, batchID]
+    );
+    const byTag = Object.fromEntries(stemRows.map(r => [r.StemTag, r.PublishedStemID]));
+    expect(byTag['PSID400']).toBe(treePublishedStemId);
+    expect(byTag['PSID400-2']).toBe(stemPublishedStemId);
+  });
+
   it('treats an exact same-batch commit replay as idempotent and does not duplicate rows or changelog metadata', async () => {
     const seeded = await seedValidStagedSession({ fileName: `arcgis-idempotent-${Date.now()}.xlsx` });
     const batchID = `arcgis_idempotent_${Date.now()}`;

--- a/frontend/tests/integration/published-stemid-inheritance.integration.test.ts
+++ b/frontend/tests/integration/published-stemid-inheritance.integration.test.ts
@@ -347,4 +347,62 @@ describe('PublishedStemID cross-census inheritance', () => {
     );
     expect(finalRows[0].PublishedStemID).toBe(8001);
   });
+
+  it('collapses two within-batch rows that differ only in PublishedStemID: one ingests keeping the non-null id, the duplicate is a clear DUPLICATE_ENTRY (not a spurious MEASUREMENT_INSERT_SKIPPED)', async () => {
+    const census1 = testData.census[0].censusID;
+    // Same physical measurement of the same stem, duplicated: one line carries the SI id, the other is blank
+    // (e.g. a doubled export row). PublishedStemID must not split these into two distinct dedup groups.
+    const identical = {
+      speciesCode: testData.species[0].SpeciesCode,
+      quadratName: testData.quadrats[0].QuadratName,
+      treeTag: 'PUBDUP1',
+      stemTag: '1',
+      x: 7,
+      y: 7,
+      dbh: 15,
+      hom: 1.3,
+      date: '2026-03-01'
+    };
+
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        { ...identical, publishedStemID: 5555 },
+        { ...identical, publishedStemID: null }
+      ],
+      { fileID: 'f_dup', batchID: 'b_dup', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_dup', 'b_dup');
+
+    const [batchRows] = await connection.query<any[]>(
+      `SELECT cm.CoreMeasurementID, cm.StemGUID
+       FROM coremeasurements cm
+       WHERE cm.UploadFileID = 'f_dup' AND cm.UploadBatchID = 'b_dup'`
+    );
+    // Exactly one row ingests successfully; the duplicate does not silently multiply into a second stem.
+    expect(batchRows.filter(r => r.StemGUID !== null)).toHaveLength(1);
+
+    const [errorRows] = await connection.query<any[]>(
+      `SELECT me.ErrorCode
+       FROM coremeasurements cm
+       JOIN measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       WHERE cm.UploadFileID = 'f_dup' AND cm.UploadBatchID = 'b_dup' AND cm.StemGUID IS NULL`
+    );
+    const errorCodes = errorRows.map(r => r.ErrorCode);
+    // The collapsed-away duplicate is reported as a duplicate, never as the confusing insert-skip that
+    // the pre-fix (PublishedStemID-in-dedup-key) behavior produced.
+    expect(errorCodes).toContain('DUPLICATE_ENTRY');
+    expect(errorCodes).not.toContain('MEASUREMENT_INSERT_SKIPPED');
+
+    const [stemRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = 'PUBDUP1' AND s.StemTag = '1' AND s.CensusID = ?`,
+      [census1]
+    );
+    // MAX() across the collapsed group preserves the non-null SI identifier the blank duplicate lacked.
+    expect(stemRows).toHaveLength(1);
+    expect(stemRows[0].PublishedStemID).toBe(5555);
+  });
 });

--- a/frontend/tests/integration/published-stemid-inheritance.integration.test.ts
+++ b/frontend/tests/integration/published-stemid-inheritance.integration.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type mysql from 'mysql2/promise';
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  insertTestMeasurements,
+  runBulkIngestion,
+  createAdditionalCensus,
+  type TestData
+} from '@/tests/setup/local-db-setup';
+
+describe('PublishedStemID cross-census inheritance', () => {
+  let connection: mysql.Connection;
+  let testData: TestData;
+  let dbConfig: Awaited<ReturnType<typeof setupTestDatabase>>['config'];
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    dbConfig = setup.config;
+  });
+  afterAll(async () => {
+    await teardownTestDatabase(connection, dbConfig);
+  });
+
+  it('inherits/catch-up-fills PublishedStemID across consecutive censuses, keeps recruits NULL, and never overwrites a non-null value', async () => {
+    const census1 = testData.census[0].censusID;
+    const tree = { treeTag: 'PUBTREE1', speciesCode: testData.species[0].SpeciesCode, quadratName: testData.quadrats[0].QuadratName };
+
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        {
+          treeTag: tree.treeTag,
+          stemTag: '1',
+          speciesCode: tree.speciesCode,
+          quadratName: tree.quadratName,
+          x: 1,
+          y: 1,
+          dbh: 10,
+          hom: 1.3,
+          date: '2026-01-01',
+          publishedStemID: 5001
+        }
+      ],
+      { fileID: 'f1', batchID: 'b1', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f1', 'b1');
+
+    const [initialRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID
+       FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = ? AND s.StemTag = '1' AND s.CensusID = ?`,
+      [tree.treeTag, census1]
+    );
+    expect(initialRows[0].PublishedStemID).toBe(5001);
+
+    const [rawRows] = await connection.query<any[]>(
+      `SELECT RawPublishedStemID
+       FROM coremeasurements
+       WHERE UploadFileID = 'f1' AND UploadBatchID = 'b1'`
+    );
+    expect(rawRows[0].RawPublishedStemID).toBe(5001);
+
+    const census2Info = await createAdditionalCensus(connection, testData, {
+      plotCensusNumber: 2,
+      startDate: '2027-01-01',
+      endDate: '2027-12-31'
+    });
+    const census2 = census2Info.censusID;
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        {
+          treeTag: tree.treeTag,
+          stemTag: '1',
+          speciesCode: tree.speciesCode,
+          quadratName: tree.quadratName,
+          x: 1,
+          y: 1,
+          dbh: 11,
+          hom: 1.3,
+          date: '2027-01-01'
+        },
+        { treeTag: tree.treeTag, stemTag: '2', speciesCode: tree.speciesCode, quadratName: tree.quadratName, x: 2, y: 2, dbh: 5, hom: 1.3, date: '2027-01-01' }
+      ],
+      { fileID: 'f2', batchID: 'b2', censusID: census2 }
+    );
+    await runBulkIngestion(connection, 'f2', 'b2');
+
+    const [rows] = await connection.query<any[]>(
+      `SELECT s.StemTag, s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = ? AND s.CensusID = ? ORDER BY s.StemTag`,
+      [tree.treeTag, census2]
+    );
+    const byTag = Object.fromEntries(rows.map(r => [r.StemTag, r.PublishedStemID]));
+    expect(byTag['1']).toBe(5001);
+    expect(byTag['2']).toBeNull();
+
+    // Catch-up: an existing current-census stem at NULL must be filled on re-ingest.
+    await connection.query(
+      `UPDATE stems s JOIN trees t ON t.TreeID = s.TreeID
+       SET s.PublishedStemID = NULL
+       WHERE t.TreeTag = ? AND s.StemTag = '1' AND s.CensusID = ?`,
+      [tree.treeTag, census2]
+    );
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        { treeTag: tree.treeTag, stemTag: '1', speciesCode: tree.speciesCode, quadratName: tree.quadratName, x: 1, y: 1, dbh: 11, hom: 1.3, date: '2027-01-01' }
+      ],
+      { fileID: 'f2_retry', batchID: 'b2_retry', censusID: census2 }
+    );
+    await runBulkIngestion(connection, 'f2_retry', 'b2_retry');
+    const [catchupRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = ? AND s.StemTag = '1' AND s.CensusID = ?`,
+      [tree.treeTag, census2]
+    );
+    expect(catchupRows[0].PublishedStemID).toBe(5001);
+
+    // No-overwrite invariant: a non-null current value must survive re-ingest even though
+    // the previous census carries a different value (guard: s.PublishedStemID IS NULL).
+    await connection.query(
+      `UPDATE stems s JOIN trees t ON t.TreeID = s.TreeID
+       SET s.PublishedStemID = 9999
+       WHERE t.TreeTag = ? AND s.StemTag = '1' AND s.CensusID = ?`,
+      [tree.treeTag, census2]
+    );
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        { treeTag: tree.treeTag, stemTag: '1', speciesCode: tree.speciesCode, quadratName: tree.quadratName, x: 1, y: 1, dbh: 11, hom: 1.3, date: '2027-01-01' }
+      ],
+      { fileID: 'f2_noov', batchID: 'b2_noov', censusID: census2 }
+    );
+    await runBulkIngestion(connection, 'f2_noov', 'b2_noov');
+    const [noOverwriteRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = ? AND s.StemTag = '1' AND s.CensusID = ?`,
+      [tree.treeTag, census2]
+    );
+    // Previous census holds 5001; the existing non-null 9999 must NOT be overwritten.
+    expect(noOverwriteRows[0].PublishedStemID).toBe(9999);
+  });
+
+  it('rejects an uploaded PublishedStemID that is already assigned to another stem identity in the plot', async () => {
+    const census1 = testData.census[0].censusID;
+    const speciesCode = testData.species[0].SpeciesCode;
+    const quadratName = testData.quadrats[0].QuadratName;
+
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        {
+          treeTag: 'PUBCONFLICT_A',
+          stemTag: '1',
+          speciesCode,
+          quadratName,
+          x: 3,
+          y: 3,
+          dbh: 10,
+          hom: 1.3,
+          date: '2026-02-01',
+          publishedStemID: 6001
+        }
+      ],
+      { fileID: 'f_conflict_a', batchID: 'b_conflict_a', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_conflict_a', 'b_conflict_a');
+
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        {
+          treeTag: 'PUBCONFLICT_B',
+          stemTag: '1',
+          speciesCode,
+          quadratName,
+          x: 4,
+          y: 4,
+          dbh: 11,
+          hom: 1.3,
+          date: '2026-02-02',
+          publishedStemID: 6001
+        }
+      ],
+      { fileID: 'f_conflict_b', batchID: 'b_conflict_b', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_conflict_b', 'b_conflict_b');
+
+    const [failureRows] = await connection.query<any[]>(
+      `SELECT cm.StemGUID, cm.RawPublishedStemID, me.ErrorCode
+       FROM coremeasurements cm
+       JOIN measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       WHERE cm.UploadFileID = 'f_conflict_b'
+         AND cm.UploadBatchID = 'b_conflict_b'`
+    );
+    const publishedConflict = failureRows.find(row => row.ErrorCode === 'PUBLISHED_STEMID_CONFLICT');
+    expect(publishedConflict).toBeDefined();
+    expect(publishedConflict.StemGUID).toBeNull();
+    expect(publishedConflict.RawPublishedStemID).toBe(6001);
+
+    const [conflictingStemRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID
+       FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = 'PUBCONFLICT_B' AND s.StemTag = '1' AND s.CensusID = ?`,
+      [census1]
+    );
+    expect(conflictingStemRows[0]?.PublishedStemID ?? null).toBeNull();
+  });
+
+  it('rejects two distinct stems in one batch that carry the same uploaded PublishedStemID', async () => {
+    const census1 = testData.census[0].censusID;
+    const speciesCode = testData.species[0].SpeciesCode;
+    const quadratName = testData.quadrats[0].QuadratName;
+
+    // Two different trees (=> two different StemCrossID groups) sharing one uploaded id in a single batch.
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        { treeTag: 'PUBBATCHID_A', stemTag: '1', speciesCode, quadratName, x: 5, y: 5, dbh: 10, hom: 1.3, date: '2026-03-01', publishedStemID: 7001 },
+        { treeTag: 'PUBBATCHID_B', stemTag: '1', speciesCode, quadratName, x: 6, y: 6, dbh: 11, hom: 1.3, date: '2026-03-01', publishedStemID: 7001 }
+      ],
+      { fileID: 'f_batchid', batchID: 'b_batchid', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_batchid', 'b_batchid');
+
+    const [failures] = await connection.query<any[]>(
+      `SELECT cm.RawTreeTag, cm.StemGUID
+       FROM coremeasurements cm
+       JOIN measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       WHERE cm.UploadFileID = 'f_batchid' AND cm.UploadBatchID = 'b_batchid'
+         AND me.ErrorCode = 'PUBLISHED_STEMID_CONFLICT'`
+    );
+    const failedTags = new Set(failures.map(r => r.RawTreeTag));
+    expect(failedTags.has('PUBBATCHID_A')).toBe(true);
+    expect(failedTags.has('PUBBATCHID_B')).toBe(true);
+    expect(failures.every(r => r.StemGUID === null)).toBe(true);
+
+    // Neither stem should have been assigned the contested id.
+    const [stemRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag IN ('PUBBATCHID_A', 'PUBBATCHID_B') AND s.CensusID = ?`,
+      [census1]
+    );
+    expect(stemRows.length).toBe(2);
+    expect(stemRows.every(r => (r.PublishedStemID ?? null) === null)).toBe(true);
+  });
+
+  it('rejects a stem measured twice in one batch with different PublishedStemIDs (via tag/stemtag collision) so neither id is adopted', async () => {
+    // The only way two rows in one batch resolve to the same StemCrossID is by sharing
+    // (CensusID, TreeTag, StemTag). Stage 2b flags those as DUPLICATE_TAG_STEMTAG and removes
+    // them before stem resolution, so the dedicated same-group PublishedStemID guard never fires
+    // in this path. This test documents that upstream behavior: both rows fail and no stem adopts
+    // either contested id.
+    const census1 = testData.census[0].censusID;
+    const plotId = testData.plots[0].plotID;
+    const speciesCode = testData.species[0].SpeciesCode;
+    const quadratName = testData.quadrats[0].QuadratName;
+
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [
+        { treeTag: 'PUBBATCHGRP', stemTag: '1', speciesCode, quadratName, x: 7, y: 7, dbh: 10, hom: 1.3, date: '2026-04-01', publishedStemID: 7101 },
+        { treeTag: 'PUBBATCHGRP', stemTag: '1', speciesCode, quadratName, x: 7, y: 7, dbh: 12, hom: 1.3, date: '2026-04-02', publishedStemID: 7102 }
+      ],
+      { fileID: 'f_batchgrp', batchID: 'b_batchgrp', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_batchgrp', 'b_batchgrp');
+
+    // Both rows failed (no successful ingestion => StemGUID NULL on every batch row).
+    const [batchRows] = await connection.query<any[]>(
+      `SELECT cm.StemGUID FROM coremeasurements cm
+       WHERE cm.UploadFileID = 'f_batchgrp' AND cm.UploadBatchID = 'b_batchgrp'`
+    );
+    expect(batchRows.length).toBeGreaterThan(0);
+    expect(batchRows.every(r => r.StemGUID === null)).toBe(true);
+
+    // Neither contested id was adopted by any stem in the plot.
+    const [adopted] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s
+       INNER JOIN census c ON c.CensusID = s.CensusID AND c.PlotID = ?
+       WHERE s.PublishedStemID IN (7101, 7102)`,
+      [plotId]
+    );
+    expect(adopted.length).toBe(0);
+  });
+
+  it('rejects an upload that assigns a different PublishedStemID to a stem that already has one', async () => {
+    const census1 = testData.census[0].censusID;
+    const speciesCode = testData.species[0].SpeciesCode;
+    const quadratName = testData.quadrats[0].QuadratName;
+
+    // First upload backfills 8001.
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [{ treeTag: 'PUBEXISTING', stemTag: '1', speciesCode, quadratName, x: 8, y: 8, dbh: 10, hom: 1.3, date: '2026-05-01', publishedStemID: 8001 }],
+      { fileID: 'f_exist_a', batchID: 'b_exist_a', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_exist_a', 'b_exist_a');
+
+    const [firstRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = 'PUBEXISTING' AND s.StemTag = '1' AND s.CensusID = ?`,
+      [census1]
+    );
+    expect(firstRows[0].PublishedStemID).toBe(8001);
+
+    // Second upload of the same stem carries a different id 8002 => conflict, existing value preserved.
+    await insertTestMeasurements(
+      connection,
+      testData,
+      [{ treeTag: 'PUBEXISTING', stemTag: '1', speciesCode, quadratName, x: 8, y: 8, dbh: 11, hom: 1.3, date: '2026-05-02', publishedStemID: 8002 }],
+      { fileID: 'f_exist_b', batchID: 'b_exist_b', censusID: census1 }
+    );
+    await runBulkIngestion(connection, 'f_exist_b', 'b_exist_b');
+
+    const [failures] = await connection.query<any[]>(
+      `SELECT cm.StemGUID, cm.RawPublishedStemID
+       FROM coremeasurements cm
+       JOIN measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       WHERE cm.UploadFileID = 'f_exist_b' AND cm.UploadBatchID = 'b_exist_b'
+         AND me.ErrorCode = 'PUBLISHED_STEMID_CONFLICT'`
+    );
+    expect(failures[0]).toBeDefined();
+    expect(failures[0].StemGUID).toBeNull();
+    expect(failures[0].RawPublishedStemID).toBe(8002);
+
+    const [finalRows] = await connection.query<any[]>(
+      `SELECT s.PublishedStemID FROM stems s JOIN trees t ON t.TreeID = s.TreeID
+       WHERE t.TreeTag = 'PUBEXISTING' AND s.StemTag = '1' AND s.CensusID = ?`,
+      [census1]
+    );
+    expect(finalRows[0].PublishedStemID).toBe(8001);
+  });
+});

--- a/frontend/tests/setup/local-db-setup.ts
+++ b/frontend/tests/setup/local-db-setup.ts
@@ -888,6 +888,7 @@ export async function insertTestMeasurements(
     date: string;
     codes?: string;
     comments?: string;
+    publishedStemID?: number | null;
   }>,
   options: {
     censusID?: number;
@@ -905,8 +906,8 @@ export async function insertTestMeasurements(
     await connection.query(
       `INSERT INTO temporarymeasurements
        (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName,
-        LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         fileID,
         batchID,
@@ -922,7 +923,8 @@ export async function insertTestMeasurements(
         meas.hom,
         meas.date,
         meas.codes || null,
-        meas.comments || null
+        meas.comments || null,
+        meas.publishedStemID ?? null
       ]
     );
   }

--- a/frontend/tests/unit/column-mapping-publishedstemid.test.ts
+++ b/frontend/tests/unit/column-mapping-publishedstemid.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { legacyCsvHeaderKey } from '@/lib/column-mapping/fields';
+
+describe('publishedstemid column mapping', () => {
+  it('resolves explicit aliases to publishedstemid', () => {
+    for (const header of ['PublishedStemID', 'published_stem_id', 'StemID', 'SI_StemID', 'ctfs_stemid']) {
+      expect(legacyCsvHeaderKey(header)).toBe('publishedstemid');
+    }
+  });
+
+  it('does not hijack ArcGIS identity fields', () => {
+    expect(legacyCsvHeaderKey('GlobalID')).toBe('globalid');
+    expect(legacyCsvHeaderKey('StemGUID')).toBe('stemguid');
+  });
+});

--- a/frontend/tests/unit/column-mapping-publishedstemid.test.ts
+++ b/frontend/tests/unit/column-mapping-publishedstemid.test.ts
@@ -3,12 +3,16 @@ import { legacyCsvHeaderKey } from '@/lib/column-mapping/fields';
 
 describe('publishedstemid column mapping', () => {
   it('resolves explicit aliases to publishedstemid', () => {
-    for (const header of ['PublishedStemID', 'published_stem_id', 'StemID', 'SI_StemID', 'ctfs_stemid']) {
+    for (const header of ['PublishedStemID', 'published_stem_id', 'SI_StemID', 'ctfs_stemid']) {
       expect(legacyCsvHeaderKey(header)).toBe('publishedstemid');
     }
   });
 
-  it('does not hijack ArcGIS identity fields', () => {
+  it("does not hijack ArcGIS identity fields or the app's own StemID/StemGUID labels", () => {
+    // A bare StemID header must NOT map to publishedstemid: the app labels its internal StemGUID as
+    // "stemID" in its own grids and CSV/form exports, so auto-mapping a re-uploaded export would feed
+    // StemGUID into the SI identifier. Only explicit unambiguous aliases resolve (see fields.ts).
+    expect(legacyCsvHeaderKey('StemID')).not.toBe('publishedstemid');
     expect(legacyCsvHeaderKey('GlobalID')).toBe('globalid');
     expect(legacyCsvHeaderKey('StemGUID')).toBe('stemguid');
   });

--- a/frontend/tests/unit/temporary-measurements-publishedstemid.test.ts
+++ b/frontend/tests/unit/temporary-measurements-publishedstemid.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildTemporaryMeasurementInsertParams, parseUnsignedIntField } from '@/lib/ingestion/temporary-measurements';
+import { SourceFormat } from '@/config/macros/formdetails';
+
+const FILE = 'f.csv',
+  BATCH = 'b1',
+  SESSION = null,
+  PLOT = 1,
+  CENSUS = 2;
+const lastParam = (row: any) => buildTemporaryMeasurementInsertParams(row, FILE, BATCH, SESSION, SourceFormat.csv, PLOT, CENSUS).at(-1);
+
+describe('buildTemporaryMeasurementInsertParams publishedstemid wiring', () => {
+  it('appends the parsed PublishedStemID as the final param', () => {
+    expect(
+      lastParam({
+        tag: 'T1',
+        stemtag: '1',
+        spcode: 'sp',
+        quadrat: 'q1',
+        lx: '1',
+        ly: '2',
+        dbh: '10',
+        hom: '1.3',
+        date: '2026-01-01',
+        codes: null,
+        comments: null,
+        publishedstemid: '5001'
+      })
+    ).toBe(5001);
+  });
+  it('yields null when publishedstemid is absent', () => {
+    expect(lastParam({ tag: 'T1', spcode: 'sp', quadrat: 'q1', lx: '1', ly: '2', date: '2026-01-01' })).toBeNull();
+  });
+});
+
+describe('parseUnsignedIntField', () => {
+  it('accepts valid positive integers (string or number) and the unsigned ceiling', () => {
+    expect(parseUnsignedIntField('5001')).toBe(5001);
+    expect(parseUnsignedIntField(5001)).toBe(5001);
+    expect(parseUnsignedIntField('4294967295')).toBe(4294967295);
+  });
+  it('rejects absent, empty, non-numeric, non-integer, non-positive, and above-ceiling values', () => {
+    for (const bad of [undefined, null, '', '   ', 'abc', '1.5', '0', '-1', '4294967296']) {
+      expect(parseUnsignedIntField(bad as unknown)).toBeNull();
+    }
+  });
+});

--- a/frontend/tests/upload-procedure-regressions.test.ts
+++ b/frontend/tests/upload-procedure-regressions.test.ts
@@ -50,10 +50,10 @@ describe('upload procedure regressions', () => {
     const canonicalSql = readSql('sqlscripting/storedprocedures.sql');
 
     expect(canonicalSql).toContain(
-      'INSERT IGNORE INTO stems (TreeID, QuadratID, CensusID, StemCrossID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)'
+      'INSERT IGNORE INTO stems (TreeID, QuadratID, CensusID, StemCrossID, PublishedStemID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)'
     );
     expect(canonicalSql).not.toContain(
-      'INSERT INTO stems (TreeID, QuadratID, CensusID, StemCrossID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)'
+      'INSERT INTO stems (TreeID, QuadratID, CensusID, StemCrossID, PublishedStemID, StemTag, LocalX, LocalY, Moved, StemDescription, IsActive)'
     );
   });
 
@@ -63,10 +63,21 @@ describe('upload procedure regressions', () => {
     expect(canonicalSql).toContain('CREATE TEMPORARY TABLE source_row_insert_conflicts AS');
     expect(canonicalSql).toContain("'Measurement insert skipped: source row resolved to multiple candidate measurements'");
     expect(canonicalSql).toContain(
-      'INSERT IGNORE INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM, Description, UserDefinedFields, UploadFileID, UploadBatchID, RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY, RawCodes, RawComments, SourceRowIndex, IsActive)'
+      'INSERT IGNORE INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM, Description, UserDefinedFields, UploadFileID, UploadBatchID, RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY, RawCodes, RawPublishedStemID, RawComments, SourceRowIndex, IsActive)'
     );
     expect(canonicalSql).toContain('FROM core_insert_candidates cic ORDER BY cic.id;');
     expect(canonicalSql).toContain('core_insert_candidates, source_row_insert_conflicts, core_insert_failures, resolved_coremeasurements');
+  });
+
+  it('backfills uploaded PublishedStemID through stem resolution with conflict guards', () => {
+    const canonicalSql = readSql('sqlscripting/storedprocedures.sql');
+    const tableStructuresSql = readSql('sqlscripting/tablestructures.sql');
+
+    expect(canonicalSql).toContain('srr.UploadedPublishedStemID AS PublishedStemID');
+    expect(canonicalSql).toContain("'PUBLISHED_STEMID_CONFLICT'");
+    expect(canonicalSql).toContain('SET s_target.PublishedStemID = rbr.PublishedStemID');
+    expect(canonicalSql).toContain('RawCodes, RawPublishedStemID, RawComments');
+    expect(tableStructuresSql).toContain("('ingestion', 'PUBLISHED_STEMID_CONFLICT'");
   });
 
   it('builds a deduped previous-census lookup before cross-census location validation aggregation', () => {


### PR DESCRIPTION
## Summary

Adds first-class support for the Smithsonian-assigned **PublishedStemID** — the canonical, externally-published stem identifier — through the census ingestion pipeline, so the app can correlate its internal `StemGUID` with the identifier SI actually publishes (the foundation for round-tripping stem identity with the SI on-prem / CTFS export).

### What it does
- **Storage & provenance** — nullable `PublishedStemID` on `stems`/`temporarymeasurements` and `RawPublishedStemID` on `coremeasurements`, in both `tablestructures.sql` (new-site provisioning) and standalone migration `60_add_published_stemid.sql` (existing schemas; registered in both migration runners).
- **Capture** — an inbound `PublishedStemID` column is recognized on CSV uploads (explicit aliases only) and now on the **ArcGIS two-sheet import**, threaded through staging into `temporarymeasurements.PublishedStemID`.
- **Inheritance & assignment** — the id is inherited across censuses via the `StemCrossID` stem identity, catch-up-filled on existing current-census stems, and propagated (fill-only, never overwriting) across the stem's census history.
- **Conflict handling** — four distinct `PUBLISHED_STEMID_CONFLICT` checks flag same-id-across-identities, identity-with-multiple-ids, identity-already-assigned, and id-owned-elsewhere-in-plot.

### Hardening (review remediation)
- Excluded `PublishedStemID` from the within-batch dedup key (coalesced via `MAX()`) so rows differing only in the id collapse cleanly instead of surfacing a spurious `MEASUREMENT_INSERT_SKIPPED`.
- Dropped the ambiguous bare `stemid` alias (collided with the app's own `StemGUID` export label).
- A present-but-unparseable `PublishedStemID` now raises a `warning`-severity `INVALID_PUBLISHED_STEMID` integrity alert instead of silently coercing to NULL.
- Documented the intentional cross-census propagation and the four conflict checks; replaced a magic positional index in the reingest test.

### Notes / follow-ups
- `PublishedStemID` is stored as `INT UNSIGNED`. If any site's StemID can be alphanumeric or exceed the 32-bit range, the columns need widening to `VARCHAR` (and the ArcGIS path would want the same invalid-value warning the CSV path has).
- "ID-first matching" (using `PublishedStemID` to override natural-key resolution — needed for sites where TreeTag+StemTag+Quadrat is not unique, e.g. Michigan Big Woods / Wytham) is intentionally deferred to a follow-up.

### Verification
`npm run test:unit` (2997 passing), the ingestion / column-mapping / ArcGIS integration suites against local MySQL (including a new end-to-end test asserting an ArcGIS StemID reaches `stems.PublishedStemID`), and `next build` all green.
