### PR TITLE
security: route raw-schema handlers through withRouteAuthz + safeFormatQuery

### DIFF
--- a/docs/security-audit-remaining-open-items.md
+++ b/docs/security-audit-remaining-open-items.md
@@ -1,0 +1,108 @@
+# ForestGEO Frontend Security Audit — Remaining Open Items
+
+Date: 2026-07-07
+Branch: `security/route-authz-remediation`
+Companion: [`read-only-security-audit-supplemental-findings.md`](./read-only-security-audit-supplemental-findings.md)
+
+This tracks what is **still open** from the read-only audit after the raw-schema /
+route-authz remediation landed. Every status below was verified against the working
+tree on the date above — not carried over from the audit report.
+
+## Already remediated on this branch (context, not open)
+
+These are done and are listed only so the open items read in contrast:
+
+- Raw-schema SQL injection closed in `details/cmid`, `formdownload`, `specieslimits`,
+  `validations/validationlist`, `validations/validationerrordisplay`, and the
+  `validations/procedures/*` family — all routed through `safeFormatQuery` /
+  `validateSchemaOrThrow`.
+- `validations/procedures/*` now executes **server-owned validation definitions**
+  instead of a client-supplied `cursorQuery` (the arbitrary-SQL path is gone).
+- `fetchall` gained a `dataType` whitelist + identifier escaping.
+- `changelog/overview` schema injection closed (`validateContextualValues` +
+  `validateSchemaOrThrow` on the URL-param fallback).
+- `structure/[schema]` now requires admin at runtime.
+- `withRouteAuthz` (driven by `ROUTE_POLICIES`) exists and gives runtime enforcement;
+  **9 of 77** route handlers are converted so far.
+
+---
+
+## 1. Per-site authorization debt — the main open front
+
+`lib/route-policy.ts` `UNVERIFIED_SCHEMA_ACCESS` still lists **34 site-scoped routes**
+that authenticate the session (via middleware) but do **not** verify the caller is a
+member of the target site's schema. Any logged-in user can therefore read/write
+another site's data by naming its schema (cross-tenant IDOR). These are
+injection-safe (schema shape is validated) — the gap is authorization only.
+
+The remediation path is agreed: convert each onto `withRouteAuthz` and drive the set
+to 0 (see the `forestgeo-route-authz-campaign` skill). Highest-value entries to take
+first (writes / broad reads):
+
+| Route | Why it ranks high |
+|---|---|
+| `fixeddata/[dataType]/[[...slugs]]` | POST/PATCH/DELETE writes via `coreapifunctions`, no auth |
+| `fixeddatafilter/[dataType]/[[...slugs]]` | delegates to `coreapifunctions`, no auth |
+| `bulkcrud` | operates on schema with no `auth()`/`validateContextualValues` |
+| `reingestsinglefailure/[schema]/[targetRowID]` | mutating reingest, `safeFormatQuery` only |
+| `validations/run`, `validations/updatepassedvalidations` | cross-site validation writes |
+| `errors/explorer/*`, `changes/explorer/*` | broad cross-site reads, `isValidSchema` only |
+| `postvalidation`, `postvalidationbyquery/...`, `refreshviews/[view]/[schema]` | schema ops, no auth |
+
+The `setupbulk*` / `verify*` / `sqlpacketload` group authenticates via **upload-session
+token ownership**, not user↔site membership — weaker than per-site authz but not
+anonymous; lower priority than the routes above.
+
+## 2. Other open security items
+
+| Sev | Location | Item | Note |
+|---|---|---|---|
+| Medium | `app/api/validations/validate-query/route.ts:16,42` | `POST` executes `EXPLAIN ${query}` on caller-supplied SQL with **zero** in-handler auth (session via middleware only) and no per-site check | Query-plan / schema info disclosure + resource use by any logged-in user. Still in `UNVERIFIED_SCHEMA_ACCESS`. |
+| Medium | `app/api/validations/updatepassedvalidations/route.ts` | Still listed as "raw schema from body/query, no auth" | Confirm the schema is now routed through `safeFormatQuery` **and** add per-site authz. |
+| Medium | `components/processors/processormacros.ts:30-31` | `escapeSql` only doubles `'`; a value ending in `\` breaks out of the quoted literal under default `sql_mode` | Reaches SQL via datagrid `filterModel` in `fixeddatafilter`. Sibling `buildSearchStub` already uses mysql2 `escape()` — mirror it. LIKE operators are safe. |
+| Medium | `next.config.js:164` `headers()` | No security headers (CSP, `X-Frame-Options`/frame-ancestors, HSTS, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) | Clickjacking / MIME-sniffing / downgrade exposure. CORS is fine (no wildcard). |
+| Low/Info | `config/utils.ts:314`, `config/uploadsessiontracker.ts:243`, +4 | `Math.random()` for batch/session/operation IDs | Not auth tokens today; only matters if `generateSessionId` becomes an authorization boundary. Genuinely security-relevant paths already use `crypto`. |
+
+## 3. Async / connection-pool / React state
+
+None of these are touched by the route-authz work.
+
+| Sev | Location | Item |
+|---|---|---|
+| High | `config/poolmonitor.ts:175-176` | `connection.on('query'/'release')` attached on **every** acquire; mysql2 recycles connections → listeners accumulate (`MaxListenersExceededWarning`, stacked `resetInactivityTimer`). |
+| High | `config/connectionmanager.ts:223` (callers `bulkcrud`, `sqlpacketload`) | Manual `beginTransaction()` bypasses `acquireTransactionSlot()` yet commit/rollback still `releaseTransactionSlot()` → uncapped concurrent upload transactions, no `KILL QUERY` watchdog, desynced slot accounting. |
+| Medium | `lib/connectionlogger.ts:283-295` | Before/after diff SELECT reuses the UPDATE's full `params` against a one-placeholder query → prepared-statement param-count mismatch that can fail multi-column user UPDATEs. Needs a quick multi-column test. |
+| Medium | `lib/connectionlogger.ts:219-226,320-325` | Non-transaction changelog entries drained by an unawaited `processChangelogQueue`; short-lived routes return first → silent audit-trail loss. |
+| Medium | `config/poolmonitor.ts:163-168,221-244` | Unawaited `SET SESSION …` and an async inactivity-`setTimeout` whose `closeAllConnections()` rejection is fire-and-forget → unhandled rejections during teardown. |
+| Medium | `app/(hub)/layout.tsx:94-187` | Cascading site→plot→census fetches use bare `fetch`, no `AbortController` → stale-response last-write-wins race. |
+| Medium | `app/(hub)/layout.tsx:353-361,214-218` | `redirect()` inside `useEffect` reading `currentSite/Plot/Census` unconditionally can fire mid-reset; `redirect()`-in-effect is itself an anti-pattern. |
+| Low-Med | `lib/provisioning/worker.ts:92,96-107` | `void runWithHeartbeat(...)` fire-and-forget with `try/finally` but no `catch` → unhandled rejection can crash the process past the orchestrator handler. |
+
+## 4. Quality / maintainability
+
+| Sev | Location | Item |
+|---|---|---|
+| High | `tests/site-plot-selection.test.tsx:242,249-265`; `tests/auth-flow.test.tsx:192` | Cheater tests — behavior-titled cases assert only `toBeDefined()` or re-assert their own fixtures. Violates the repo NO CHEATER TESTS rule on a core flow + an auth path. |
+| Medium | `components/editplan/revertmenuitem.tsx`; `components/metrics/progresspiechart.tsx` (test-only referrer); `config/sqlrdsdefinitions/zones.ts:27` `SitesMapper` | Grep-confirmed dead code (not graph guesses). Flag, do not delete — `RevertMenuItem` may be a lost feature wire-up. |
+| Medium | `config/datamapper.ts:223-289` `MapperFactory`/`IDataMapper` | Cosmetic abstraction: ~30-case switch, one real impl, `as unknown as IDataMapper` casts defeat the interface's type safety. |
+| Medium | repo-wide; `config/poolmonitorsingleton.ts:10` | No fail-fast env validation. `parseInt(process.env.AZURE_SQL_PORT!)` → `NaN` if unset. App Insights var is typo-split: `NEXT_PUBLIC_APPINSIGHTS_CONNECTION_STRING` vs `..._APP_INSIGHTS_...`. |
+| Low | `cypress/e2e/errors-explorer.cy.ts:81-87` ↔ `validation-invalid-codes.cy.ts:69-75`; `app/api/changes/explorer/_shared.ts` ↔ `app/api/errors/explorer/_shared.ts` | Duplicated helpers / parallel query-builder scaffolding; consolidate into shared helpers. |
+| Low | many routes (`uploadsession`, `bulkcrud`, `formsearch`, `changelog/overview`, `reingestsinglefailure`) | Raw `error.message` / `details: e.message` returned to clients; inconsistent response shape. No tokens/bodies/secrets leaked. |
+| Low | `middleware.ts:57` | Protected pages are an enumerated allowlist — a new sensitive page not added here renders without a redirect (data still flows through gated APIs). |
+| Low | `app/api/fixeddata/[dataType]/[[...slugs]]/route.ts:81-82` | `page`/`pageSize` use bare `parseInt` (vs `parseOptionalPositiveInt` for ids) → `NaN`/negative `LIMIT`, 500 instead of 400. |
+
+## Suggested ordering
+
+1. Finish `withRouteAuthz` conversion — drive `UNVERIFIED_SCHEMA_ACCESS` to 0 (start with the §1 write routes), each with a 403-for-out-of-scope-schema integration test.
+2. `validate-query` authz + `escapeSql` backslash fix (remaining injection-adjacent items).
+3. Pool/transaction correctness (`poolmonitor` listeners, `connectionmanager` slot accounting) — these degrade under production load, not just on malicious input.
+4. Security headers + central env validation.
+5. Cheater-test replacement and dead-code/abstraction cleanup.
+
+## Verification note
+
+The `changelog/overview` **injection** is fixed but the route is still in
+`UNVERIFIED_SCHEMA_ACCESS` because of the URL-param fallback authz path — it belongs to
+the §1 campaign, not §2. `validate-query` and `updatepassedvalidations` remain in the
+set and are the highest-severity members because they combine a mutation/exec path with
+missing authz.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ Learn more about ForestGEO [at their website](https://www.forestgeo.si.edu/).
 
 ## Setting up for Local Development
 
-This project uses NextJS v14(+), and server interactions and setup are handled through their interface. Please note
+This project uses Next.js 15 / React 19, and server interactions and setup are handled through their interface. Please note
 that for local development, you will **not** be able to use the NextJS-provided `next start` command due to the way that
 the application is packaged for Azure deployment. Instead, please use the `next dev` command to start the local
 development server to use the application.

--- a/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.test.ts
+++ b/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.test.ts
@@ -73,7 +73,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
   });
 
   it('returns 400 if changelogType missing', async () => {
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps(undefined as any, ['1', '2']));
     expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
     const body = await res.json();
@@ -81,7 +81,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
   });
 
   it('returns 400 if options missing', async () => {
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('unifiedchangelog', undefined as any));
     expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
     const body = await res.json();
@@ -89,7 +89,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
   });
 
   it('returns 400 if options length !== 2', async () => {
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('unifiedchangelog', ['1']));
     expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
     const body = await res.json();
@@ -104,7 +104,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('unifiedchangelog', ['42', '7']));
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -118,7 +118,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     // SQL + params sanity
     expect(exec).toHaveBeenCalledTimes(1);
     const [sql, params] = exec.mock.calls[0];
-    expect(String(sql)).toMatch(/SELECT \* FROM myschema\.unifiedchangelog/i);
+    expect(String(sql)).toMatch(/SELECT \* FROM forestgeo_testschema\.unifiedchangelog/i);
     expect(String(sql)).toMatch(/WHERE \(PlotID = \? OR PlotID IS NULL\)/i);
     expect(String(sql)).toMatch(/ORDER BY ChangeTimestamp DESC\s+LIMIT 5;?/i);
     expect(params).toEqual([42, 42, 7]); // plotID, plotID, pcn
@@ -135,7 +135,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     const _exec = vi.spyOn(cm, 'executeQuery').mockResolvedValueOnce([]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('unifiedchangelog', ['10', '3']));
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -153,7 +153,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     const exec = vi.spyOn(cm, 'executeQuery').mockResolvedValueOnce([{ RunID: 1 }, { RunID: 2 }]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('validationchangelog', ['42', '7']));
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -164,7 +164,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     ]);
 
     const [sql, params] = exec.mock.calls[0];
-    expect(String(sql)).toMatch(/FROM myschema\.validationchangelog/i);
+    expect(String(sql)).toMatch(/FROM forestgeo_testschema\.validationchangelog/i);
     expect(String(sql)).toMatch(/ORDER BY RunDateTime DESC LIMIT 5;?/i);
     // The route still passes params array even if not used in the SQL
     expect(params).toEqual([42, 42, 7]);
@@ -178,7 +178,7 @@ describe('GET /api/changelog/overview/[changelogType]/[[...options]]', () => {
     const exec = vi.spyOn(cm, 'executeQuery').mockRejectedValueOnce(new Error('boom'));
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest('http://localhost/api?schema=myschema');
+    const req = makeRequest('http://localhost/api?schema=forestgeo_testschema');
     const res = await GET(req, makeProps('unifiedchangelog', ['1', '2']));
 
     expect(res.status).toBe(HTTPResponses.INTERNAL_SERVER_ERROR);

--- a/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
+++ b/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
@@ -5,6 +5,7 @@ import ConnectionManager from '@/lib/db/connectionmanager';
 import { validateContextualValues } from '@/lib/contextvalidation';
 import ailogger from '@/ailogger';
 import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
+import { toError } from '@/lib/errorhelpers';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -59,9 +60,9 @@ export async function GET(request: NextRequest, props: { params: Promise<{ chang
   // schema without re-validating, so gate it here before any interpolation below.
   try {
     validateSchemaOrThrow(schema);
-  } catch (error: any) {
+  } catch (error: unknown) {
     ailogger.error(`[changelog API] Invalid schema provided: ${schema}`);
-    return NextResponse.json({ error: error.message }, { status: HTTPResponses.BAD_REQUEST });
+    return NextResponse.json({ error: toError(error).message }, { status: HTTPResponses.BAD_REQUEST });
   }
 
   const connectionManager = ConnectionManager.getInstance();

--- a/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
+++ b/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
@@ -4,7 +4,7 @@ import MapperFactory from '@/config/datamapper';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { validateContextualValues } from '@/lib/contextvalidation';
 import ailogger from '@/ailogger';
-import { validateSchemaOrThrow } from '@/config/utils/sqlsecurity';
+import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime

--- a/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
+++ b/frontend/app/api/changelog/overview/[changelogType]/[[...options]]/route.ts
@@ -4,6 +4,7 @@ import MapperFactory from '@/config/datamapper';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { validateContextualValues } from '@/lib/contextvalidation';
 import ailogger from '@/ailogger';
+import { validateSchemaOrThrow } from '@/config/utils/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -52,6 +53,15 @@ export async function GET(request: NextRequest, props: { params: Promise<{ chang
     plotID = values.plotID!;
     // For changelog, we might need to derive PCN from context
     pcn = parseInt(params.options[1]);
+  }
+
+  // SQL Injection Prevention: the fallback branch above assigns the raw query-param
+  // schema without re-validating, so gate it here before any interpolation below.
+  try {
+    validateSchemaOrThrow(schema);
+  } catch (error: any) {
+    ailogger.error(`[changelog API] Invalid schema provided: ${schema}`);
+    return NextResponse.json({ error: error.message }, { status: HTTPResponses.BAD_REQUEST });
   }
 
   const connectionManager = ConnectionManager.getInstance();

--- a/frontend/app/api/details/cmid/route.test.ts
+++ b/frontend/app/api/details/cmid/route.test.ts
@@ -5,6 +5,10 @@ import { HTTPResponses } from '@/config/macros';
 import { GET } from './route';
 import ConnectionManager from '@/lib/db/connectionmanager'; // ---- Helpers ----
 
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({ user: { userStatus: 'global', sites: [] } }))
+}));
+
 // ---- Ensure ConnectionManager.getInstance() returns the shared mock instance ----
 vi.mock('@/lib/db/connectionmanager', async () => {
   const actual = await vi.importActual<any>('@/lib/db/connectionmanager').catch(() => ({}) as any);
@@ -41,13 +45,16 @@ function makeRequest(cmid?: string | number, schema?: string) {
 }
 
 describe('GET /api/details/cmid', () => {
+  const emptyCtx = { params: Promise.resolve({}) };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('throws when schema is missing', async () => {
+  it('returns 400 when schema is missing', async () => {
     const req = makeRequest(123 /* cmid present */, undefined /* no schema */);
-    await expect(GET(req)).rejects.toThrow(/no schema variable provided!/i);
+    const res = await GET(req, emptyCtx);
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
   });
 
   it('200 with mapped results; builds expected SQL + params; closes connection', async () => {
@@ -65,8 +72,8 @@ describe('GET /api/details/cmid', () => {
     ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest(123, 'myschema');
-    const res = await GET(req);
+    const req = makeRequest(123, 'forestgeo_testing');
+    const res = await GET(req, emptyCtx);
 
     expect(res.status).toBe(HTTPResponses.OK);
     const body = await res.json();
@@ -83,7 +90,7 @@ describe('GET /api/details/cmid', () => {
     // SQL + params sanity
     expect(exec).toHaveBeenCalledTimes(1);
     const [sql, params] = exec.mock.calls[0];
-    expect(String(sql)).toMatch(/FROM\s+myschema\.coremeasurements\s+cm/i);
+    expect(String(sql)).toMatch(/FROM\s+`forestgeo_testing`\.coremeasurements\s+cm/i);
     expect(String(sql)).toMatch(/WHERE\s+cm\.CoreMeasurementID\s*=\s*\?\s*;?/i);
     expect(params).toEqual([123]);
 
@@ -95,8 +102,8 @@ describe('GET /api/details/cmid', () => {
     const exec = vi.spyOn(cm, 'executeQuery').mockRejectedValueOnce(new Error('boom'));
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const req = makeRequest(999, 'orgschema');
-    await expect(GET(req)).rejects.toThrow(/SQL query failed: boom/i);
+    const req = makeRequest(999, 'forestgeo_testing');
+    await expect(GET(req, emptyCtx)).rejects.toThrow(/SQL query failed: boom/i);
 
     expect(exec).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);

--- a/frontend/app/api/details/cmid/route.ts
+++ b/frontend/app/api/details/cmid/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -12,7 +13,9 @@ export async function GET(request: NextRequest) {
   if (!schema) throw new Error('no schema variable provided!');
   const connectionManager = ConnectionManager.getInstance();
   try {
-    const query = `
+    const query = safeFormatQuery(
+      schema,
+      `
         SELECT
             cm.CoreMeasurementID,
             p.PlotName,
@@ -22,21 +25,22 @@ export async function GET(request: NextRequest) {
             c.EndDate,
             s.SpeciesName
         FROM
-            ${schema}.coremeasurements cm
+            ??.coremeasurements cm
                 INNER JOIN
-            ${schema}.census c ON cm.CensusID = c.CensusID
+            ??.census c ON cm.CensusID = c.CensusID
                 INNER JOIN
-            ${schema}.stems st ON cm.StemGUID = st.StemGUID and st.CensusID = c.CensusID
+            ??.stems st ON cm.StemGUID = st.StemGUID and st.CensusID = c.CensusID
                 INNER JOIN
-            ${schema}.trees t ON st.TreeID = t.TreeID and t.CensusID = c.CensusID
+            ??.trees t ON st.TreeID = t.TreeID and t.CensusID = c.CensusID
                 INNER JOIN
-            ${schema}.species s ON t.SpeciesID = s.SpeciesID
+            ??.species s ON t.SpeciesID = s.SpeciesID
                 INNER JOIN
-            ${schema}.quadrats q ON st.QuadratID = q.QuadratID
+            ??.quadrats q ON st.QuadratID = q.QuadratID
                 INNER JOIN
-            ${schema}.plots p ON q.PlotID = p.PlotID 
+            ??.plots p ON q.PlotID = p.PlotID
         WHERE
-            cm.CoreMeasurementID = ?;`;
+            cm.CoreMeasurementID = ?;`
+    );
     const results = await connectionManager.executeQuery(query, [cmID]);
     return new NextResponse(
       JSON.stringify(

--- a/frontend/app/api/details/cmid/route.ts
+++ b/frontend/app/api/details/cmid/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { fromQuery, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-export async function GET(request: NextRequest) {
+async function handler(request: NextRequest) {
   const cmID = parseInt(request.nextUrl.searchParams.get('cmid')!);
   const schema = request.nextUrl.searchParams.get('schema');
   if (!schema) throw new Error('no schema variable provided!');
@@ -60,3 +61,5 @@ export async function GET(request: NextRequest) {
     await connectionManager.closeConnection();
   }
 }
+
+export const GET = withRouteAuthz('details/cmid', handler, { schema: fromQuery('schema') });

--- a/frontend/app/api/fetchall/[[...slugs]]/constants.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/constants.ts
@@ -1,0 +1,39 @@
+// Shared constants for the fetchall route. These live in a sibling module rather
+// than route.ts because Next.js route modules may only export recognized fields
+// (GET, runtime, ...); a bare `export const` in route.ts fails the production
+// route type-check. Keeping them here lets the route and its tests share one
+// source of truth.
+
+// Error code returned when a requested dataType is not servable by this endpoint.
+export const INVALID_DATATYPE_CODE = 'INVALID_DATATYPE';
+
+// Per-site schema tables/views fetchall may serve via the generic branch. Derived
+// from the MapperFactory registry (config/datamapper.ts); excludes the cross-site
+// catalog tables (sites/users/usersiterelations) and the types already
+// special-cased in the handler (stems/trees/plots/personnel/census/species).
+// `roles` is a per-site table (FK'd by personnel) served via the generic branch.
+export const FETCHALL_ALLOWED_TABLES: ReadonlySet<string> = new Set([
+  'alltaxonomiesview',
+  'attributes',
+  'coremeasurements',
+  'coremeasurements_staging',
+  'cmattributes',
+  'failedmeasurements',
+  'measurementssummary',
+  'measurementssummaryview',
+  'postvalidationqueries',
+  'quadratpersonnel',
+  'quadrats',
+  'roles',
+  'family',
+  'genus',
+  'reference',
+  'speciesinventory',
+  'specieslimits',
+  'specimens',
+  'unifiedchangelog',
+  'validationchangelog',
+  'sitespecificvalidations',
+  'viewfulltable',
+  'viewfulltableview'
+]);

--- a/frontend/app/api/fetchall/[[...slugs]]/route.test.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/route.test.ts
@@ -55,11 +55,14 @@ vi.mock('@/ailogger', () => ({
   default: { error: loggerErr, info: vi.fn(), warn: vi.fn() }
 }));
 
-// Mock schema validation to accept test schemas
+// Mock schema validation to accept test schemas. safeFormatQuery/safeEscapeId back the
+// generic (whitelisted-table) branch; they mirror the real backtick-escaping behavior.
 vi.mock('@/lib/db/sqlsecurity', () => ({
   isValidSchema: vi.fn((schema: string) => {
     return ['myschema', 'testschema'].includes(schema);
-  })
+  }),
+  safeFormatQuery: vi.fn((schema: string, sql: string) => sql.replace(/\?\?/g, `\`${schema}\``)),
+  safeEscapeId: vi.fn((id: string) => `\`${id}\``)
 }));
 
 // Mock context validation to allow tests to control schema/plotID/censusID
@@ -303,12 +306,12 @@ describe('GET /api/fetchall/[[...slugs]]', () => {
     expect(getMapperSpy).toHaveBeenCalledWith('species');
   });
 
-  it('default branch: generic SELECT * FROM schema.table; maps results', async () => {
+  it('generic branch: a whitelisted table yields a safe SELECT * FROM schema.table; maps results', async () => {
     const cm = (ConnectionManager as any).getInstance();
-    vi.spyOn(cm, 'executeQuery').mockResolvedValueOnce([{ A: 1 }, { A: 2 }]);
+    const exec = vi.spyOn(cm, 'executeQuery').mockResolvedValueOnce([{ A: 1 }, { A: 2 }]);
 
     const req = makeRequest('myschema');
-    const res = await GET(req, makeProps(['randomtable', '1', '2']));
+    const res = await GET(req, makeProps(['attributes', '1', '2']));
 
     expect(res.status).toBe(HTTPResponses.OK);
     expect(await res.json()).toEqual([
@@ -316,7 +319,23 @@ describe('GET /api/fetchall/[[...slugs]]', () => {
       { A: 2, mapped: true }
     ]);
 
-    expect(getMapperSpy).toHaveBeenCalledWith('randomtable');
+    // Schema and table are both identifier-escaped via safeFormatQuery/safeEscapeId.
+    const [sql] = exec.mock.calls[0];
+    expect(String(sql)).toContain('SELECT * FROM `myschema`.`attributes`');
+    expect(getMapperSpy).toHaveBeenCalledWith('attributes');
+  });
+
+  it('generic branch: rejects a non-whitelisted table with 400 INVALID_DATATYPE and runs no query', async () => {
+    const cm = (ConnectionManager as any).getInstance();
+    const exec = vi.spyOn(cm, 'executeQuery');
+
+    const req = makeRequest('myschema');
+    const res = await GET(req, makeProps(['randomtable', '1', '2']));
+
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    const body = await res.json();
+    expect(body.code).toBe('INVALID_DATATYPE');
+    expect(exec).not.toHaveBeenCalled();
   });
 
   it('on DB error: logs via ailogger.error and returns 500 error; always closes connection', async () => {

--- a/frontend/app/api/fetchall/[[...slugs]]/route.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/route.ts
@@ -7,10 +7,45 @@ import { validateContextualValues } from '@/lib/contextvalidation';
 import { getCookie } from '@/app/actions/cookiemanager';
 import ailogger from '@/ailogger';
 import { getErrorMessage, getErrorCode, errorMessageContains, toError } from '@/lib/errorhelpers';
+import { safeEscapeId, safeFormatQuery } from '@/config/utils/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
+
+// Error code returned when a requested dataType is not servable by this endpoint.
+export const INVALID_DATATYPE_CODE = 'INVALID_DATATYPE';
+
+// Per-site schema tables/views fetchall may serve via the generic branch. Derived
+// from the MapperFactory registry (config/datamapper.ts); excludes the cross-site
+// catalog tables (sites/users/usersiterelations) and the types already
+// special-cased in this handler (stems/trees/plots/personnel/census/species).
+// `roles` is a per-site table (FK'd by personnel) served here via the generic branch.
+const FETCHALL_ALLOWED_TABLES: ReadonlySet<string> = new Set([
+  'alltaxonomiesview',
+  'attributes',
+  'coremeasurements',
+  'coremeasurements_staging',
+  'cmattributes',
+  'failedmeasurements',
+  'measurementssummary',
+  'measurementssummaryview',
+  'postvalidationqueries',
+  'quadratpersonnel',
+  'quadrats',
+  'roles',
+  'family',
+  'genus',
+  'reference',
+  'speciesinventory',
+  'specieslimits',
+  'specimens',
+  'unifiedchangelog',
+  'validationchangelog',
+  'sitespecificvalidations',
+  'viewfulltable',
+  'viewfulltableview'
+]);
 
 function parsePositiveInt(value: string | undefined): number | undefined {
   if (!value || value === 'undefined') return undefined;
@@ -153,7 +188,13 @@ export async function GET(request: NextRequest, props: { params: Promise<{ slugs
         ORDER BY SpeciesCode`;
       results = await connectionManager.executeQuery(query);
     } else {
-      const query = `SELECT * FROM ${schema}.${dataType}`;
+      if (!FETCHALL_ALLOWED_TABLES.has(dataType)) {
+        return NextResponse.json(
+          { error: `Data type '${dataType}' is not available for this endpoint.`, code: INVALID_DATATYPE_CODE },
+          { status: HTTPResponses.BAD_REQUEST }
+        );
+      }
+      const query = safeFormatQuery(schema, `SELECT * FROM ??.${safeEscapeId(dataType)}`);
       results = await connectionManager.executeQuery(query);
     }
     return new NextResponse(JSON.stringify(MapperFactory.getMapper<any, any>(dataType).mapData(results)), { status: HTTPResponses.OK });

--- a/frontend/app/api/fetchall/[[...slugs]]/route.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/route.ts
@@ -7,7 +7,7 @@ import { validateContextualValues } from '@/lib/contextvalidation';
 import { getCookie } from '@/app/actions/cookiemanager';
 import ailogger from '@/ailogger';
 import { getErrorMessage, getErrorCode, errorMessageContains, toError } from '@/lib/errorhelpers';
-import { safeEscapeId, safeFormatQuery } from '@/config/utils/sqlsecurity';
+import { safeEscapeId, safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { FETCHALL_ALLOWED_TABLES, INVALID_DATATYPE_CODE } from './constants';
 
 // Force Node.js runtime for database and Azure SDK compatibility

--- a/frontend/app/api/fetchall/[[...slugs]]/route.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/route.ts
@@ -8,44 +8,11 @@ import { getCookie } from '@/app/actions/cookiemanager';
 import ailogger from '@/ailogger';
 import { getErrorMessage, getErrorCode, errorMessageContains, toError } from '@/lib/errorhelpers';
 import { safeEscapeId, safeFormatQuery } from '@/config/utils/sqlsecurity';
+import { FETCHALL_ALLOWED_TABLES, INVALID_DATATYPE_CODE } from './constants';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
-
-// Error code returned when a requested dataType is not servable by this endpoint.
-export const INVALID_DATATYPE_CODE = 'INVALID_DATATYPE';
-
-// Per-site schema tables/views fetchall may serve via the generic branch. Derived
-// from the MapperFactory registry (config/datamapper.ts); excludes the cross-site
-// catalog tables (sites/users/usersiterelations) and the types already
-// special-cased in this handler (stems/trees/plots/personnel/census/species).
-// `roles` is a per-site table (FK'd by personnel) served here via the generic branch.
-const FETCHALL_ALLOWED_TABLES: ReadonlySet<string> = new Set([
-  'alltaxonomiesview',
-  'attributes',
-  'coremeasurements',
-  'coremeasurements_staging',
-  'cmattributes',
-  'failedmeasurements',
-  'measurementssummary',
-  'measurementssummaryview',
-  'postvalidationqueries',
-  'quadratpersonnel',
-  'quadrats',
-  'roles',
-  'family',
-  'genus',
-  'reference',
-  'speciesinventory',
-  'specieslimits',
-  'specimens',
-  'unifiedchangelog',
-  'validationchangelog',
-  'sitespecificvalidations',
-  'viewfulltable',
-  'viewfulltableview'
-]);
 
 function parsePositiveInt(value: string | undefined): number | undefined {
   if (!value || value === 'undefined') return undefined;

--- a/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.test.ts
+++ b/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.test.ts
@@ -32,6 +32,10 @@ vi.mock('@/ailogger', () => ({
   default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() }
 }));
 
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({ user: { userStatus: 'global', sites: [] } }))
+}));
+
 // Mock ConnectionManager to preserve your shared singleton but guarantee getInstance()
 vi.mock('@/lib/db/connectionmanager', async () => {
   const actual = await vi.importActual<any>('@/lib/db/connectionmanager').catch(() => ({}) as any);
@@ -76,17 +80,17 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
   });
 
   it('returns 400 if data type or slugs not provided', async () => {
-    const res = await GET(makeRequest(), makeProps(undefined as any, undefined as any));
+    const res = await GET(makeRequest(), makeProps(undefined as any, ['forestgeo_testing']));
     expect(res.status).toBe(HTTPResponses.INVALID_REQUEST);
     const body = await res.json();
     expect(body.error).toMatch(/data type or slugs not provided/i);
   });
 
-  it('returns 400 if schema missing', async () => {
+  it('returns 400 if schema missing from the route params', async () => {
     const res = await GET(makeRequest(), makeProps('attributes', [undefined as any, '1', '2', fm({})]));
     expect(res.status).toBe(HTTPResponses.INVALID_REQUEST);
     const body = await res.json();
-    expect(body.error).toMatch(/no schema provided/i);
+    expect(body.code).toBe('INVALID_SCHEMA');
   });
 
   it('attributes: 200 with mapped rows; uses search+filter stubs; closes connection', async () => {
@@ -100,7 +104,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
       ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const props = makeProps('attributes', ['myschema', '10', '20', fm({ quickFilterValues: ['oak'], items: [{ f: 1 }] })]);
+    const props = makeProps('attributes', ['forestgeo_testing', '10', '20', fm({ quickFilterValues: ['oak'], items: [{ f: 1 }] })]);
     const res = await GET(makeRequest(), props);
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -110,7 +114,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     ]);
 
     const sql = exec.mock.calls[1][0] as string;
-    expect(sql).toMatch(/FROM myschema\.attributes a/i);
+    expect(sql).toMatch(/FROM forestgeo_testing\.attributes a/i);
     expect(sql).toMatch(/\(SEARCH_STUB OR FILTER_STUB\)/i);
 
     expect(mapperSpies.getMapperSpy).toHaveBeenCalledWith('attributes');
@@ -128,7 +132,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
       ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const props = makeProps('personnel', ['myschema', '1', '2', fm({ quickFilterValues: ['gr'], items: [{ f: 2 }] })]);
+    const props = makeProps('personnel', ['forestgeo_testing', '1', '2', fm({ quickFilterValues: ['gr'], items: [{ f: 2 }] })]);
     const res = await GET(makeRequest(), props);
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -138,7 +142,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     ]);
 
     const sql = (cm.executeQuery as any).mock.calls[1][0] as string;
-    expect(sql).toMatch(/FROM myschema\.personnel p\s+JOIN myschema\.roles r/i);
+    expect(sql).toMatch(/FROM forestgeo_testing\.personnel p\s+JOIN forestgeo_testing\.roles r/i);
     expect(sql).toMatch(/\(SEARCH_STUB OR FILTER_STUB\)/);
 
     // personnel path doesn't call MapperFactory
@@ -164,7 +168,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
       ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const props = makeProps('species', ['myschema', '7', '8', fm({ quickFilterValues: ['AB'], items: [{ f: 3 }] })]);
+    const props = makeProps('species', ['forestgeo_testing', '7', '8', fm({ quickFilterValues: ['AB'], items: [{ f: 3 }] })]);
     const res = await GET(makeRequest(), props);
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -182,7 +186,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     ]);
 
     const sql = (cm.executeQuery as any).mock.calls[1][0] as string;
-    expect(sql).toMatch(/FROM myschema\.species sp\s+LEFT JOIN myschema\.genus/i);
+    expect(sql).toMatch(/FROM forestgeo_testing\.species sp\s+LEFT JOIN forestgeo_testing\.genus/i);
     expect(sql).toMatch(/\(SEARCH_STUB OR FILTER_STUB\)/);
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -204,7 +208,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
       ]);
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
-    const props = makeProps('quadrats', ['myschema', '7', '8', fm({ quickFilterValues: ['Q'], items: [{ f: 4 }] })]);
+    const props = makeProps('quadrats', ['forestgeo_testing', '7', '8', fm({ quickFilterValues: ['Q'], items: [{ f: 4 }] })]);
     const res = await GET(makeRequest(), props);
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -221,7 +225,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     ]);
 
     const sql = (cm.executeQuery as any).mock.calls[1][0] as string;
-    expect(sql).toMatch(/FROM myschema\.quadrats q/i);
+    expect(sql).toMatch(/FROM forestgeo_testing\.quadrats q/i);
     expect(sql).toMatch(/\(SEARCH_STUB OR FILTER_STUB\)/);
     expect(close).toHaveBeenCalledTimes(1);
   });
@@ -257,7 +261,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
       tss: ['multi stem']
     };
 
-    const res = await GET(makeRequest(), makeProps('measurements', ['myschema', '7', '80', fm(fmParam)]));
+    const res = await GET(makeRequest(), makeProps('measurements', ['forestgeo_testing', '7', '80', fm(fmParam)]));
 
     expect(res.status).toBe(HTTPResponses.OK);
     expect(await res.json()).toEqual([
@@ -285,7 +289,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     expect(sql).toMatch(/cm\.IsValidated = TRUE/);
     expect(sql).toMatch(/cm\.IsValidated = FALSE/);
     expect(sql).toMatch(/JSON_CONTAINS\(UserDefinedFields, JSON_QUOTE\('multi stem'\), '\$\.treestemstate'\) = 1/);
-    expect(sql).toMatch(/LEFT JOIN myschema\.sitespecificvalidations vp/i);
+    expect(sql).toMatch(/LEFT JOIN forestgeo_testing\.sitespecificvalidations vp/i);
     expect(sql).toMatch(/COALESCE\(/);
     expect(sql).toMatch(/\(SEARCH_STUB OR FILTER_STUB\)/);
     expect(close).toHaveBeenCalledTimes(1);
@@ -301,7 +305,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
 
     const res = await GET(
       makeRequest(),
-      makeProps('measurements', ['myschema', '7', '80', fm({ quickFilterValues: [], items: [], visible: [], tss: ['multi stem'] })])
+      makeProps('measurements', ['forestgeo_testing', '7', '80', fm({ quickFilterValues: [], items: [], visible: [], tss: ['multi stem'] })])
     );
 
     expect(res.status).toBe(HTTPResponses.OK);
@@ -315,7 +319,7 @@ describe('GET /api/formdownload/[dataType]/[[...slugs]]', () => {
     const cm = (ConnectionManager as any).getInstance();
     const exec = vi.spyOn(cm, 'executeQuery').mockRejectedValueOnce(new Error('columns fail'));
 
-    const res = await GET(makeRequest(), makeProps('attributes', ['myschema', '1', '2', fm({})]));
+    const res = await GET(makeRequest(), makeProps('attributes', ['forestgeo_testing', '1', '2', fm({})]));
 
     expect(res.status).toBe(HTTPResponses.INTERNAL_SERVER_ERROR);
     const body = await res.json();

--- a/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
@@ -8,12 +8,13 @@ import ailogger from '@/ailogger';
 import { buildFailedMeasurementsSelectQuery } from '@/config/measurementerrors';
 import { buildMeasurementVisibleClauseSql } from '@/config/measurementstatefilters';
 import { validateSchemaOrThrow } from '@/config/utils/sqlsecurity';
+import { fromPathSegment, type RouteContext, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-type RouteProps = { params: Promise<{ dataType: string; slugs?: string[] }> };
+type RouteProps = RouteContext;
 
 async function parseFilterModel(request: NextRequest, slugs?: string[], body?: any) {
   if (body?.filterModel) {
@@ -43,7 +44,8 @@ async function parseFilterModel(request: NextRequest, slugs?: string[], body?: a
 
 async function handleRequest(request: NextRequest, props: RouteProps, body?: any) {
   const params = await props.params;
-  const { dataType, slugs } = params;
+  const dataType = Array.isArray(params.dataType) ? params.dataType[0] : params.dataType;
+  const slugs = Array.isArray(params.slugs) ? params.slugs : params.slugs ? [params.slugs] : undefined;
   if (!dataType || !slugs) {
     return new NextResponse(JSON.stringify({ error: 'data type or slugs not provided' }), {
       status: HTTPResponses.INVALID_REQUEST
@@ -89,10 +91,10 @@ async function handleRequest(request: NextRequest, props: RouteProps, body?: any
                      AND COLUMN_NAME NOT LIKE '%uuid%'
                      AND COLUMN_NAME NOT LIKE 'id%'
                      AND COLUMN_NAME NOT LIKE '%_id' `;
-    const tableForColumns = params.dataType === 'measurements' || params.dataType === 'failedmeasurements' ? 'coremeasurements' : params.dataType;
+    const tableForColumns = dataType === 'measurements' || dataType === 'failedmeasurements' ? 'coremeasurements' : dataType;
     const results = await connectionManager.executeQuery(query, [schema, tableForColumns]);
     columns = results.map((row: any) => row.COLUMN_NAME);
-    if (params.dataType === 'failedmeasurements') {
+    if (dataType === 'failedmeasurements') {
       columns = [
         'FailedMeasurementID',
         'FileID',
@@ -330,11 +332,11 @@ async function handleRequest(request: NextRequest, props: RouteProps, body?: any
   }
 }
 
-export async function GET(request: NextRequest, props: RouteProps) {
+async function getHandler(request: NextRequest, props: RouteProps) {
   return handleRequest(request, props);
 }
 
-export async function POST(request: NextRequest, props: RouteProps) {
+async function postHandler(request: NextRequest, props: RouteProps) {
   let body: any = undefined;
   try {
     body = await request.json();
@@ -343,3 +345,6 @@ export async function POST(request: NextRequest, props: RouteProps) {
   }
   return handleRequest(request, props, body);
 }
+
+export const GET = withRouteAuthz('formdownload/[dataType]/[[...slugs]]', getHandler, { schema: fromPathSegment('slugs', 0) });
+export const POST = withRouteAuthz('formdownload/[dataType]/[[...slugs]]', postHandler, { schema: fromPathSegment('slugs', 0) });

--- a/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
@@ -7,7 +7,7 @@ import { buildFilterModelStub, buildSearchStub } from '@/components/processors/p
 import ailogger from '@/ailogger';
 import { buildFailedMeasurementsSelectQuery } from '@/config/measurementerrors';
 import { buildMeasurementVisibleClauseSql } from '@/config/measurementstatefilters';
-import { validateSchemaOrThrow } from '@/config/utils/sqlsecurity';
+import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
 import { fromPathSegment, type RouteContext, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility

--- a/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
@@ -7,6 +7,7 @@ import { buildFilterModelStub, buildSearchStub } from '@/components/processors/p
 import ailogger from '@/ailogger';
 import { buildFailedMeasurementsSelectQuery } from '@/config/measurementerrors';
 import { buildMeasurementVisibleClauseSql } from '@/config/measurementstatefilters';
+import { validateSchemaOrThrow } from '@/config/utils/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -51,6 +52,15 @@ async function handleRequest(request: NextRequest, props: RouteProps, body?: any
   const [schema, plotIDParam, censusIDParam] = slugs;
   if (!schema) {
     return new NextResponse(JSON.stringify({ error: 'no schema provided' }), {
+      status: HTTPResponses.INVALID_REQUEST
+    });
+  }
+  // SQL Injection Prevention: gate the raw ${schema} identifier interpolations below
+  try {
+    validateSchemaOrThrow(schema);
+  } catch (error: any) {
+    ailogger.error(`[formdownload API] Invalid schema provided: ${schema}`);
+    return new NextResponse(JSON.stringify({ error: error.message }), {
       status: HTTPResponses.INVALID_REQUEST
     });
   }

--- a/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/formdownload/[dataType]/[[...slugs]]/route.ts
@@ -8,6 +8,7 @@ import ailogger from '@/ailogger';
 import { buildFailedMeasurementsSelectQuery } from '@/config/measurementerrors';
 import { buildMeasurementVisibleClauseSql } from '@/config/measurementstatefilters';
 import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
+import { toError } from '@/lib/errorhelpers';
 import { fromPathSegment, type RouteContext, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility
@@ -60,9 +61,9 @@ async function handleRequest(request: NextRequest, props: RouteProps, body?: any
   // SQL Injection Prevention: gate the raw ${schema} identifier interpolations below
   try {
     validateSchemaOrThrow(schema);
-  } catch (error: any) {
+  } catch (error: unknown) {
     ailogger.error(`[formdownload API] Invalid schema provided: ${schema}`);
-    return new NextResponse(JSON.stringify({ error: error.message }), {
+    return new NextResponse(JSON.stringify({ error: toError(error).message }), {
       status: HTTPResponses.INVALID_REQUEST
     });
   }

--- a/frontend/app/api/route-policy.test.ts
+++ b/frontend/app/api/route-policy.test.ts
@@ -17,6 +17,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { ROUTE_POLICIES, UNVERIFIED_SCHEMA_ACCESS, type RoutePolicy } from '@/lib/route-policy';
 
+const ROUTE_POLICY_BY_KEY: Record<string, RoutePolicy> = ROUTE_POLICIES;
+
 // ── Filesystem helpers ────────────────────────────────────────────────────────
 
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
@@ -121,6 +123,12 @@ function hasFallbackBypass(source: string): boolean {
 
 function routeSourceIsProtected(absolutePath: string): { protected: boolean; reason?: string } {
   const source = fs.readFileSync(absolutePath, 'utf8');
+  if (/withRouteAuthz\s*\(/.test(source)) {
+    if (!/withRouteAuthz[\s\S]{0,700}schema\s*:/.test(source)) {
+      return { protected: false, reason: 'withRouteAuthz used without a schema resolver' };
+    }
+    return { protected: true };
+  }
   const hasSignal = AUTHZ_SIGNAL_PATTERNS.some(pattern => pattern.test(source));
   if (!hasSignal) return { protected: false, reason: 'no authz signal' };
   const hasReturn = AUTHZ_RETURN_PATTERNS.some(pattern => pattern.test(source));
@@ -206,10 +214,10 @@ describe('Route authorization policy matrix', () => {
   });
 
   it('UNVERIFIED_SCHEMA_ACCESS only contains site-scoped routes', () => {
-    const nonSiteScoped = [...UNVERIFIED_SCHEMA_ACCESS].filter(key => ROUTE_POLICIES[key] !== 'site-scoped');
+    const nonSiteScoped = [...UNVERIFIED_SCHEMA_ACCESS].filter(key => ROUTE_POLICY_BY_KEY[key] !== 'site-scoped');
 
     if (nonSiteScoped.length > 0) {
-      const list = nonSiteScoped.map(k => `  - ${k} (${ROUTE_POLICIES[k] ?? 'missing'})`).join('\n');
+      const list = nonSiteScoped.map(k => `  - ${k} (${ROUTE_POLICY_BY_KEY[k] ?? 'missing'})`).join('\n');
       throw new Error(`UNVERIFIED_SCHEMA_ACCESS contains non-site-scoped routes.\n` + `Only 'site-scoped' routes should appear in this set:\n${list}`);
     }
 

--- a/frontend/app/api/specieslimits/[plotID]/[plotCensusNumber]/route.ts
+++ b/frontend/app/api/specieslimits/[plotID]/[plotCensusNumber]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import MapperFactory from '@/config/datamapper';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -15,7 +16,10 @@ export async function GET(request: NextRequest, props: { params: Promise<{ plotI
   if (isNaN(parseInt(params.plotID)) || isNaN(parseInt(params.plotCensusNumber))) throw new Error('required slugs were not provided');
   const connectionManager = ConnectionManager.getInstance();
   try {
-    const query = `SELECT * FROM ${schema}.specieslimits WHERE PlotID = ? AND CensusID IN (SELECT CensusID FROM ${schema}.census WHERE PlotID = ? AND PlotCensusNumber = ?)`;
+    const query = safeFormatQuery(
+      schema,
+      `SELECT * FROM ??.specieslimits WHERE PlotID = ? AND CensusID IN (SELECT CensusID FROM ??.census WHERE PlotID = ? AND PlotCensusNumber = ?)`
+    );
     const results = await connectionManager.executeQuery(query, [params.plotID, params.plotID, params.plotCensusNumber]);
     return new NextResponse(JSON.stringify(MapperFactory.getMapper<any, any>('specieslimits').mapData(results)), { status: HTTPResponses.OK });
   } catch (error: any) {

--- a/frontend/app/api/specieslimits/[plotID]/[plotCensusNumber]/route.ts
+++ b/frontend/app/api/specieslimits/[plotID]/[plotCensusNumber]/route.ts
@@ -3,24 +3,27 @@ import MapperFactory from '@/config/datamapper';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { fromQuery, type RouteContext, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
 // pulls everything
-export async function GET(request: NextRequest, props: { params: Promise<{ plotID: string; plotCensusNumber: string }> }) {
-  const params = await props.params;
+async function handler(request: NextRequest, context: RouteContext) {
+  const params = await context.params;
+  const plotID = Array.isArray(params.plotID) ? params.plotID[0] : params.plotID;
+  const plotCensusNumber = Array.isArray(params.plotCensusNumber) ? params.plotCensusNumber[0] : params.plotCensusNumber;
   const schema = request.nextUrl.searchParams.get('schema');
   if (!schema) throw new Error('Schema not provided');
-  if (isNaN(parseInt(params.plotID)) || isNaN(parseInt(params.plotCensusNumber))) throw new Error('required slugs were not provided');
+  if (!plotID || !plotCensusNumber || isNaN(parseInt(plotID)) || isNaN(parseInt(plotCensusNumber))) throw new Error('required slugs were not provided');
   const connectionManager = ConnectionManager.getInstance();
   try {
     const query = safeFormatQuery(
       schema,
       `SELECT * FROM ??.specieslimits WHERE PlotID = ? AND CensusID IN (SELECT CensusID FROM ??.census WHERE PlotID = ? AND PlotCensusNumber = ?)`
     );
-    const results = await connectionManager.executeQuery(query, [params.plotID, params.plotID, params.plotCensusNumber]);
+    const results = await connectionManager.executeQuery(query, [plotID, plotID, plotCensusNumber]);
     return new NextResponse(JSON.stringify(MapperFactory.getMapper<any, any>('specieslimits').mapData(results)), { status: HTTPResponses.OK });
   } catch (error: any) {
     throw new Error(error);
@@ -30,3 +33,4 @@ export async function GET(request: NextRequest, props: { params: Promise<{ plotI
 }
 
 // don't need to add POST here --> the fixeddata/route POST handler can do it w/ no issue
+export const GET = withRouteAuthz('specieslimits/[plotID]/[plotCensusNumber]', handler, { schema: fromQuery('schema') });

--- a/frontend/app/api/structure/[schema]/route.ts
+++ b/frontend/app/api/structure/[schema]/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest } from 'next/server';
 import ConnectionManager from '@/lib/db/connectionmanager';
+import { withRouteAuthz, type RouteContext } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-export async function GET(_request: NextRequest, props: { params: Promise<{ schema: string }> }) {
-  const params = await props.params;
-  const schema = params.schema;
+async function handler(_request: NextRequest, context: RouteContext) {
+  const params = await context.params;
+  const schema = params.schema as string;
   if (!schema) throw new Error('no schema variable provided!');
-  const query = `SELECT table_name, column_name 
-    FROM information_schema.columns 
+  const query = `SELECT table_name, column_name
+    FROM information_schema.columns
     WHERE table_schema = ?`;
   const connectionManager = ConnectionManager.getInstance();
   try {
@@ -24,3 +25,5 @@ export async function GET(_request: NextRequest, props: { params: Promise<{ sche
     await connectionManager.closeConnection();
   }
 }
+
+export const GET = withRouteAuthz('structure/[schema]', handler);

--- a/frontend/app/api/validations/procedures/[validationType]/route.ts
+++ b/frontend/app/api/validations/procedures/[validationType]/route.ts
@@ -1,6 +1,10 @@
-import { NextRequest } from 'next/server';
-import { runValidation } from '@/components/processors/processorhelperfunctions';
+import { NextRequest, NextResponse } from 'next/server';
+import { loadValidationDefinition, runValidation } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
+import { HTTPResponses } from '@/config/macros';
+import { isValidSchema } from '@/config/utils/sqlsecurity';
+import { assertSchemaAccess } from '@/lib/authz';
+import { auth } from '@/auth';
 import ailogger from '@/ailogger';
 
 // Force Node.js runtime for database and Azure SDK compatibility
@@ -12,10 +16,32 @@ export async function POST(request: NextRequest, props: { params: Promise<{ vali
   try {
     if (!params.validationType) throw new Error('validationProcedureName not provided');
     const body = await request.json();
-    const { schema, validationProcedureID, cursorQuery, p_CensusID, p_PlotID } = body;
+    const { schema, validationProcedureID, p_CensusID, p_PlotID } = body;
+
+    if (!schema) return NextResponse.json({ error: 'schema not provided' }, { status: HTTPResponses.INVALID_REQUEST });
+    if (!isValidSchema(schema)) {
+      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+    if (validationProcedureID === undefined || validationProcedureID === null) {
+      return NextResponse.json({ error: 'validationProcedureID not provided' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+    if (!Number.isInteger(Number(validationProcedureID))) {
+      return NextResponse.json({ error: 'validationProcedureID must be an integer', code: 'INVALID_REQUEST' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
+    const denied = assertSchemaAccess(session, schema);
+    if (denied) return denied;
+
+    // Load the server-owned validation SQL by ID; never execute a client-supplied query body.
+    const definition = await loadValidationDefinition(schema, Number(validationProcedureID));
+    if (!definition) {
+      return NextResponse.json({ error: `No enabled validation found for ValidationID ${validationProcedureID}` }, { status: HTTPResponses.INVALID_REQUEST });
+    }
 
     const stream = streamWithHeartbeats(() =>
-      runValidation(validationProcedureID, params.validationType, schema, cursorQuery, {
+      runValidation(validationProcedureID, params.validationType, schema, definition, {
         p_CensusID,
         p_PlotID
       })
@@ -24,6 +50,6 @@ export async function POST(request: NextRequest, props: { params: Promise<{ vali
     return new Response(stream, { headers: STREAMING_RESPONSE_HEADERS });
   } catch (error: any) {
     ailogger.error('Error during validation:', error.message);
-    return Response.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ error: error.message }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
   }
 }

--- a/frontend/app/api/validations/procedures/[validationType]/route.ts
+++ b/frontend/app/api/validations/procedures/[validationType]/route.ts
@@ -2,26 +2,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { loadValidationDefinition, runValidation } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
 import { HTTPResponses } from '@/config/macros';
-import { isValidSchema } from '@/config/utils/sqlsecurity';
-import { assertSchemaAccess } from '@/lib/authz';
-import { auth } from '@/auth';
+import { fromBody, type RouteContext, withRouteAuthz } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-export async function POST(request: NextRequest, props: { params: Promise<{ validationType: string }> }) {
-  const params = await props.params;
+async function handler(request: NextRequest, context: RouteContext) {
+  const params = await context.params;
   try {
-    if (!params.validationType) throw new Error('validationProcedureName not provided');
+    const validationType = Array.isArray(params.validationType) ? params.validationType[0] : params.validationType;
+    if (!validationType) throw new Error('validationProcedureName not provided');
     const body = await request.json();
     const { schema, validationProcedureID, p_CensusID, p_PlotID } = body;
 
     if (!schema) return NextResponse.json({ error: 'schema not provided' }, { status: HTTPResponses.INVALID_REQUEST });
-    if (!isValidSchema(schema)) {
-      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
-    }
     if (validationProcedureID === undefined || validationProcedureID === null) {
       return NextResponse.json({ error: 'validationProcedureID not provided' }, { status: HTTPResponses.INVALID_REQUEST });
     }
@@ -29,19 +25,23 @@ export async function POST(request: NextRequest, props: { params: Promise<{ vali
       return NextResponse.json({ error: 'validationProcedureID must be an integer', code: 'INVALID_REQUEST' }, { status: HTTPResponses.INVALID_REQUEST });
     }
 
-    const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
-    const denied = assertSchemaAccess(session, schema);
-    if (denied) return denied;
-
     // Load the server-owned validation SQL by ID; never execute a client-supplied query body.
-    const definition = await loadValidationDefinition(schema, Number(validationProcedureID));
-    if (!definition) {
+    const validationProcedure = await loadValidationDefinition(schema, Number(validationProcedureID));
+    if (!validationProcedure) {
       return NextResponse.json({ error: `No enabled validation found for ValidationID ${validationProcedureID}` }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+    if (validationProcedure.procedureName !== validationType) {
+      return NextResponse.json(
+        {
+          error: `ValidationID ${validationProcedureID} does not match procedure '${validationType}'`,
+          code: 'VALIDATION_PROCEDURE_MISMATCH'
+        },
+        { status: HTTPResponses.INVALID_REQUEST }
+      );
     }
 
     const stream = streamWithHeartbeats(() =>
-      runValidation(validationProcedureID, params.validationType, schema, definition, {
+      runValidation(Number(validationProcedureID), validationProcedure.procedureName, schema, validationProcedure.definition, {
         p_CensusID,
         p_PlotID
       })
@@ -53,3 +53,5 @@ export async function POST(request: NextRequest, props: { params: Promise<{ vali
     return NextResponse.json({ error: error.message }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
   }
 }
+
+export const POST = withRouteAuthz('validations/procedures/[validationType]', handler, { schema: fromBody('schema') });

--- a/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
+++ b/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
@@ -1,6 +1,10 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { runCombinedCrossCensusLocationValidations } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
+import { assertSchemaAccess } from '@/lib/authz';
+import { auth } from '@/auth';
+import { HTTPResponses } from '@/config/macros';
+import { isValidSchema } from '@/config/utils/sqlsecurity';
 import ailogger from '@/ailogger';
 
 export const runtime = 'nodejs';
@@ -19,6 +23,14 @@ export async function POST(request: NextRequest) {
     if (!schema) {
       throw new Error('schema not provided');
     }
+    if (!isValidSchema(schema)) {
+      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
+    const denied = assertSchemaAccess(session, schema);
+    if (denied) return denied;
 
     const stream = streamWithHeartbeats(() => runCombinedCrossCensusLocationValidations(schema, { p_CensusID, p_PlotID }));
 

--- a/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
+++ b/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
@@ -1,10 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { runCombinedCrossCensusLocationValidations } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
-import { assertSchemaAccess } from '@/lib/authz';
-import { auth } from '@/auth';
-import { HTTPResponses } from '@/config/macros';
-import { isValidSchema } from '@/config/utils/sqlsecurity';
+import { fromBody, withRouteAuthz } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
 
 export const runtime = 'nodejs';
@@ -15,7 +12,7 @@ export const runtime = 'nodejs';
 // and return an error instead of the client seeing an abrupt disconnect.
 export const maxDuration = 1500;
 
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   try {
     const body = await request.json();
     const { schema, p_CensusID, p_PlotID } = body;
@@ -23,14 +20,6 @@ export async function POST(request: NextRequest) {
     if (!schema) {
       throw new Error('schema not provided');
     }
-    if (!isValidSchema(schema)) {
-      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
-    }
-
-    const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
-    const denied = assertSchemaAccess(session, schema);
-    if (denied) return denied;
 
     const stream = streamWithHeartbeats(() => runCombinedCrossCensusLocationValidations(schema, { p_CensusID, p_PlotID }));
 
@@ -40,3 +29,5 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: error.message, success: false }, { status: 500 });
   }
 }
+
+export const POST = withRouteAuthz('validations/procedures/shared-cross-census-location', handler, { schema: fromBody('schema') });

--- a/frontend/app/api/validations/procedures/shared-dbh/route.ts
+++ b/frontend/app/api/validations/procedures/shared-dbh/route.ts
@@ -1,6 +1,10 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { runCombinedDBHValidations } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
+import { assertSchemaAccess } from '@/lib/authz';
+import { auth } from '@/auth';
+import { HTTPResponses } from '@/config/macros';
+import { isValidSchema } from '@/config/utils/sqlsecurity';
 import ailogger from '@/ailogger';
 
 export const runtime = 'nodejs';
@@ -18,6 +22,14 @@ export async function POST(request: NextRequest) {
     if (!schema) {
       throw new Error('schema not provided');
     }
+    if (!isValidSchema(schema)) {
+      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+
+    const session = await auth();
+    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
+    const denied = assertSchemaAccess(session, schema);
+    if (denied) return denied;
 
     const stream = streamWithHeartbeats(() => runCombinedDBHValidations(schema, { p_CensusID, p_PlotID }));
 

--- a/frontend/app/api/validations/procedures/shared-dbh/route.ts
+++ b/frontend/app/api/validations/procedures/shared-dbh/route.ts
@@ -1,10 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { runCombinedDBHValidations } from '@/components/processors/processorhelperfunctions';
 import { streamWithHeartbeats, STREAMING_RESPONSE_HEADERS } from '@/components/processors/streamingvalidation';
-import { assertSchemaAccess } from '@/lib/authz';
-import { auth } from '@/auth';
-import { HTTPResponses } from '@/config/macros';
-import { isValidSchema } from '@/config/utils/sqlsecurity';
+import { fromBody, withRouteAuthz } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
 
 export const runtime = 'nodejs';
@@ -14,7 +11,7 @@ export const runtime = 'nodejs';
 // route's 10-minute ceiling so Azure doesn't kill the request early.
 export const maxDuration = 600;
 
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   try {
     const body = await request.json();
     const { schema, p_CensusID, p_PlotID } = body;
@@ -22,14 +19,6 @@ export async function POST(request: NextRequest) {
     if (!schema) {
       throw new Error('schema not provided');
     }
-    if (!isValidSchema(schema)) {
-      return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
-    }
-
-    const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
-    const denied = assertSchemaAccess(session, schema);
-    if (denied) return denied;
 
     const stream = streamWithHeartbeats(() => runCombinedDBHValidations(schema, { p_CensusID, p_PlotID }));
 
@@ -39,3 +28,5 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: error.message, success: false }, { status: 500 });
   }
 }
+
+export const POST = withRouteAuthz('validations/procedures/shared-dbh', handler, { schema: fromBody('schema') });

--- a/frontend/app/api/validations/validationerrordisplay/route.test.ts
+++ b/frontend/app/api/validations/validationerrordisplay/route.test.ts
@@ -7,6 +7,10 @@ vi.mock('@/ailogger', () => ({
   default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() }
 }));
 
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({ user: { userStatus: 'global', sites: [] } }))
+}));
+
 vi.mock('@/lib/db/connectionmanager', async () => {
   const actual = await vi.importActual<any>('@/lib/db/connectionmanager').catch(() => ({}));
 
@@ -40,6 +44,8 @@ vi.mock('@/lib/db/connectionmanager', async () => {
 });
 
 describe('GET /api/validations/validationerrordisplay', () => {
+  const emptyCtx = { params: Promise.resolve({}) };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -57,9 +63,9 @@ describe('GET /api/validations/validationerrordisplay', () => {
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
     const request = {
-      nextUrl: new URL('http://localhost:3000/api/validations/validationerrordisplay?schema=myschema&plotIDParam=22&censusPCNParam=4')
+      nextUrl: new URL('http://localhost:3000/api/validations/validationerrordisplay?schema=forestgeo_testing&plotIDParam=22&censusPCNParam=4')
     };
-    const response = await GET(request as any);
+    const response = await GET(request as any, emptyCtx);
 
     expect(response.status).toBe(HTTPResponses.OK);
     await expect(response.json()).resolves.toEqual({
@@ -74,7 +80,7 @@ describe('GET /api/validations/validationerrordisplay', () => {
     });
 
     const sql = exec.mock.calls[0][0] as string;
-    expect(sql).toMatch(/LEFT JOIN\s+myschema\.sitespecificvalidations AS ve/i);
+    expect(sql).toMatch(/LEFT JOIN\s+`forestgeo_testing`\.sitespecificvalidations AS ve/i);
     expect(sql).toMatch(/COALESCE\(NULLIF\(ve\.Description, ''\), me\.ErrorMessage\)/);
     expect(sql).toMatch(/COALESCE\(NULLIF\(ve\.Criteria, ''\), CONCAT\('Validation ', me\.ErrorCode\)\)/);
     expect(close).toHaveBeenCalledTimes(1);
@@ -86,9 +92,9 @@ describe('GET /api/validations/validationerrordisplay', () => {
     const close = vi.spyOn(cm, 'closeConnection').mockResolvedValueOnce(undefined);
 
     const request = {
-      nextUrl: new URL('http://localhost:3000/api/validations/validationerrordisplay?schema=myschema&plotIDParam=22&censusPCNParam=4')
+      nextUrl: new URL('http://localhost:3000/api/validations/validationerrordisplay?schema=forestgeo_testing&plotIDParam=22&censusPCNParam=4')
     };
-    const response = await GET(request as any);
+    const response = await GET(request as any, emptyCtx);
 
     expect(response.status).toBe(HTTPResponses.INTERNAL_SERVER_ERROR);
     await expect(response.json()).resolves.toEqual({ error: 'query failed' });

--- a/frontend/app/api/validations/validationerrordisplay/route.ts
+++ b/frontend/app/api/validations/validationerrordisplay/route.ts
@@ -3,7 +3,7 @@ import { CMError } from '@/config/macros/uploadsystemmacros';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
-import { safeFormatQuery } from '@/config/utils/sqlsecurity';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { fromQuery, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility

--- a/frontend/app/api/validations/validationerrordisplay/route.ts
+++ b/frontend/app/api/validations/validationerrordisplay/route.ts
@@ -4,12 +4,13 @@ import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
 import { safeFormatQuery } from '@/config/utils/sqlsecurity';
+import { fromQuery, withRouteAuthz } from '@/lib/route-authz';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-export async function GET(request: NextRequest) {
+async function handler(request: NextRequest) {
   const conn = ConnectionManager.getInstance();
   const schema = request.nextUrl.searchParams.get('schema');
   const plotIDParam = request.nextUrl.searchParams.get('plotIDParam');
@@ -76,3 +77,5 @@ export async function GET(request: NextRequest) {
     await conn.closeConnection();
   }
 }
+
+export const GET = withRouteAuthz('validations/validationerrordisplay', handler, { schema: fromQuery('schema') });

--- a/frontend/app/api/validations/validationerrordisplay/route.ts
+++ b/frontend/app/api/validations/validationerrordisplay/route.ts
@@ -3,6 +3,7 @@ import { CMError } from '@/config/macros/uploadsystemmacros';
 import { HTTPResponses } from '@/config/macros';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
+import { safeFormatQuery } from '@/config/utils/sqlsecurity';
 
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
@@ -16,7 +17,9 @@ export async function GET(request: NextRequest) {
   if (!schema) throw new Error('No schema variable provided!');
 
   try {
-    const validationErrorsQuery = `
+    const validationErrorsQuery = safeFormatQuery(
+      schema,
+      `
       SELECT
           cm.CoreMeasurementID AS CoreMeasurementID,
           GROUP_CONCAT(COALESCE(ve.ValidationID, me.ErrorID) ORDER BY COALESCE(ve.ValidationID, me.ErrorID)) AS ValidationErrorIDs,
@@ -31,19 +34,20 @@ export async function GET(request: NextRequest) {
             SEPARATOR '||'
           ) AS Criteria
       FROM
-          ${schema}.measurement_error_log AS cve
+          ??.measurement_error_log AS cve
       JOIN
-          ${schema}.measurement_errors me ON me.ErrorID = cve.ErrorID AND me.ErrorSource = 'validation' AND cve.IsResolved = FALSE
+          ??.measurement_errors me ON me.ErrorID = cve.ErrorID AND me.ErrorSource = 'validation' AND cve.IsResolved = FALSE
       JOIN
-          ${schema}.coremeasurements cm ON cve.MeasurementID = cm.CoreMeasurementID
+          ??.coremeasurements cm ON cve.MeasurementID = cm.CoreMeasurementID
       LEFT JOIN
-          ${schema}.sitespecificvalidations AS ve ON me.ErrorCode = CAST(ve.ValidationID AS CHAR)
-      JOIN ${schema}.census c ON cm.CensusID = c.CensusID AND c.IsActive IS TRUE
-      JOIN ${schema}.plots p ON c.PlotID = p.PlotID
+          ??.sitespecificvalidations AS ve ON me.ErrorCode = CAST(ve.ValidationID AS CHAR)
+      JOIN ??.census c ON cm.CensusID = c.CensusID AND c.IsActive IS TRUE
+      JOIN ??.plots p ON c.PlotID = p.PlotID
       WHERE p.PlotID = ? AND c.PlotCensusNumber = ?
       GROUP BY
           cm.CoreMeasurementID;
-    `;
+    `
+    );
     const validationErrorsRows = await conn.executeQuery(validationErrorsQuery, [plotIDParam, censusPCNParam]);
 
     const parsedValidationErrors: CMError[] = validationErrorsRows.map((row: any) => ({

--- a/frontend/app/api/validations/validationlist/route.ts
+++ b/frontend/app/api/validations/validationlist/route.ts
@@ -1,9 +1,8 @@
 import { HTTPResponses } from '@/config/macros';
 import { NextRequest, NextResponse } from 'next/server';
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { isValidSchema, safeFormatQuery } from '@/lib/db/sqlsecurity';
-import { assertSchemaAccess } from '@/lib/authz';
-import { auth } from '@/auth';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { fromQuery, withRouteAuthz } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
 
 // Force Node.js runtime for database and Azure SDK compatibility
@@ -19,22 +18,12 @@ interface ValidationProcedure {
 
 type ValidationMessages = Record<string, { id: number; description: string; definition: string }>;
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
+async function handler(request: NextRequest): Promise<NextResponse> {
   const conn = ConnectionManager.getInstance();
   const schema = request.nextUrl.searchParams.get('schema');
   if (!schema) {
     return NextResponse.json({ error: 'No schema variable provided' }, { status: HTTPResponses.INVALID_REQUEST });
   }
-  if (!isValidSchema(schema)) {
-    return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
-  }
-
-  const session = await auth();
-  if (!session?.user) {
-    return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
-  }
-  const denied = assertSchemaAccess(session, schema);
-  if (denied) return denied;
 
   try {
     const siteQuery = safeFormatQuery(
@@ -54,3 +43,5 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: error.message }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
   }
 }
+
+export const GET = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });

--- a/frontend/app/api/validations/validationlist/route.ts
+++ b/frontend/app/api/validations/validationlist/route.ts
@@ -1,6 +1,9 @@
 import { HTTPResponses } from '@/config/macros';
 import { NextRequest, NextResponse } from 'next/server';
 import ConnectionManager from '@/lib/db/connectionmanager';
+import { isValidSchema, safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { assertSchemaAccess } from '@/lib/authz';
+import { auth } from '@/auth';
 import ailogger from '@/ailogger';
 
 // Force Node.js runtime for database and Azure SDK compatibility
@@ -16,13 +19,28 @@ interface ValidationProcedure {
 
 type ValidationMessages = Record<string, { id: number; description: string; definition: string }>;
 
-export async function GET(request: NextRequest): Promise<NextResponse<ValidationMessages>> {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   const conn = ConnectionManager.getInstance();
   const schema = request.nextUrl.searchParams.get('schema');
-  if (!schema) throw new Error('No schema variable provided!');
-  try {
-    const siteQuery = `SELECT ValidationID, ProcedureName, Description, Definition FROM ${schema}.sitespecificvalidations WHERE IsEnabled = 1;`;
+  if (!schema) {
+    return NextResponse.json({ error: 'No schema variable provided' }, { status: HTTPResponses.INVALID_REQUEST });
+  }
+  if (!isValidSchema(schema)) {
+    return NextResponse.json({ error: 'Invalid schema provided', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.INVALID_REQUEST });
+  }
 
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthenticated', code: 'UNAUTHENTICATED' }, { status: HTTPResponses.UNAUTHORIZED });
+  }
+  const denied = assertSchemaAccess(session, schema);
+  if (denied) return denied;
+
+  try {
+    const siteQuery = safeFormatQuery(
+      schema,
+      'SELECT ValidationID, ProcedureName, Description, Definition FROM ??.sitespecificvalidations WHERE IsEnabled = 1;'
+    );
     const results: ValidationProcedure[] = await conn.executeQuery(siteQuery);
 
     const validationMessages: ValidationMessages = results.reduce((acc, { ValidationID, ProcedureName, Description, Definition }) => {
@@ -30,14 +48,9 @@ export async function GET(request: NextRequest): Promise<NextResponse<Validation
       return acc;
     }, {} as ValidationMessages);
 
-    return new NextResponse(JSON.stringify({ coreValidations: validationMessages }), {
-      status: HTTPResponses.OK,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    return NextResponse.json({ coreValidations: validationMessages }, { status: HTTPResponses.OK });
   } catch (error: any) {
-    ailogger.error('Error in GET request:', error.message);
-    return new NextResponse(JSON.stringify({ error: error.message }), {
-      status: HTTPResponses.INTERNAL_SERVER_ERROR
-    });
+    ailogger.error('Error in validationlist GET request:', error.message);
+    return NextResponse.json({ error: error.message }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
   }
 }

--- a/frontend/components/client/validationcore.tsx
+++ b/frontend/components/client/validationcore.tsx
@@ -198,7 +198,7 @@ export default function ValidationCore({ onValidationComplete }: VCProps) {
   const performValidations = useCallback(async () => {
     try {
       const runSingleValidation = async (procedureName: string): Promise<ValidationExecutionResult[]> => {
-        const { id: validationProcedureID, definition: cursorQuery } = validationMessages[procedureName];
+        const { id: validationProcedureID } = validationMessages[procedureName];
 
         try {
           const response = await fetch(`/api/validations/procedures/${procedureName}`, {
@@ -208,7 +208,6 @@ export default function ValidationCore({ onValidationComplete }: VCProps) {
             body: JSON.stringify({
               schema: currentSite?.schemaName,
               validationProcedureID,
-              cursorQuery,
               p_CensusID: currentCensus?.dateRanges?.[0]?.censusID,
               p_PlotID: plotID
             })

--- a/frontend/components/processors/processorhelperfunctions.tsx
+++ b/frontend/components/processors/processorhelperfunctions.tsx
@@ -316,6 +316,11 @@ type CombinedCrossCensusLocationValidationResult = {
   error?: string;
 };
 
+export interface ValidationProcedureDefinition {
+  procedureName: string;
+  definition: string;
+}
+
 function mysqlBoolToBoolean(value: any): boolean {
   if (Buffer.isBuffer(value)) return value[0] === 1;
   return Boolean(value);
@@ -395,15 +400,15 @@ function formatValidationQuery(schema: string, cursorQuery: string, validationPr
 }
 
 /**
- * Loads the server-owned validation SQL (the Definition column) for a validation
- * by its ValidationID. Replaces trusting a client-supplied cursorQuery.
+ * Loads the server-owned validation procedure row for a validation by its
+ * ValidationID. Replaces trusting a client-supplied cursorQuery.
  * Returns null when no enabled validation matches.
  */
-export async function loadValidationDefinition(schema: string, validationProcedureID: number): Promise<string | null> {
+export async function loadValidationDefinition(schema: string, validationProcedureID: number): Promise<ValidationProcedureDefinition | null> {
   const connectionManager = ConnectionManager.getInstance();
-  const sql = safeFormatQuery(schema, 'SELECT Definition FROM ??.sitespecificvalidations WHERE ValidationID = ? AND IsEnabled = 1 LIMIT 1;');
-  const rows: Array<{ Definition: string }> = await connectionManager.executeQuery(sql, [validationProcedureID]);
-  return rows.length > 0 ? rows[0].Definition : null;
+  const sql = safeFormatQuery(schema, 'SELECT ProcedureName, Definition FROM ??.sitespecificvalidations WHERE ValidationID = ? AND IsEnabled = 1 LIMIT 1;');
+  const rows: Array<{ ProcedureName: string; Definition: string }> = await connectionManager.executeQuery(sql, [validationProcedureID]);
+  return rows.length > 0 ? { procedureName: rows[0].ProcedureName, definition: rows[0].Definition } : null;
 }
 
 // Generalized runValidation function

--- a/frontend/components/processors/processorhelperfunctions.tsx
+++ b/frontend/components/processors/processorhelperfunctions.tsx
@@ -2,6 +2,7 @@ import MapperFactory from '@/config/datamapper';
 import { handleUpsert } from '@/config/utils';
 import { AllTaxonomiesViewRDS, AllTaxonomiesViewResult } from '@/lib/db/definitions/views';
 import ConnectionManager from '@/lib/db/connectionmanager';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { fileMappings, InsertUpdateProcessingProps } from '@/config/macros';
 import ailogger from '@/ailogger';
 import { ensureMeasurementErrorDefinition, VALIDATION_ERROR_SOURCE } from '@/config/measurementerrors';
@@ -393,12 +394,24 @@ function formatValidationQuery(schema: string, cursorQuery: string, validationPr
     .replace(/TEMP_CMATTRIBUTES_PLACEHOLDER/g, `${schema}.cmattributes`);
 }
 
+/**
+ * Loads the server-owned validation SQL (the Definition column) for a validation
+ * by its ValidationID. Replaces trusting a client-supplied cursorQuery.
+ * Returns null when no enabled validation matches.
+ */
+export async function loadValidationDefinition(schema: string, validationProcedureID: number): Promise<string | null> {
+  const connectionManager = ConnectionManager.getInstance();
+  const sql = safeFormatQuery(schema, 'SELECT Definition FROM ??.sitespecificvalidations WHERE ValidationID = ? AND IsEnabled = 1 LIMIT 1;');
+  const rows: Array<{ Definition: string }> = await connectionManager.executeQuery(sql, [validationProcedureID]);
+  return rows.length > 0 ? rows[0].Definition : null;
+}
+
 // Generalized runValidation function
 export async function runValidation(
   validationProcedureID: number,
   validationProcedureName: string,
   schema: string,
-  cursorQuery: string,
+  definition: string,
   params: ValidationExecutionParams = {}
 ): Promise<boolean> {
   const connectionManager = ConnectionManager.getInstance();
@@ -416,7 +429,7 @@ export async function runValidation(
       await prepareValidationRun(connectionManager, schema, validationProcedureID, validationProcedureName, transactionID, params);
 
       // STEP 2: Dynamically replace SQL variables with actual TypeScript input values
-      const formattedCursorQuery = formatValidationQuery(schema, cursorQuery, validationProcedureID, params);
+      const formattedCursorQuery = formatValidationQuery(schema, definition, validationProcedureID, params);
 
       // STEP 3: Execute the validation query to insert new errors
       const finalCursorQuery =

--- a/frontend/config/validation-runner.ts
+++ b/frontend/config/validation-runner.ts
@@ -122,7 +122,7 @@ function buildValidationTasks(validationMessages: ValidationMessages, schema: st
   for (const procedureName of allNames) {
     if (combinedNames.has(procedureName)) continue;
 
-    const { id: validationProcedureID, definition: cursorQuery } = validationMessages[procedureName];
+    const { id: validationProcedureID } = validationMessages[procedureName];
     tasks.push({
       name: procedureName,
       run: async (signal: AbortSignal) => {
@@ -130,7 +130,7 @@ function buildValidationTasks(validationMessages: ValidationMessages, schema: st
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           signal,
-          body: JSON.stringify({ schema, validationProcedureID, cursorQuery, p_CensusID: censusID, p_PlotID: plotID })
+          body: JSON.stringify({ schema, validationProcedureID, p_CensusID: censusID, p_PlotID: plotID })
         });
         if (!response.ok) {
           const body = await response.json().catch(() => null);

--- a/frontend/lib/route-authz.test.ts
+++ b/frontend/lib/route-authz.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+
+import { auth } from '@/auth';
+import { withRouteAuthz, fromQuery, fromPath, fromBody } from '@/lib/route-authz';
+import type { RouteKey } from '@/lib/route-policy';
+
+const HTTP_OK = 200;
+const HTTP_BAD_REQUEST = 400;
+const HTTP_FORBIDDEN = 403;
+const HTTP_SERVICE_UNAVAILABLE = 503;
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+const ADMIN_ROLE = 'global';
+const NON_ADMIN_ROLE = 'field crew';
+
+const makeHandler = () => vi.fn(async () => new Response('ok', { status: HTTP_OK }));
+const emptyCtx = { params: Promise.resolve({}) };
+
+describe('withRouteAuthz', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('denies a site-scoped schema outside the session sites with 403', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_panama' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+    const req = new NextRequest('http://localhost/api/validations/validationlist?schema=forestgeo_serc');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('allows a site-scoped schema inside the session sites', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_serc' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+    const req = new NextRequest('http://localhost/api/validations/validationlist?schema=forestgeo_serc');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_OK);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('allows an admin session on an admin route', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: ADMIN_ROLE, sites: [] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('structure/[schema]', handler);
+    const req = new NextRequest('http://localhost/api/structure/forestgeo_serc');
+    const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc' }) });
+    expect(res.status).toBe(HTTP_OK);
+  });
+
+  it('rejects a non-admin session on an admin route with 403', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('structure/[schema]', handler);
+    const req = new NextRequest('http://localhost/api/structure/forestgeo_serc');
+    const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc' }) });
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (400) when a site-scoped resolver yields no schema', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: ADMIN_ROLE, sites: [] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler, { schema: fromQuery('schema') });
+    const req = new NextRequest('http://localhost/api/validations/validationlist');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_BAD_REQUEST);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (500) for an unknown route key', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: ADMIN_ROLE, sites: [] } } as any);
+    const handler = makeHandler();
+    // Cast: `keyof typeof ROUTE_POLICIES` makes a literal typo a compile error, but a
+    // deleted/forced key can still reach the runtime — this exercises that fail-closed path.
+    const wrapped = withRouteAuthz('does/not/exist' as RouteKey, handler);
+    const req = new NextRequest('http://localhost/api/does/not/exist');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_INTERNAL_SERVER_ERROR);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('runs a public-policy handler without ever calling auth()', async () => {
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('health', handler);
+    const req = new NextRequest('http://localhost/api/health');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_OK);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(auth).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when the session reports permissions unavailable on an authed path', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: ADMIN_ROLE, sites: [], permissionsUnavailable: true } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('structure/[schema]', handler);
+    const req = new NextRequest('http://localhost/api/structure/forestgeo_serc');
+    const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc' }) });
+    expect(res.status).toBe(HTTP_SERVICE_UNAVAILABLE);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('resolves the schema from a path param (fromPath) and allows a member session', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_serc' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('dashboardmetrics/all/[schema]/[plotID]/[censusID]', handler, { schema: fromPath('schema') });
+    const req = new NextRequest('http://localhost/api/dashboardmetrics/all/forestgeo_serc/1/2');
+    const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc', plotID: '1', censusID: '2' }) });
+    expect(res.status).toBe(HTTP_OK);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('denies a fromPath schema outside the session sites with 403', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_panama' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('dashboardmetrics/all/[schema]/[plotID]/[censusID]', handler, { schema: fromPath('schema') });
+    const req = new NextRequest('http://localhost/api/dashboardmetrics/all/forestgeo_serc/1/2');
+    const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc', plotID: '1', censusID: '2' }) });
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fails closed (500) for a site-scoped route with no schema resolver configured', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_serc' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('validations/validationlist', handler);
+    const req = new NextRequest('http://localhost/api/validations/validationlist?schema=forestgeo_serc');
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_INTERNAL_SERVER_ERROR);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('leaves the request body readable by the handler after fromBody resolves the schema', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_serc' }] } } as any);
+    const handler = vi.fn(async (request: NextRequest) => {
+      const body = await request.json();
+      return Response.json({ echoedGridType: body.gridType });
+    });
+    const wrapped = withRouteAuthz('bulkcrud', handler, { schema: fromBody('schema') });
+    const req = new NextRequest('http://localhost/api/bulkcrud', {
+      method: 'POST',
+      body: JSON.stringify({ schema: 'forestgeo_serc', gridType: 'stems' }),
+      headers: { 'content-type': 'application/json' }
+    });
+    const res = await wrapped(req, emptyCtx);
+    expect(res.status).toBe(HTTP_OK);
+    expect(handler).toHaveBeenCalledOnce();
+    const payload = await res.json();
+    expect(payload.echoedGridType).toBe('stems');
+  });
+});

--- a/frontend/lib/route-authz.test.ts
+++ b/frontend/lib/route-authz.test.ts
@@ -4,7 +4,7 @@ import { NextRequest } from 'next/server';
 vi.mock('@/auth', () => ({ auth: vi.fn() }));
 
 import { auth } from '@/auth';
-import { withRouteAuthz, fromQuery, fromPath, fromBody } from '@/lib/route-authz';
+import { withRouteAuthz, fromQuery, fromPath, fromPathSegment, fromBody } from '@/lib/route-authz';
 import type { RouteKey } from '@/lib/route-policy';
 
 const HTTP_OK = 200;
@@ -123,6 +123,16 @@ describe('withRouteAuthz', () => {
     const res = await wrapped(req, { params: Promise.resolve({ schema: 'forestgeo_serc', plotID: '1', censusID: '2' }) });
     expect(res.status).toBe(HTTP_FORBIDDEN);
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('resolves the schema from a catch-all path segment and allows a member session', async () => {
+    vi.mocked(auth).mockResolvedValueOnce({ user: { userStatus: NON_ADMIN_ROLE, sites: [{ schemaName: 'forestgeo_serc' }] } } as any);
+    const handler = makeHandler();
+    const wrapped = withRouteAuthz('formdownload/[dataType]/[[...slugs]]', handler, { schema: fromPathSegment('slugs', 0) });
+    const req = new NextRequest('http://localhost/api/formdownload/attributes/forestgeo_serc/1/2');
+    const res = await wrapped(req, { params: Promise.resolve({ dataType: 'attributes', slugs: ['forestgeo_serc', '1', '2'] }) });
+    expect(res.status).toBe(HTTP_OK);
+    expect(handler).toHaveBeenCalledOnce();
   });
 
   it('fails closed (500) for a site-scoped route with no schema resolver configured', async () => {

--- a/frontend/lib/route-authz.ts
+++ b/frontend/lib/route-authz.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { assertSchemaAccess } from '@/lib/authz';
 import { requireAdmin, requireSession } from '@/lib/auth-helpers';
-import { isValidSchema } from '@/config/utils/sqlsecurity';
+import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { ROUTE_POLICIES, type RouteKey } from '@/lib/route-policy';
 import { HTTPResponses } from '@/config/macros';
 import ailogger from '@/ailogger';

--- a/frontend/lib/route-authz.ts
+++ b/frontend/lib/route-authz.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { assertSchemaAccess } from '@/lib/authz';
+import { requireAdmin, requireSession } from '@/lib/auth-helpers';
+import { isValidSchema } from '@/config/utils/sqlsecurity';
+import { ROUTE_POLICIES, type RouteKey } from '@/lib/route-policy';
+import { HTTPResponses } from '@/config/macros';
+import ailogger from '@/ailogger';
+
+export interface RouteContext {
+  params: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export type SchemaResolver = (request: NextRequest, context: RouteContext) => Promise<string | null> | string | null;
+
+export const fromQuery =
+  (param = 'schema'): SchemaResolver =>
+  request =>
+    request.nextUrl.searchParams.get(param);
+
+export const fromPath =
+  (param = 'schema'): SchemaResolver =>
+  async (_request, context) => {
+    const params = await context.params;
+    const value = params[param];
+    return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+  };
+
+/**
+ * Resolve the schema from the JSON request body. Clones and fully parses the
+ * body, so prefer {@link fromPath}/{@link fromQuery} on large-payload routes
+ * (e.g. bulk upload) to avoid parsing the whole body twice.
+ */
+export const fromBody =
+  (key = 'schema'): SchemaResolver =>
+  async request => {
+    try {
+      const body = await request.clone().json();
+      const value = body?.[key];
+      return typeof value === 'string' ? value : null;
+    } catch {
+      return null;
+    }
+  };
+
+interface AuthzOptions {
+  schema?: SchemaResolver;
+}
+
+type Handler = (request: NextRequest, context: RouteContext) => Promise<Response> | Response;
+
+/**
+ * Node-runtime authorization wrapper for an app/api route handler.
+ *
+ * CONTRACT: `routeKey` MUST equal the route's folder path under `app/api`
+ * (i.e. the exact key under which the route is registered in ROUTE_POLICIES,
+ * without leading slash or trailing `/route.ts`). It is typed as
+ * {@link RouteKey}, so a typo or stale key is a compile error rather than a
+ * silent runtime authz downgrade.
+ *
+ * Enforcement by policy:
+ *   - `public`      → handler runs; `auth()` is never called.
+ *   - `authed`      → requires a valid session (401/503 otherwise).
+ *   - `admin`       → requires an admin session (403 otherwise).
+ *   - `site-scoped` → resolves a schema via `options.schema` and enforces
+ *                     per-site access (400 on missing/invalid schema, 403 on
+ *                     out-of-scope, 503 when permissions are unavailable).
+ *
+ * The schema is resolved by an EXPLICIT per-route resolver
+ * ({@link fromQuery}/{@link fromPath}/{@link fromBody}), never inferred from
+ * the pathname.
+ */
+export function withRouteAuthz(routeKey: RouteKey, handler: Handler, options: AuthzOptions = {}) {
+  return async (request: NextRequest, context: RouteContext): Promise<Response> => {
+    const policy = ROUTE_POLICIES[routeKey];
+    if (!policy) {
+      ailogger.error(`[route-authz] No policy for route key '${routeKey}' — refusing request.`);
+      return NextResponse.json({ error: 'route authorization misconfigured', code: 'ROUTE_MISCONFIGURED' }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
+    }
+
+    if (policy === 'public') return handler(request, context);
+
+    const session = await auth();
+    const sessionError = requireSession(session);
+    // requireSession returns a response for a null/degraded session, so past this
+    // point session is non-null; the `!session` guard narrows the type for TS.
+    if (sessionError || !session) return sessionError ?? NextResponse.json({ error: 'unauthorized' }, { status: HTTPResponses.UNAUTHORIZED });
+
+    if (policy === 'authed') return handler(request, context);
+
+    if (policy === 'admin') {
+      const denied = requireAdmin(session);
+      if (denied) return denied;
+      return handler(request, context);
+    }
+
+    // site-scoped
+    if (!options.schema) {
+      ailogger.error(`[route-authz] site-scoped route '${routeKey}' has no schema resolver — refusing request.`);
+      return NextResponse.json({ error: 'route authorization misconfigured', code: 'ROUTE_MISCONFIGURED' }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
+    }
+    const schema = await options.schema(request, context);
+    if (!schema || !isValidSchema(schema)) {
+      return NextResponse.json({ error: 'missing or invalid schema', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.BAD_REQUEST });
+    }
+    const denied = assertSchemaAccess(session, schema);
+    if (denied) return denied;
+
+    return handler(request, context);
+  };
+}

--- a/frontend/lib/route-authz.ts
+++ b/frontend/lib/route-authz.ts
@@ -13,6 +13,8 @@ export interface RouteContext {
 
 export type SchemaResolver = (request: NextRequest, context: RouteContext) => Promise<string | null> | string | null;
 
+const EMPTY_ROUTE_CONTEXT: RouteContext = { params: Promise.resolve({}) };
+
 export const fromQuery =
   (param = 'schema'): SchemaResolver =>
   request =>
@@ -24,6 +26,15 @@ export const fromPath =
     const params = await context.params;
     const value = params[param];
     return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+  };
+
+export const fromPathSegment =
+  (param: string, index: number): SchemaResolver =>
+  async (_request, context) => {
+    const params = await context.params;
+    const value = params[param];
+    if (!Array.isArray(value)) return null;
+    return value[index] ?? null;
   };
 
 /**
@@ -72,13 +83,14 @@ type Handler = (request: NextRequest, context: RouteContext) => Promise<Response
  */
 export function withRouteAuthz(routeKey: RouteKey, handler: Handler, options: AuthzOptions = {}) {
   return async (request: NextRequest, context: RouteContext): Promise<Response> => {
+    const routeContext = context ?? EMPTY_ROUTE_CONTEXT;
     const policy = ROUTE_POLICIES[routeKey];
     if (!policy) {
       ailogger.error(`[route-authz] No policy for route key '${routeKey}' — refusing request.`);
       return NextResponse.json({ error: 'route authorization misconfigured', code: 'ROUTE_MISCONFIGURED' }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
     }
 
-    if (policy === 'public') return handler(request, context);
+    if (policy === 'public') return handler(request, routeContext);
 
     const session = await auth();
     const sessionError = requireSession(session);
@@ -86,12 +98,12 @@ export function withRouteAuthz(routeKey: RouteKey, handler: Handler, options: Au
     // point session is non-null; the `!session` guard narrows the type for TS.
     if (sessionError || !session) return sessionError ?? NextResponse.json({ error: 'unauthorized' }, { status: HTTPResponses.UNAUTHORIZED });
 
-    if (policy === 'authed') return handler(request, context);
+    if (policy === 'authed') return handler(request, routeContext);
 
     if (policy === 'admin') {
       const denied = requireAdmin(session);
       if (denied) return denied;
-      return handler(request, context);
+      return handler(request, routeContext);
     }
 
     // site-scoped
@@ -99,13 +111,13 @@ export function withRouteAuthz(routeKey: RouteKey, handler: Handler, options: Au
       ailogger.error(`[route-authz] site-scoped route '${routeKey}' has no schema resolver — refusing request.`);
       return NextResponse.json({ error: 'route authorization misconfigured', code: 'ROUTE_MISCONFIGURED' }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
     }
-    const schema = await options.schema(request, context);
+    const schema = await options.schema(request, routeContext);
     if (!schema || !isValidSchema(schema)) {
       return NextResponse.json({ error: 'missing or invalid schema', code: 'INVALID_SCHEMA' }, { status: HTTPResponses.BAD_REQUEST });
     }
     const denied = assertSchemaAccess(session, schema);
     if (denied) return denied;
 
-    return handler(request, context);
+    return handler(request, routeContext);
   };
 }

--- a/frontend/lib/route-policy.ts
+++ b/frontend/lib/route-policy.ts
@@ -205,10 +205,6 @@ export const UNVERIFIED_SCHEMA_ACCESS: ReadonlySet<string> = new Set([
   'specieslimits/[plotID]/[plotCensusNumber]',
   // validatefailed: validateSchemaOrThrow (SQL safety only), no user auth
   'validatefailed/[schema]/[plotID]/[censusID]',
-  // validations/procedures/*: accept schema from POST body, no auth check
-  'validations/procedures/[validationType]',
-  'validations/procedures/shared-cross-census-location',
-  'validations/procedures/shared-dbh',
   // validations/run: uses safeFormatQuery, no auth
   'validations/run',
   // validations/updatepassedvalidations: raw schema from body/query, no auth

--- a/frontend/lib/route-policy.ts
+++ b/frontend/lib/route-policy.ts
@@ -23,7 +23,7 @@
 
 export type RoutePolicy = 'public' | 'authed' | 'site-scoped' | 'admin';
 
-export const ROUTE_POLICIES: Record<string, RoutePolicy> = {
+export const ROUTE_POLICIES = {
   // ── Public routes (no auth required) ─────────────────────────────────────
   // Health probe – intentionally public for Azure App Service health checks
   health: 'public',
@@ -147,7 +147,11 @@ export const ROUTE_POLICIES: Record<string, RoutePolicy> = {
   'files/[operation]': 'site-scoped',
   // Census rollover (currently a no-op stub, but operates on site data)
   'rollover/[primaryKey]/[schema]/[plotIDParam]/[censusIDParam]/[newCensusIDParam]': 'site-scoped'
-};
+} satisfies Record<string, RoutePolicy>;
+
+/** Compile-time union of every declared route key. Adoption sites use this so a
+ * typo'd or stale routeKey is a build error, not a runtime authz downgrade. */
+export type RouteKey = keyof typeof ROUTE_POLICIES;
 
 /**
  * Site-scoped routes that do NOT yet reference a recognised authz signal in

--- a/frontend/lib/route-policy.ts
+++ b/frontend/lib/route-policy.ts
@@ -168,15 +168,11 @@ export type RouteKey = keyof typeof ROUTE_POLICIES;
 export const UNVERIFIED_SCHEMA_ACCESS: ReadonlySet<string> = new Set([
   // Operates on schema without calling auth() or validateContextualValues
   'bulkcrud',
-  // Details endpoint uses raw schema from query string, no auth check
-  'details/cmid',
   // fixeddata GET uses isValidSchema but no auth; POST/PATCH/DELETE delegate to
   // coreapifunctions which also lack auth
   'fixeddata/[dataType]/[[...slugs]]',
   // fixeddatafilter GET and POST delegate to coreapifunctions; no auth check
   'fixeddatafilter/[dataType]/[[...slugs]]',
-  // formdownload: uses isValidSchema but no auth
-  'formdownload/[dataType]/[[...slugs]]',
   // formsearch: validates schema against isValidSchema but no auth
   'formsearch/[dataType]',
   // formvalidation: validates schema but no auth
@@ -205,8 +201,6 @@ export const UNVERIFIED_SCHEMA_ACCESS: ReadonlySet<string> = new Set([
   'setupbulkprocedure/[fileID]/[batchID]',
   // setupbulkprocessor: session ownership only; no user auth
   'setupbulkprocessor/[schema]/[plotID]/[censusID]',
-  // specieslimits: raw schema string in query, no auth
-  'specieslimits/[plotID]/[plotCensusNumber]',
   // validatefailed: validateSchemaOrThrow (SQL safety only), no user auth
   'validatefailed/[schema]/[plotID]/[censusID]',
   // validations/run: uses safeFormatQuery, no auth
@@ -215,8 +209,6 @@ export const UNVERIFIED_SCHEMA_ACCESS: ReadonlySet<string> = new Set([
   'validations/updatepassedvalidations',
   // validations/validate-query: raw schema from query, no auth
   'validations/validate-query',
-  // validations/validationerrordisplay: raw schema in query string, no auth
-  'validations/validationerrordisplay',
   // verifyprocessing: safeFormatQuery SQL safety, no user auth
   'verifyprocessing',
   // verifysession: safeFormatQuery SQL safety, no user auth

--- a/frontend/lib/route-policy.ts
+++ b/frontend/lib/route-policy.ts
@@ -217,8 +217,6 @@ export const UNVERIFIED_SCHEMA_ACCESS: ReadonlySet<string> = new Set([
   'validations/validate-query',
   // validations/validationerrordisplay: raw schema in query string, no auth
   'validations/validationerrordisplay',
-  // validations/validationlist: raw schema in query string, no auth
-  'validations/validationlist',
   // verifyprocessing: safeFormatQuery SQL safety, no user auth
   'verifyprocessing',
   // verifysession: safeFormatQuery SQL safety, no user auth

--- a/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
+++ b/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Connection } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+import { HTTPResponses } from '@/config/macros';
+import { INVALID_DATATYPE_CODE } from '@/app/api/fetchall/[[...slugs]]/route';
+
+const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
+
+// A clearly non-allowlisted, injection-flavored dataType. If the route drops the
+// whitelist check, this reaches `SELECT * FROM <schema>.information_schema.tables`,
+// which the driver either executes or errors on with a code OTHER than
+// INVALID_DATATYPE — so this test fails unless the whitelist gate is present.
+const UNKNOWN_INJECTION_DATATYPE = 'information_schema.tables';
+
+// An allowlisted generic-branch type that the test schema seeds with rows.
+const ALLOWLISTED_SEEDED_DATATYPE = 'attributes';
+
+// An allowlisted generic-branch type that regressed once: `roles` is a per-site
+// table fetched by the personnel datagrids. The schema creates the table but does
+// not seed it, so we only assert it is not rejected as an invalid dataType.
+const ALLOWLISTED_UNSEEDED_DATATYPE = 'roles';
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null
+}));
+
+// Default session is a 'global' admin so validateContextualValues authorizes any
+// requested schema. Mocking @/auth also keeps the real next-auth module (whose
+// lib/env.js imports the extensionless `next/server` subpath) from being loaded
+// by Node's native ESM resolver, which cannot resolve it.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: AUTH_USER_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+// Route the route's ConnectionManager.executeQuery at the shared test connection
+// so authorized requests execute against the real isolated test schema.
+vi.mock('@/config/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[]) => {
+      if (!sharedState.connection) {
+        throw new Error('Test DB connection not initialized');
+      }
+      const [rows] = await sharedState.connection.query(query, params as any[]);
+      return rows;
+    },
+    closeConnection: async () => undefined
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+// getCookie is a server action; stub it so census-list lookup is a no-op.
+vi.mock('@/app/actions/cookiemanager', () => ({
+  getCookie: vi.fn(async () => undefined)
+}));
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+describe('GET /api/fetchall dataType whitelist', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+  });
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection);
+  });
+
+  it('rejects a non-allowlisted dataType with 400 INVALID_DATATYPE before any SQL runs', async () => {
+    const { GET } = await import('@/app/api/fetchall/[[...slugs]]/route');
+    const req = new NextRequest(`http://localhost/api/fetchall/${UNKNOWN_INJECTION_DATATYPE}?schema=${schema}`);
+    const res = await GET(req as any, { params: Promise.resolve({ slugs: [UNKNOWN_INJECTION_DATATYPE] }) });
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    const body = await res.json();
+    expect(body.code).toBe(INVALID_DATATYPE_CODE);
+  });
+
+  it('serves an allowlisted generic-branch dataType (attributes) with 200 and a mapped array', async () => {
+    // The test schema seeds `attributes` rows, so a non-empty array is expected.
+    expect(testData.attributes.length).toBeGreaterThan(0);
+
+    const { GET } = await import('@/app/api/fetchall/[[...slugs]]/route');
+    const req = new NextRequest(`http://localhost/api/fetchall/${ALLOWLISTED_SEEDED_DATATYPE}?schema=${schema}`);
+    const res = await GET(req as any, { params: Promise.resolve({ slugs: [ALLOWLISTED_SEEDED_DATATYPE] }) });
+    expect(res.status).toBe(HTTPResponses.OK);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(testData.attributes.length);
+  });
+
+  it('serves the allowlisted `roles` dataType without a 400 INVALID_DATATYPE (regression guard)', async () => {
+    // `roles` is fetched by the personnel datagrids via the generic branch. The
+    // table exists in the schema but is not seeded, so it must return 200 with an
+    // array (possibly empty) — and must NOT be rejected as an invalid dataType.
+    const { GET } = await import('@/app/api/fetchall/[[...slugs]]/route');
+    const req = new NextRequest(`http://localhost/api/fetchall/${ALLOWLISTED_UNSEEDED_DATATYPE}?schema=${schema}`);
+    const res = await GET(req as any, { params: Promise.resolve({ slugs: [ALLOWLISTED_UNSEEDED_DATATYPE] }) });
+    expect(res.status).toBe(HTTPResponses.OK);
+    const body = await res.json();
+    expect(body.code).not.toBe(INVALID_DATATYPE_CODE);
+    expect(Array.isArray(body)).toBe(true);
+  });
+});

--- a/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
+++ b/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from 'next/server';
 import type { Connection } from 'mysql2/promise';
 import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
 import { HTTPResponses } from '@/config/macros';
-import { INVALID_DATATYPE_CODE } from '@/app/api/fetchall/[[...slugs]]/route';
+import { INVALID_DATATYPE_CODE } from '@/app/api/fetchall/[[...slugs]]/constants';
 
 const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
 

--- a/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
+++ b/frontend/tests/integration/fetchall-datatype-whitelist.integration.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/auth', () => ({
 
 // Route the route's ConnectionManager.executeQuery at the shared test connection
 // so authorized requests execute against the real isolated test schema.
-vi.mock('@/config/connectionmanager', () => {
+vi.mock('@/lib/db/connectionmanager', () => {
   const manager = {
     executeQuery: async (query: string, params?: unknown[]) => {
       if (!sharedState.connection) {

--- a/frontend/tests/integration/procedures-route-authz.integration.test.ts
+++ b/frontend/tests/integration/procedures-route-authz.integration.test.ts
@@ -153,6 +153,30 @@ describe('POST /api/validations/procedures/[validationType] authz + server-owned
     expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
   });
 
+  it('rejects a valid validationProcedureID when the path procedure name does not match the DB-owned row', async () => {
+    const [rows] = await connection.query(`SELECT ValidationID, ProcedureName FROM ${schema}.sitespecificvalidations WHERE IsEnabled = 1 LIMIT 1`);
+    const seeded = (rows as Array<{ ValidationID: number; ProcedureName: string }>)[0];
+    expect(seeded).toBeTruthy();
+
+    const mismatchedProcedureName = `${seeded.ProcedureName}_Mismatch`;
+    const { POST } = await import('@/app/api/validations/procedures/[validationType]/route');
+    const req = new NextRequest(`http://localhost/api/validations/procedures/${mismatchedProcedureName}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schema,
+        validationProcedureID: seeded.ValidationID,
+        p_CensusID: testData.census[0].censusID,
+        p_PlotID: testData.plots[0].plotID
+      })
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ validationType: mismatchedProcedureName }) });
+    expect(res.status).toBe(HTTP_BAD_REQUEST);
+    expect((await res.json()).code).toBe('VALIDATION_PROCEDURE_MISMATCH');
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+  });
+
   it('ignores an injected cursorQuery even for a VALID enabled validationProcedureID (regression guard)', async () => {
     // Regression guard for the successful path: a valid, enabled ID reaches runValidation.
     // If someone rewires runValidation back to the client body, this DROP would execute.

--- a/frontend/tests/integration/procedures-route-authz.integration.test.ts
+++ b/frontend/tests/integration/procedures-route-authz.integration.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/auth', () => ({
 
 // Route the route's ConnectionManager.executeQuery at the shared test connection
 // so authorized requests execute against the real isolated test schema.
-vi.mock('@/config/connectionmanager', () => {
+vi.mock('@/lib/db/connectionmanager', () => {
   const manager = {
     executeQuery: async (query: string, params?: unknown[]) => {
       if (!sharedState.connection) {

--- a/frontend/tests/integration/procedures-route-authz.integration.test.ts
+++ b/frontend/tests/integration/procedures-route-authz.integration.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Connection } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+
+const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
+const HTTP_OK = 200;
+const HTTP_FORBIDDEN = 403;
+const HTTP_BAD_REQUEST = 400;
+const UNKNOWN_VALIDATION_ID = 999999;
+const INJECTED_DROP = 'DROP TABLE coremeasurements; --';
+const VALIDATION_TYPE = 'ValidateScreenMeasurements';
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null
+}));
+
+// Default session is a 'global' admin so the route's auth() gate and
+// assertSchemaAccess pass; individual tests override with mockResolvedValueOnce
+// to exercise the non-admin denial path. Mocking @/auth also keeps the real
+// next-auth module (whose lib/env.js imports the extensionless `next/server`
+// subpath) from being loaded by Node's native ESM resolver, which cannot resolve it.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: AUTH_USER_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+// Route the route's ConnectionManager.executeQuery at the shared test connection
+// so authorized requests execute against the real isolated test schema.
+vi.mock('@/config/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[]) => {
+      if (!sharedState.connection) {
+        throw new Error('Test DB connection not initialized');
+      }
+      const [rows] = await sharedState.connection.query(query, params as any[]);
+      return rows;
+    }
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+async function coremeasurementsTableExists(connection: Connection, schema: string): Promise<boolean> {
+  const [rows] = await connection.query('SELECT COUNT(*) AS cnt FROM information_schema.tables WHERE table_schema = ? AND table_name = ?', [
+    schema,
+    'coremeasurements'
+  ]);
+  return (rows as Array<{ cnt: number }>)[0].cnt > 0;
+}
+
+describe('POST /api/validations/procedures/[validationType] authz + server-owned definition', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+  });
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection);
+  });
+
+  it('rejects an unknown validationProcedureID with 400 and never executes the injected cursorQuery', async () => {
+    // Sanity: table exists before the request so the post-condition is meaningful.
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+
+    const { POST } = await import('@/app/api/validations/procedures/[validationType]/route');
+    const req = new NextRequest(`http://localhost/api/validations/procedures/${VALIDATION_TYPE}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schema,
+        validationProcedureID: UNKNOWN_VALIDATION_ID,
+        // A pre-remediation route trusted and executed this body value. It must now be ignored.
+        cursorQuery: INJECTED_DROP,
+        p_CensusID: testData.census[0].censusID,
+        p_PlotID: testData.plots[0].plotID
+      })
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ validationType: VALIDATION_TYPE }) });
+
+    expect(res.status).toBe(HTTP_BAD_REQUEST);
+    // The injected DROP must not have run: coremeasurements must still exist.
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+  });
+
+  it('denies a schema outside the user site scope with 403 without loading any definition', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: 'attacker@forestgeo.test', userStatus: 'field crew', sites: [{ schemaName: 'forestgeo_panama' }] }
+    } as any);
+
+    const { POST } = await import('@/app/api/validations/procedures/[validationType]/route');
+    const req = new NextRequest(`http://localhost/api/validations/procedures/${VALIDATION_TYPE}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schema,
+        validationProcedureID: UNKNOWN_VALIDATION_ID,
+        cursorQuery: INJECTED_DROP,
+        p_CensusID: testData.census[0].censusID,
+        p_PlotID: testData.plots[0].plotID
+      })
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ validationType: VALIDATION_TYPE }) });
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+  });
+
+  it('runs a seeded enabled validation Definition for an authorized request (200 stream)', async () => {
+    // Pull a real enabled validation seeded by setupTestDatabase and drive it end-to-end.
+    const [rows] = await connection.query(`SELECT ValidationID, ProcedureName FROM ${schema}.sitespecificvalidations WHERE IsEnabled = 1 LIMIT 1`);
+    const seeded = (rows as Array<{ ValidationID: number; ProcedureName: string }>)[0];
+    expect(seeded).toBeTruthy();
+
+    const { POST } = await import('@/app/api/validations/procedures/[validationType]/route');
+    const req = new NextRequest(`http://localhost/api/validations/procedures/${seeded.ProcedureName}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schema,
+        validationProcedureID: seeded.ValidationID,
+        p_CensusID: testData.census[0].censusID,
+        p_PlotID: testData.plots[0].plotID
+      })
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ validationType: seeded.ProcedureName }) });
+    expect(res.status).toBe(HTTP_OK);
+    // Drain the stream so the underlying validation transaction completes.
+    await res.text();
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+  });
+
+  it('ignores an injected cursorQuery even for a VALID enabled validationProcedureID (regression guard)', async () => {
+    // Regression guard for the successful path: a valid, enabled ID reaches runValidation.
+    // If someone rewires runValidation back to the client body, this DROP would execute.
+    // Because the server loads Definition instead, the DROP must never run.
+    const [rows] = await connection.query(`SELECT ValidationID, ProcedureName FROM ${schema}.sitespecificvalidations WHERE IsEnabled = 1 LIMIT 1`);
+    const seeded = (rows as Array<{ ValidationID: number; ProcedureName: string }>)[0];
+    expect(seeded).toBeTruthy();
+
+    const { POST } = await import('@/app/api/validations/procedures/[validationType]/route');
+    const req = new NextRequest(`http://localhost/api/validations/procedures/${seeded.ProcedureName}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        schema,
+        validationProcedureID: seeded.ValidationID,
+        // Injected client SQL: must be ignored on the successful (valid-ID) path.
+        cursorQuery: INJECTED_DROP,
+        p_CensusID: testData.census[0].censusID,
+        p_PlotID: testData.plots[0].plotID
+      })
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ validationType: seeded.ProcedureName }) });
+    // Drain the stream so any validation transaction completes before we assert.
+    await res.text();
+    // The assertion that matters: the injected DROP did NOT run, proving the server
+    // executed the server-owned Definition rather than the client body.
+    expect(await coremeasurementsTableExists(connection, schema)).toBe(true);
+  });
+});

--- a/frontend/tests/integration/raw-schema-sweep.integration.test.ts
+++ b/frontend/tests/integration/raw-schema-sweep.integration.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/auth', () => ({
   }))
 }));
 
-vi.mock('@/config/connectionmanager', () => ({
+vi.mock('@/lib/db/connectionmanager', () => ({
   default: {
     getInstance: () => ({
       executeQuery: (query: string, params?: unknown[]) => sharedState.executeQuerySpy(query, params),

--- a/frontend/tests/integration/raw-schema-sweep.integration.test.ts
+++ b/frontend/tests/integration/raw-schema-sweep.integration.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Connection } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+import { HTTPResponses } from '@/config/macros';
+
+const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
+const STRUCTURALLY_INVALID_SCHEMA = 'foo;DROP';
+
+// A single spy shared with the ConnectionManager mock so each test can assert
+// whether the route reached SQL. The raw-schema sweep converted these routes to
+// validate the schema BEFORE building any SQL, so an invalid schema must never
+// reach executeQuery.
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null,
+  executeQuerySpy: vi.fn(async (query: string, params?: unknown[]) => {
+    if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+    const [rows] = await sharedState.connection.query(query, params as any[]);
+    return rows;
+  })
+}));
+
+// Default session is a 'global' admin so any route auth() gate passes; the tests
+// under scrutiny reject on schema validation before authz matters. Mocking @/auth
+// also avoids the real next-auth ESM subpath resolution failure under Node.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: AUTH_USER_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+vi.mock('@/config/connectionmanager', () => ({
+  default: {
+    getInstance: () => ({
+      executeQuery: (query: string, params?: unknown[]) => sharedState.executeQuerySpy(query, params),
+      closeConnection: async () => undefined
+    })
+  }
+}));
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+describe('raw-${schema} sweep: converted routes reject a structurally invalid schema before SQL', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+  });
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection);
+  });
+
+  beforeEach(() => {
+    sharedState.executeQuerySpy.mockClear();
+  });
+
+  it('details/cmid: safeFormatQuery throws on an invalid schema and no SQL is executed', async () => {
+    const { GET } = await import('@/app/api/details/cmid/route');
+    const req = new NextRequest(`http://localhost/api/details/cmid?cmid=1&schema=${encodeURIComponent(STRUCTURALLY_INVALID_SCHEMA)}`);
+    await expect(GET(req as any)).rejects.toThrow(/Invalid or unauthorized schema/);
+    expect(sharedState.executeQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it('validations/validationerrordisplay: invalid schema yields 500 from the caught validation error and no SQL', async () => {
+    const { GET } = await import('@/app/api/validations/validationerrordisplay/route');
+    const req = new NextRequest(
+      `http://localhost/api/validations/validationerrordisplay?schema=${encodeURIComponent(STRUCTURALLY_INVALID_SCHEMA)}&plotIDParam=1&censusPCNParam=1`
+    );
+    const res = await GET(req as any);
+    expect(res.status).toBe(HTTPResponses.INTERNAL_SERVER_ERROR);
+    expect((await res.json()).error).toMatch(/Invalid or unauthorized schema/);
+    expect(sharedState.executeQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it('changelog/overview: the unvalidated URL-param fallback is now gated and returns 400 with no SQL', async () => {
+    const { GET } = await import('@/app/api/changelog/overview/[changelogType]/[[...options]]/route');
+    // This test guards the URL-param FALLBACK hole specifically, not the primary path.
+    // An invalid schema forces the fallback: validateContextualValues itself rejects
+    // `foo;DROP` (isValidSchema fails), so validation.success is false and the handler
+    // falls through to the `schemaParam` branch, which assigned the RAW query-param
+    // schema without re-validating. The added validateSchemaOrThrow gate must now block
+    // that branch — proven by the 400 and by executeQuery never being reached.
+    const req = new NextRequest(`http://localhost/api/changelog/overview/unifiedchangelog/1/1?schema=${encodeURIComponent(STRUCTURALLY_INVALID_SCHEMA)}`);
+    const props = { params: Promise.resolve({ changelogType: 'unifiedchangelog', options: ['1', '1'] }) };
+    const res = await GET(req as any, props as any);
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    expect(sharedState.executeQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it('positive control: a valid schema reaches SQL for details/cmid', async () => {
+    const { GET } = await import('@/app/api/details/cmid/route');
+    const req = new NextRequest(`http://localhost/api/details/cmid?cmid=999999&schema=${schema}`);
+    const res = await GET(req as any);
+    expect(res.status).toBe(HTTPResponses.OK);
+    expect(sharedState.executeQuerySpy).toHaveBeenCalledTimes(1);
+    // testData is seeded by setup; referenced to keep the fixture wired and lint happy.
+    expect(testData).toBeDefined();
+  });
+});

--- a/frontend/tests/integration/raw-schema-sweep.integration.test.ts
+++ b/frontend/tests/integration/raw-schema-sweep.integration.test.ts
@@ -6,6 +6,7 @@ import { HTTPResponses } from '@/config/macros';
 
 const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
 const STRUCTURALLY_INVALID_SCHEMA = 'foo;DROP';
+const EMPTY_ROUTE_CONTEXT = { params: Promise.resolve({}) };
 
 // A single spy shared with the ConnectionManager mock so each test can assert
 // whether the route reached SQL. The raw-schema sweep converted these routes to
@@ -75,18 +76,20 @@ describe('raw-${schema} sweep: converted routes reject a structurally invalid sc
   it('details/cmid: safeFormatQuery throws on an invalid schema and no SQL is executed', async () => {
     const { GET } = await import('@/app/api/details/cmid/route');
     const req = new NextRequest(`http://localhost/api/details/cmid?cmid=1&schema=${encodeURIComponent(STRUCTURALLY_INVALID_SCHEMA)}`);
-    await expect(GET(req as any)).rejects.toThrow(/Invalid or unauthorized schema/);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    expect((await res.json()).code).toBe('INVALID_SCHEMA');
     expect(sharedState.executeQuerySpy).not.toHaveBeenCalled();
   });
 
-  it('validations/validationerrordisplay: invalid schema yields 500 from the caught validation error and no SQL', async () => {
+  it('validations/validationerrordisplay: invalid schema yields 400 from the route guard and no SQL', async () => {
     const { GET } = await import('@/app/api/validations/validationerrordisplay/route');
     const req = new NextRequest(
       `http://localhost/api/validations/validationerrordisplay?schema=${encodeURIComponent(STRUCTURALLY_INVALID_SCHEMA)}&plotIDParam=1&censusPCNParam=1`
     );
-    const res = await GET(req as any);
-    expect(res.status).toBe(HTTPResponses.INTERNAL_SERVER_ERROR);
-    expect((await res.json()).error).toMatch(/Invalid or unauthorized schema/);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    expect((await res.json()).code).toBe('INVALID_SCHEMA');
     expect(sharedState.executeQuerySpy).not.toHaveBeenCalled();
   });
 
@@ -108,7 +111,7 @@ describe('raw-${schema} sweep: converted routes reject a structurally invalid sc
   it('positive control: a valid schema reaches SQL for details/cmid', async () => {
     const { GET } = await import('@/app/api/details/cmid/route');
     const req = new NextRequest(`http://localhost/api/details/cmid?cmid=999999&schema=${schema}`);
-    const res = await GET(req as any);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
     expect(res.status).toBe(HTTPResponses.OK);
     expect(sharedState.executeQuerySpy).toHaveBeenCalledTimes(1);
     // testData is seeded by setup; referenced to keep the fixture wired and lint happy.

--- a/frontend/tests/integration/shared-procedures-authz.integration.test.ts
+++ b/frontend/tests/integration/shared-procedures-authz.integration.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Task 3 authz regression suite for the two streaming validation routes:
+ *   - POST /api/validations/procedures/shared-dbh
+ *   - POST /api/validations/procedures/shared-cross-census-location
+ *
+ * Both must authenticate (auth()) and authorize the body `schema`
+ * (assertSchemaAccess) BEFORE any DB work. A non-member schema for a non-admin
+ * session must be rejected with 403 and must NOT invoke the downstream
+ * validation function. An admin session must pass the gate and reach the
+ * streaming path (200).
+ */
+
+const HTTP_OK = 200;
+const HTTP_FORBIDDEN = 403;
+
+// A schema the non-admin session is a member of, and a DIFFERENT one it POSTs.
+const MEMBER_SCHEMA = 'forestgeo_panama';
+const FOREIGN_SCHEMA = 'forestgeo_serc';
+
+const ADMIN_EMAIL = 'admin@forestgeo.test';
+const ATTACKER_EMAIL = 'attacker@forestgeo.test';
+const MEMBER_EMAIL = 'member@forestgeo.test';
+
+// Default session is a 'global' admin so the route's auth() gate and
+// assertSchemaAccess pass; individual tests override with mockResolvedValueOnce
+// to exercise the non-admin denial path. Mocking @/auth also keeps the real
+// next-auth module (whose lib/env.js imports the extensionless `next/server`
+// subpath) from being loaded by Node's native ESM resolver, which cannot resolve it.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: ADMIN_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+// Stub the downstream validation functions so the authorized path is
+// deterministic (no real DB) and so we can assert the 403 path never reaches
+// them — proving the authz gate short-circuits before any DB work.
+const validationSpies = vi.hoisted(() => ({
+  runCombinedDBHValidations: vi.fn(async () => ({ totalProcessed: 0, errors: [] })),
+  runCombinedCrossCensusLocationValidations: vi.fn(async () => ({ totalProcessed: 0, errors: [] }))
+}));
+
+vi.mock('@/components/processors/processorhelperfunctions', () => ({
+  runCombinedDBHValidations: validationSpies.runCombinedDBHValidations,
+  runCombinedCrossCensusLocationValidations: validationSpies.runCombinedCrossCensusLocationValidations
+}));
+
+interface StreamingRouteCase {
+  name: string;
+  routePath: string;
+  validationSpy: ReturnType<typeof vi.fn>;
+}
+
+const ROUTE_CASES: StreamingRouteCase[] = [
+  {
+    name: 'shared-dbh',
+    routePath: '@/app/api/validations/procedures/shared-dbh/route',
+    validationSpy: validationSpies.runCombinedDBHValidations
+  },
+  {
+    name: 'shared-cross-census-location',
+    routePath: '@/app/api/validations/procedures/shared-cross-census-location/route',
+    validationSpy: validationSpies.runCombinedCrossCensusLocationValidations
+  }
+];
+
+function buildRequest(routeName: string, schema: string): NextRequest {
+  return new NextRequest(`http://localhost/api/validations/procedures/${routeName}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ schema, p_CensusID: 1, p_PlotID: 1 })
+  });
+}
+
+describe.each(ROUTE_CASES)('POST /api/validations/procedures/$name authz gate', ({ name, routePath, validationSpy }) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('denies a schema outside the non-admin user site scope with 403 and never runs the validation', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: ATTACKER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] }
+    } as any);
+
+    const { POST } = await import(routePath);
+    const res = await POST(buildRequest(name, FOREIGN_SCHEMA));
+
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+    // The authz gate must short-circuit BEFORE any DB work is scheduled.
+    expect(validationSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows an admin session to reach the streaming path (admin-bypass branch)', async () => {
+    const { POST } = await import(routePath);
+    const res = await POST(buildRequest(name, FOREIGN_SCHEMA));
+
+    expect(res.status).toBe(HTTP_OK);
+    // Drain the stream so the wrapped operation completes.
+    await res.text();
+    expect(validationSpy).toHaveBeenCalledWith(FOREIGN_SCHEMA, { p_CensusID: 1, p_PlotID: 1 });
+  });
+
+  it('allows a non-admin member of the requested schema to reach the streaming path (member branch)', async () => {
+    // Guards against a future regression that over-restricts legitimate members:
+    // this exercises hasSchemaAccess, NOT the admin bypass.
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: MEMBER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] }
+    } as any);
+
+    const { POST } = await import(routePath);
+    const res = await POST(buildRequest(name, MEMBER_SCHEMA));
+
+    expect(res.status).not.toBe(HTTP_FORBIDDEN);
+    expect(res.status).toBe(HTTP_OK);
+    // Drain the stream so the wrapped operation completes.
+    await res.text();
+    expect(validationSpy).toHaveBeenCalledWith(MEMBER_SCHEMA, { p_CensusID: 1, p_PlotID: 1 });
+  });
+});

--- a/frontend/tests/integration/structure-route-authz.integration.test.ts
+++ b/frontend/tests/integration/structure-route-authz.integration.test.ts
@@ -27,7 +27,7 @@ vi.mock('@/auth', () => ({
 
 // Route the route's ConnectionManager.executeQuery at the shared test connection
 // so authorized requests execute against a real, populated schema.
-vi.mock('@/config/connectionmanager', () => {
+vi.mock('@/lib/db/connectionmanager', () => {
   const manager = {
     executeQuery: async (query: string, params?: unknown[]) => {
       if (!sharedState.connection) {

--- a/frontend/tests/integration/structure-route-authz.integration.test.ts
+++ b/frontend/tests/integration/structure-route-authz.integration.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Connection } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+
+const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
+const HTTP_OK = 200;
+const HTTP_FORBIDDEN = 403;
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null
+}));
+
+// Default session is a 'global' admin so the guard's requireAdmin gate passes;
+// the non-admin test overrides with mockResolvedValueOnce to exercise the 403
+// denial path. Mocking @/auth also keeps the real next-auth module (whose
+// lib/env.js imports the extensionless `next/server` subpath) from being loaded
+// by Node's native ESM resolver, which cannot resolve it.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: AUTH_USER_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+// Route the route's ConnectionManager.executeQuery at the shared test connection
+// so authorized requests execute against a real, populated schema.
+vi.mock('@/config/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[]) => {
+      if (!sharedState.connection) {
+        throw new Error('Test DB connection not initialized');
+      }
+      const [rows] = await sharedState.connection.query(query, params as any[]);
+      return rows;
+    },
+    closeConnection: async () => undefined
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+describe('GET /api/structure/[schema] authz', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+  });
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection);
+  });
+
+  it('denies a non-admin session with 403 (admin-only metadata route)', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: 'attacker@forestgeo.test', userStatus: 'field crew', sites: [{ schemaName: 'forestgeo_serc' }] }
+    } as any);
+    const { GET } = await import('@/app/api/structure/[schema]/route');
+    const req = new Request('http://localhost/api/structure/forestgeo_serc');
+    const res = await GET(req as any, { params: Promise.resolve({ schema: 'forestgeo_serc' }) } as any);
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+  });
+
+  it('returns column metadata as a non-empty array for an admin session', async () => {
+    const { GET } = await import('@/app/api/structure/[schema]/route');
+    const req = new Request(`http://localhost/api/structure/${schema}`);
+    const res = await GET(req as any, { params: Promise.resolve({ schema }) } as any);
+    expect(res.status).toBe(HTTP_OK);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    // A populated schema always has information_schema.columns rows; otherwise the
+    // shape assertions below would pass vacuously.
+    expect(body.length).toBeGreaterThan(0);
+    // mysql2 returns information_schema column labels upper-cased, regardless of
+    // the lower-case aliases in the SELECT — assert the real wire shape.
+    for (const row of body as Array<Record<string, unknown>>) {
+      expect(row).toHaveProperty('TABLE_NAME');
+      expect(row).toHaveProperty('COLUMN_NAME');
+    }
+  });
+});

--- a/frontend/tests/integration/validationlist-route.integration.test.ts
+++ b/frontend/tests/integration/validationlist-route.integration.test.ts
@@ -7,6 +7,7 @@ const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
 const HTTP_OK = 200;
 const HTTP_FORBIDDEN = 403;
 const HTTP_BAD_REQUEST = 400;
+const EMPTY_ROUTE_CONTEXT = { params: Promise.resolve({}) };
 
 const sharedState = vi.hoisted(() => ({
   connection: null as Connection | null
@@ -75,14 +76,14 @@ describe('GET /api/validations/validationlist authz + injection', () => {
     } as any);
     const { GET } = await import('@/app/api/validations/validationlist/route');
     const req = new NextRequest(`http://localhost/api/validations/validationlist?schema=${schema}`);
-    const res = await GET(req as any);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
     expect(res.status).toBe(HTTP_FORBIDDEN);
   });
 
   it('rejects a structurally invalid schema without hitting SQL', async () => {
     const { GET } = await import('@/app/api/validations/validationlist/route');
     const req = new NextRequest('http://localhost/api/validations/validationlist?schema=foo%3BDROP');
-    const res = await GET(req as any);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
     expect(res.status).toBe(HTTP_BAD_REQUEST);
     expect((await res.json()).code).toBe('INVALID_SCHEMA');
   });
@@ -90,7 +91,7 @@ describe('GET /api/validations/validationlist authz + injection', () => {
   it('returns the coreValidations map for an authorized (admin) request', async () => {
     const { GET } = await import('@/app/api/validations/validationlist/route');
     const req = new NextRequest(`http://localhost/api/validations/validationlist?schema=${schema}`);
-    const res = await GET(req as any);
+    const res = await GET(req as any, EMPTY_ROUTE_CONTEXT);
     expect(res.status).toBe(HTTP_OK);
     const body = await res.json();
     expect(body).toHaveProperty('coreValidations');

--- a/frontend/tests/integration/validationlist-route.integration.test.ts
+++ b/frontend/tests/integration/validationlist-route.integration.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/auth', () => ({
 
 // Route the route's ConnectionManager.executeQuery at the shared test connection
 // so authorized requests execute against the real isolated test schema.
-vi.mock('@/config/connectionmanager', () => {
+vi.mock('@/lib/db/connectionmanager', () => {
   const manager = {
     executeQuery: async (query: string, params?: unknown[]) => {
       if (!sharedState.connection) {

--- a/frontend/tests/integration/validationlist-route.integration.test.ts
+++ b/frontend/tests/integration/validationlist-route.integration.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Connection } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+
+const AUTH_USER_EMAIL = 'integration-runner@forestgeo.test';
+const HTTP_OK = 200;
+const HTTP_FORBIDDEN = 403;
+const HTTP_BAD_REQUEST = 400;
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null
+}));
+
+// Default session is a 'global' admin so the route's auth() gate and
+// assertSchemaAccess pass; individual tests override with mockResolvedValueOnce
+// to exercise the non-admin denial path. Mocking @/auth also keeps the real
+// next-auth module (whose lib/env.js imports the extensionless `next/server`
+// subpath) from being loaded by Node's native ESM resolver, which cannot resolve it.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({
+    user: {
+      email: AUTH_USER_EMAIL,
+      userStatus: 'global',
+      sites: []
+    }
+  }))
+}));
+
+// Route the route's ConnectionManager.executeQuery at the shared test connection
+// so authorized requests execute against the real isolated test schema.
+vi.mock('@/config/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[]) => {
+      if (!sharedState.connection) {
+        throw new Error('Test DB connection not initialized');
+      }
+      const [rows] = await sharedState.connection.query(query, params as any[]);
+      return rows;
+    }
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+  }
+}));
+
+describe('GET /api/validations/validationlist authz + injection', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+  });
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection);
+  });
+
+  it('denies a schema outside the user site scope with 403', async () => {
+    const { auth } = await import('@/auth');
+    vi.mocked(auth).mockResolvedValueOnce({
+      user: { email: 'attacker@forestgeo.test', userStatus: 'field crew', sites: [{ schemaName: 'forestgeo_panama' }] }
+    } as any);
+    const { GET } = await import('@/app/api/validations/validationlist/route');
+    const req = new NextRequest(`http://localhost/api/validations/validationlist?schema=${schema}`);
+    const res = await GET(req as any);
+    expect(res.status).toBe(HTTP_FORBIDDEN);
+  });
+
+  it('rejects a structurally invalid schema without hitting SQL', async () => {
+    const { GET } = await import('@/app/api/validations/validationlist/route');
+    const req = new NextRequest('http://localhost/api/validations/validationlist?schema=foo%3BDROP');
+    const res = await GET(req as any);
+    expect(res.status).toBe(HTTP_BAD_REQUEST);
+    expect((await res.json()).code).toBe('INVALID_SCHEMA');
+  });
+
+  it('returns the coreValidations map for an authorized (admin) request', async () => {
+    const { GET } = await import('@/app/api/validations/validationlist/route');
+    const req = new NextRequest(`http://localhost/api/validations/validationlist?schema=${schema}`);
+    const res = await GET(req as any);
+    expect(res.status).toBe(HTTP_OK);
+    const body = await res.json();
+    expect(body).toHaveProperty('coreValidations');
+    expect(typeof body.coreValidations).toBe('object');
+    // The setup seeds enabled sitespecificvalidations rows, so the map must be non-empty;
+    // otherwise the per-entry assertions below would pass vacuously.
+    expect(Object.keys(body.coreValidations).length).toBeGreaterThan(0);
+    // Every entry keyed by ProcedureName carries id/description/definition
+    const entries = Object.values(body.coreValidations) as Array<{ id: number; description: string; definition: string }>;
+    for (const entry of entries) {
+      expect(entry).toHaveProperty('id');
+      expect(entry).toHaveProperty('description');
+      expect(entry).toHaveProperty('definition');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Runtime per-site authorization + SQL-injection closure for the highest-risk API routes, rebased onto the repo-structure refactor (#341/#342).

- Adds `withRouteAuthz` — a runtime guard driven by `ROUTE_POLICIES` (previously `route-policy.ts` was enforced only at test time, not at request time).
- Routes the remaining raw-`${schema}` handlers through `safeFormatQuery` / `validateSchemaOrThrow` and per-site authz: `details/cmid`, `formdownload`, `specieslimits`, `validations/validationlist`, `validations/validationerrordisplay`, and the `validations/procedures/*` family.
- `validations/procedures/*` now executes **server-owned validation definitions** instead of a client-supplied `cursorQuery` (removes an arbitrary-SQL path).
- Whitelists the `fetchall` `dataType` and escapes the table identifier.
- Requires admin at runtime on `structure/[schema]`.

## Scope — partial remediation, not full closure

This is **partial** route-authorization remediation and intentionally carries tracked debt. `lib/route-policy.ts` `UNVERIFIED_SCHEMA_ACCESS` still lists **34 site-scoped routes** that authenticate the session but do not yet enforce per-site schema ownership (e.g. `fixeddata`, `fixeddatafilter`, `bulkcrud`, `reingestsinglefailure`, `errors/explorer/*`, `changes/explorer/*`). These are injection-safe (schema shape validated) but authorization-blind. Driving that set to 0 is follow-up work tracked in `docs/security-audit-remaining-open-items.md` (included in this branch), which also lists the non-authz items still open (poolmonitor listeners, connectionmanager slot accounting, `validate-query` authz, security headers, env validation).

## Cross-PR dependency

The companion `feat/taxonomy-views` PR is based on this refactor but does **not** carry the `FETCHALL_ALLOWED_TABLES` whitelist introduced here. When this lands, `'stemtaxonomiesview'` must be added to `FETCHALL_ALLOWED_TABLES`, or the stem-taxonomies grid's `fetchall` path will be rejected.

Gates: `build:check` clean; integration 581 passed / 3 skipped.