### PR TITLE
feat(taxonomy): stem taxonomies view with datagrid and per-schema deploy script

### DIFF
--- a/frontend/app/api/fetchall/[[...slugs]]/constants.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/constants.ts
@@ -14,6 +14,7 @@ export const INVALID_DATATYPE_CODE = 'INVALID_DATATYPE';
 // `roles` is a per-site table (FK'd by personnel) served via the generic branch.
 export const FETCHALL_ALLOWED_TABLES: ReadonlySet<string> = new Set([
   'alltaxonomiesview',
+  'stemtaxonomiesview',
   'attributes',
   'coremeasurements',
   'coremeasurements_staging',

--- a/frontend/app/api/fetchall/[[...slugs]]/route.test.ts
+++ b/frontend/app/api/fetchall/[[...slugs]]/route.test.ts
@@ -325,6 +325,21 @@ describe('GET /api/fetchall/[[...slugs]]', () => {
     expect(getMapperSpy).toHaveBeenCalledWith('attributes');
   });
 
+  it('generic branch: serves stemtaxonomiesview (the stem-taxonomies grid fetchall path is whitelisted)', async () => {
+    // Regression guard for the cross-PR dependency: the stem-taxonomies datagrid loads via
+    // fetchall, so 'stemtaxonomiesview' must be in FETCHALL_ALLOWED_TABLES or the grid 400s.
+    const cm = (ConnectionManager as any).getInstance();
+    const exec = vi.spyOn(cm, 'executeQuery').mockResolvedValueOnce([{ StemGUID: 1 }]);
+
+    const req = makeRequest('myschema');
+    const res = await GET(req, makeProps(['stemtaxonomiesview', '1', '2']));
+
+    expect(res.status).toBe(HTTPResponses.OK);
+    const [sql] = exec.mock.calls[0];
+    expect(String(sql)).toContain('SELECT * FROM `myschema`.`stemtaxonomiesview`');
+    expect(getMapperSpy).toHaveBeenCalledWith('stemtaxonomiesview');
+  });
+
   it('generic branch: rejects a non-whitelisted table with 400 INVALID_DATATYPE and runs no query', async () => {
     const cm = (ConnectionManager as any).getInstance();
     const exec = vi.spyOn(cm, 'executeQuery');

--- a/frontend/app/api/fixeddata/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/fixeddata/[dataType]/[[...slugs]]/route.ts
@@ -26,6 +26,7 @@ const VALID_DATA_TYPES = [
   'quadrats',
   'personnel',
   'alltaxonomiesview',
+  'stemtaxonomiesview',
   'stems',
   'roles',
   'census'
@@ -159,6 +160,11 @@ export async function GET(
       case 'alltaxonomiesview':
         paginatedQuery = `SELECT SQL_CALC_FOUND_ROWS atv.* FROM ${schema}.${params.dataType} atv
             ORDER BY atv.SpeciesCode ASC LIMIT ?, ?;`;
+        queryParams.push(page * pageSize, pageSize);
+        break;
+      case 'stemtaxonomiesview':
+        paginatedQuery = `SELECT SQL_CALC_FOUND_ROWS stv.* FROM ${schema}.${params.dataType} stv
+            ORDER BY stv.StemTag ASC LIMIT ?, ?;`;
         queryParams.push(page * pageSize, pageSize);
         break;
       case 'stems':

--- a/frontend/app/api/fixeddatafilter/[dataType]/[[...slugs]]/route.ts
+++ b/frontend/app/api/fixeddatafilter/[dataType]/[[...slugs]]/route.ts
@@ -30,6 +30,7 @@ const ALLOWED_DATA_TYPES = [
   'species',
   'stems',
   'alltaxonomiesview',
+  'stemtaxonomiesview',
   'roles',
   'personnel',
   'unifiedchangelog',
@@ -218,6 +219,7 @@ export async function POST(
         case 'species':
         case 'stems':
         case 'alltaxonomiesview':
+        case 'stemtaxonomiesview':
         case 'roles':
           if (filterModel.quickFilterValues) searchStub = buildSearchStub(columns, filterModel.quickFilterValues);
           if (filterModel.items) filterStub = buildFilterModelStub(filterModel);

--- a/frontend/components/client/datagridcolumns.tsx
+++ b/frontend/components/client/datagridcolumns.tsx
@@ -397,13 +397,13 @@ export const StemTaxonomiesViewGridColumns: GridColDef[] = standardizeGridColumn
     flex: 1
   },
   {
-    field: 'speciesIDLevel',
+    field: 'idLevel',
     headerName: 'Species ID Level',
     renderHeader: () => formatHeader('Species', 'ID Level'),
     flex: 1
   },
   {
-    field: 'speciesFieldFamily',
+    field: 'fieldFamily',
     headerName: 'Species Field Family',
     renderHeader: () => formatHeader('Species', 'Field Family'),
     flex: 1
@@ -1391,7 +1391,7 @@ export const AllTaxonomiesViewGridColumns: GridColDef[] = standardizeGridColumns
     editable: true
   },
   {
-    field: 'speciesDescription',
+    field: 'description',
     headerName: 'Species Description',
     renderHeader: () => formatHeader('Species', 'Description'),
     flex: 1,

--- a/frontend/components/datagrids/applications/isolated/isolatedalltaxonomiesdatagrid.tsx
+++ b/frontend/components/datagrids/applications/isolated/isolatedalltaxonomiesdatagrid.tsx
@@ -146,7 +146,7 @@ export default function IsolatedAllTaxonomiesViewDataGrid() {
         clusters={{
           Family: ['family'],
           Genus: ['genus', 'genusAuthority'],
-          Species: ['speciesCode', 'speciesName', 'speciesIDLevel', 'speciesAuthority', 'fieldFamily', 'validCode', 'speciesDescription'],
+          Species: ['speciesCode', 'speciesName', 'idLevel', 'speciesAuthority', 'fieldFamily', 'validCode', 'description'],
           Subspecies: ['subspeciesName', 'subspeciesAuthority']
         }}
         dynamicButtons={[

--- a/frontend/components/datagrids/applications/isolated/isolatedstemtaxonomiesviewdatagrid.tsx
+++ b/frontend/components/datagrids/applications/isolated/isolatedstemtaxonomiesviewdatagrid.tsx
@@ -60,7 +60,7 @@ export default function IsolatedStemTaxonomiesViewDataGrid() {
           Tree: ['treeTag'],
           Family: ['family'],
           Genus: ['genus', 'genusAuthority'],
-          Species: ['speciesCode', 'speciesName', 'validCode', 'speciesAuthority', 'speciesIDLevel', 'speciesFieldFamily'],
+          Species: ['speciesCode', 'speciesName', 'validCode', 'speciesAuthority', 'idLevel', 'fieldFamily'],
           Subspecies: ['subspeciesName', 'subspeciesAuthority']
         }}
         dynamicButtons={[

--- a/frontend/components/datagrids/isolateddatagridcommons.test.tsx
+++ b/frontend/components/datagrids/isolateddatagridcommons.test.tsx
@@ -16,7 +16,8 @@ const UPDATED_TEST_SP_CODE = 'TEST_SP_CODE_B';
 vi.mock('@/lib/db/definitions/views', () => ({
   getAllTaxonomiesViewHCs: () => ({}),
   getAllViewFullTableViewsHCs: () => ({}),
-  getMeasurementsSummaryViewHCs: () => ({})
+  getMeasurementsSummaryViewHCs: () => ({}),
+  getStemTaxonomiesViewHCs: () => ({})
 }));
 
 vi.mock('@/lib/db/definitions/zones', () => ({
@@ -160,6 +161,7 @@ vi.mock('@/config/styleddatagrid', async () => {
         <div data-testid="pagination-slot-present">{String(Boolean(props.slots?.pagination))}</div>
         <div data-testid="infinite-scroll-enabled">{String(Boolean(props.slots?.pagination?.infiniteScroll?.enabled))}</div>
         <div data-testid="infinite-scroll-prop-present">{String(Boolean(props.slots?.pagination?.infiniteScroll))}</div>
+        <div data-testid="export-csv-handler-present">{String(typeof props.slotProps?.toolbar?.handleExportCSV === 'function')}</div>
         <button type="button" onClick={() => props.slots?.pagination?.infiniteScroll?.onToggle?.(true)}>
           Test Toggle Infinite On
         </button>
@@ -613,5 +615,53 @@ describe('IsolatedDataGridCommons', () => {
     await waitFor(() => {
       expect(screen.getByTestId('infinite-scroll-enabled').textContent).toBe('false');
     });
+  });
+
+  it('omits the CSV export handler for stemtaxonomiesview (no formdownload endpoint) but provides it for a grid that can export', async () => {
+    // The toolbar renders its "Export as CSV" button only when handleExportCSV is a function
+    // (datagridelements hasAnyExport). exportAllCSV has no stemtaxonomiesview case, so passing the
+    // handler would surface a button that silently no-ops. This asserts the handler is withheld.
+    const row = { id: 1, speciesID: 1, spCode: ORIGINAL_TEST_SP_CODE };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ output: [row], totalCount: 1, finishedQuery: 'SELECT 1' })
+    } as Response);
+
+    const gridColumns = [
+      { field: 'id', editable: false },
+      { field: 'spCode', editable: true }
+    ];
+
+    // Control: alltaxonomiesview has a real export path (species formdownload), so the handler is passed.
+    const { unmount } = render(
+      <SWRConfig value={{ provider: () => new Map(), revalidateOnFocus: false, dedupingInterval: 0 }}>
+        <IsolatedDataGridCommons
+          gridType="alltaxonomiesview"
+          gridColumns={gridColumns}
+          refresh={false}
+          setRefresh={vi.fn()}
+          dynamicButtons={[]}
+          initialRow={row}
+        />
+      </SWRConfig>
+    );
+    await waitFor(() => expect(screen.getByTestId('row-state').textContent).toContain(ORIGINAL_TEST_SP_CODE));
+    expect(screen.getByTestId('export-csv-handler-present').textContent).toBe('true');
+    unmount();
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), revalidateOnFocus: false, dedupingInterval: 0 }}>
+        <IsolatedDataGridCommons
+          gridType="stemtaxonomiesview"
+          gridColumns={gridColumns}
+          refresh={false}
+          setRefresh={vi.fn()}
+          dynamicButtons={[]}
+          initialRow={row}
+        />
+      </SWRConfig>
+    );
+    await waitFor(() => expect(screen.getByTestId('row-state').textContent).toContain(ORIGINAL_TEST_SP_CODE));
+    expect(screen.getByTestId('export-csv-handler-present').textContent).toBe('false');
   });
 });

--- a/frontend/components/datagrids/isolateddatagridcommons.tsx
+++ b/frontend/components/datagrids/isolateddatagridcommons.tsx
@@ -1259,7 +1259,7 @@ const IsolatedDataGridCommonsInner = forwardRef(function IsolatedDataGridCommons
   }, [gridRows, columns, hidingEmpty]);
 
   // Grid types under "Stem & Plot Details" that don't require a census selection
-  const censusIndependentGridTypes = ['attributes', 'personnel', 'quadrats', 'alltaxonomiesview'];
+  const censusIndependentGridTypes = ['attributes', 'personnel', 'quadrats', 'alltaxonomiesview', 'stemtaxonomiesview'];
   const requiresCensus = !censusIndependentGridTypes.includes(gridType);
 
   const pageSizeOptions = useMemo(() => [paginationModel.pageSize, paginationModel.pageSize * 5, paginationModel.pageSize * 10], [paginationModel.pageSize]);
@@ -1305,8 +1305,10 @@ const IsolatedDataGridCommonsInner = forwardRef(function IsolatedDataGridCommons
       toolbar: {
         handleAddNewRow,
         handleRefresh,
-        handleExportAll: fetchFullData,
-        handleExportCSV: exportAllCSV,
+        // stemtaxonomiesview has no formdownload endpoint, so exportAllCSV would fall through and no-op.
+        // Omit the export handlers for it so the toolbar hides the button instead of showing a dead one.
+        handleExportAll: gridType === 'stemtaxonomiesview' ? undefined : fetchFullData,
+        handleExportCSV: gridType === 'stemtaxonomiesview' ? undefined : exportAllCSV,
         handleQuickFilterChange: onQuickFilterChange,
         filterModel: gridFilterModel,
         dynamicButtons,

--- a/frontend/components/errors/errorsexplorer.test.tsx
+++ b/frontend/components/errors/errorsexplorer.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The row-edit flow drives beginEdit/UndoToast through an async chain
+// (__triggerRowUpdate -> processRowUpdate -> flow.beginEdit). Under CI load that
+// chain can exceed waitFor's 1000ms default, causing intermittent "spy called 0
+// times" timeouts. Give async assertions in this file a wider margin; it only
+// lengthens the polling window and never affects a passing assertion.
+configure({ asyncUtilTimeout: 5000 });
 
 import { getUploadedCodesValue, hasCodesMismatch, joinCodesArray, parseCodesString } from './errorsexplorer';
 import type { EditPlan } from '@/config/editplan/types';

--- a/frontend/config/datagridhelpers.ts
+++ b/frontend/config/datagridhelpers.ts
@@ -1,5 +1,5 @@
 import { getQuadratHCs, Plot, Site } from '@/lib/db/definitions/zones';
-import { getAllTaxonomiesViewHCs, getAllViewFullTableViewsHCs, getMeasurementsSummaryViewHCs } from '@/lib/db/definitions/views';
+import { getAllTaxonomiesViewHCs, getAllViewFullTableViewsHCs, getMeasurementsSummaryViewHCs, getStemTaxonomiesViewHCs } from '@/lib/db/definitions/views';
 import { getPersonnelHCs } from '@/lib/db/definitions/personnel';
 import { getCoreMeasurementsHCs, getFailedMeasurementsHCs } from '@/lib/db/definitions/core';
 import { GridColDef, GridFilterModel, GridRowId, GridRowModel, GridRowModesModel, GridRowsProp, GridSortDirection } from '@mui/x-data-grid';
@@ -41,6 +41,10 @@ const columnVisibilityMap: Record<string, Record<string, boolean>> = {
   alltaxonomiesview: {
     id: false,
     ...getAllTaxonomiesViewHCs()
+  },
+  stemtaxonomiesview: {
+    id: false,
+    ...getStemTaxonomiesViewHCs()
   },
   species: {
     id: false,

--- a/frontend/config/datamapper.ts
+++ b/frontend/config/datamapper.ts
@@ -27,6 +27,8 @@ import {
   AllTaxonomiesViewResult,
   MeasurementsSummaryRDS,
   MeasurementsSummaryResult,
+  StemTaxonomiesViewRDS,
+  StemTaxonomiesViewResult,
   ViewFullTableRDS,
   ViewFullTableResult
 } from '@/lib/db/definitions/views';
@@ -226,6 +228,8 @@ class MapperFactory {
       // tables
       case 'alltaxonomiesview':
         return new GenericMapper<AllTaxonomiesViewRDS, AllTaxonomiesViewResult>() as unknown as IDataMapper<RDS, Result>;
+      case 'stemtaxonomiesview':
+        return new GenericMapper<StemTaxonomiesViewRDS, StemTaxonomiesViewResult>() as unknown as IDataMapper<RDS, Result>;
       case 'attributes':
         return new GenericMapper<AttributesRDS, AttributesResult>() as unknown as IDataMapper<RDS, Result>;
       case 'census':

--- a/frontend/config/macros/coreapifunctions.ts
+++ b/frontend/config/macros/coreapifunctions.ts
@@ -24,6 +24,7 @@ const PRIMARY_KEY_MAP: Record<string, string> = {
   quadrats: 'QuadratID',
   species: 'SpeciesID',
   stems: 'StemGUID',
+  stemtaxonomiesview: 'StemGUID',
   trees: 'TreeID',
   rolemapping: 'RoleMappingID',
   roles: 'RoleID',

--- a/frontend/config/servergridhelpers.ts
+++ b/frontend/config/servergridhelpers.ts
@@ -37,6 +37,8 @@ export function getGridID(gridType: string): string {
     case 'alltaxonomiesview':
     case 'species':
       return 'speciesID';
+    case 'stemtaxonomiesview':
+      return 'stemGUID';
     case 'specieslimits':
       return 'speciesLimitID';
     case 'sitespecificvalidations':

--- a/frontend/db/sql/tablestructures.sql
+++ b/frontend/db/sql/tablestructures.sql
@@ -1322,3 +1322,57 @@ SELECT
 FROM uploadmetrics um
 WHERE um.status IN ('completed', 'failed')
   AND um.missingRecords > 0;
+
+-- Flattens the species/genus/family taxonomy hierarchy into one row per species.
+-- Backs the alltaxonomies datagrid (DatagridType.alltaxonomiesview) and its upload
+-- review step. Column names mirror the base tables so GenericMapper maps them
+-- directly. LEFT JOINs keep a species visible even if its genus/family is missing.
+CREATE OR REPLACE VIEW alltaxonomiesview AS
+SELECT s.SpeciesID           AS SpeciesID,
+       f.FamilyID            AS FamilyID,
+       g.GenusID             AS GenusID,
+       f.Family              AS Family,
+       g.Genus               AS Genus,
+       g.GenusAuthority      AS GenusAuthority,
+       s.SpeciesCode         AS SpeciesCode,
+       s.SpeciesName         AS SpeciesName,
+       s.SubspeciesName      AS SubspeciesName,
+       s.IDLevel             AS IDLevel,
+       s.SpeciesAuthority    AS SpeciesAuthority,
+       s.SubspeciesAuthority AS SubspeciesAuthority,
+       s.ValidCode           AS ValidCode,
+       s.FieldFamily         AS FieldFamily,
+       s.Description         AS Description
+FROM species s
+         LEFT JOIN genus g ON s.GenusID = g.GenusID AND g.IsActive IS TRUE
+         LEFT JOIN family f ON g.FamilyID = f.FamilyID AND f.IsActive IS TRUE
+WHERE s.IsActive IS TRUE;
+
+-- Resolves each active stem to its full taxonomy via its tree's species.
+-- Backs the stemtaxonomies datagrid (DatagridType.stemtaxonomiesview).
+CREATE OR REPLACE VIEW stemtaxonomiesview AS
+SELECT st.StemGUID           AS StemGUID,
+       t.TreeID              AS TreeID,
+       s.SpeciesID           AS SpeciesID,
+       g.GenusID             AS GenusID,
+       f.FamilyID            AS FamilyID,
+       st.QuadratID          AS QuadratID,
+       st.StemTag            AS StemTag,
+       t.TreeTag             AS TreeTag,
+       s.SpeciesCode         AS SpeciesCode,
+       f.Family              AS Family,
+       g.Genus               AS Genus,
+       s.SpeciesName         AS SpeciesName,
+       s.SubspeciesName      AS SubspeciesName,
+       s.ValidCode           AS ValidCode,
+       g.GenusAuthority      AS GenusAuthority,
+       s.SpeciesAuthority    AS SpeciesAuthority,
+       s.SubspeciesAuthority AS SubspeciesAuthority,
+       s.IDLevel             AS IDLevel,
+       s.FieldFamily         AS FieldFamily
+FROM stems st
+         JOIN trees t ON st.TreeID = t.TreeID AND t.IsActive IS TRUE
+         JOIN species s ON t.SpeciesID = s.SpeciesID AND s.IsActive IS TRUE
+         LEFT JOIN genus g ON s.GenusID = g.GenusID AND g.IsActive IS TRUE
+         LEFT JOIN family f ON g.FamilyID = f.FamilyID AND f.IsActive IS TRUE
+WHERE st.IsActive IS TRUE;

--- a/frontend/lib/db/definitions/views.ts
+++ b/frontend/lib/db/definitions/views.ts
@@ -114,6 +114,19 @@ export interface StemTaxonomiesViewRDS {
   fieldFamily?: string;
 }
 
+export type StemTaxonomiesViewResult = ResultType<StemTaxonomiesViewRDS>;
+
+export function getStemTaxonomiesViewHCs(): ColumnStates {
+  return {
+    stemGUID: false,
+    treeID: false,
+    speciesID: false,
+    genusID: false,
+    familyID: false,
+    quadratID: false
+  };
+}
+
 export interface ViewFullTableRDS {
   id?: number;
   coreMeasurementID?: number;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "stress:workshop:smoke": "node tests/stress/workshop-stress.mjs --duration=15s --vus-per-site=1 --max-sites=2 --min-sites=1 --profile=smoke",
     "db:seed:e2e": "npx tsx tests/setup/e2e-seed.ts",
     "deploy:validations": "npx tsx scripts/deploy-validations-to-all-schemas.ts",
+    "deploy:taxonomy-views": "npx tsx scripts/deploy-taxonomy-views-to-all-schemas.ts",
     "docs": "npm run dev --prefix docs",
     "docs:build": "npm run build --prefix docs",
     "docs:preview": "npm run preview --prefix docs",

--- a/frontend/scripts/deploy-taxonomy-views-to-all-schemas.ts
+++ b/frontend/scripts/deploy-taxonomy-views-to-all-schemas.ts
@@ -1,0 +1,195 @@
+/**
+ * Backfill the taxonomy views (alltaxonomiesview, stemtaxonomiesview) into all
+ * existing ForestGEO site schemas.
+ *
+ * These views back the alltaxonomies / stemtaxonomies datagrids. They are defined
+ * in db/sql/tablestructures.sql, so any site provisioned AFTER that file
+ * gained them is fine. Sites provisioned earlier (or restored from a legacy
+ * CTFSweb dump with a differently-shaped view) are missing the current
+ * definition, which makes the species viewer fail with "error fetching data".
+ *
+ * The operation is non-destructive: it runs CREATE OR REPLACE VIEW only. It does
+ * NOT drop, truncate, or reprovision anything. Schemas that lack the base
+ * tables required by the views (species/genus/family/trees/stems) — e.g. the
+ * catalog schema or legacy CTFS-format exports — are skipped.
+ *
+ * The view DDL is read from tablestructures.sql so this script and provisioning
+ * stay in lockstep (single source of truth).
+ *
+ * Usage: npx tsx scripts/deploy-taxonomy-views-to-all-schemas.ts
+ */
+
+import mysql from 'mysql2/promise';
+import fs from 'fs';
+import path from 'path';
+
+const AZURE_HOST = 'forestgeo-mysqldataserver.mysql.database.azure.com';
+const AZURE_USER = 'azureroot';
+const AZURE_PORT = 3306;
+
+const TAXONOMY_VIEWS = ['alltaxonomiesview', 'stemtaxonomiesview'] as const;
+const REQUIRED_BASE_TABLES = ['species', 'genus', 'family', 'trees', 'stems'] as const;
+
+interface SchemaResult {
+  schema: string;
+  status: 'deployed' | 'skipped' | 'failed';
+  detail: string;
+}
+
+/**
+ * Extract the `CREATE OR REPLACE VIEW <name> ... ;` statement for each taxonomy
+ * view from tablestructures.sql. The view bodies contain no inner semicolons, so
+ * a non-greedy match up to the first `;` captures exactly one statement.
+ */
+function extractViewStatements(tablestructuresSQL: string): Map<string, string> {
+  const statements = new Map<string, string>();
+  for (const viewName of TAXONOMY_VIEWS) {
+    const pattern = new RegExp(`CREATE\\s+OR\\s+REPLACE\\s+VIEW\\s+${viewName}\\b[\\s\\S]*?;`, 'i');
+    const match = tablestructuresSQL.match(pattern);
+    if (!match) {
+      throw new Error(`Could not find CREATE OR REPLACE VIEW ${viewName} in tablestructures.sql`);
+    }
+    statements.set(viewName, match[0]);
+  }
+  return statements;
+}
+
+async function hasRequiredBaseTables(conn: mysql.Connection, schema: string): Promise<{ ready: boolean; missing: string[] }> {
+  const [rows] = await conn.query<mysql.RowDataPacket[]>(
+    `SELECT TABLE_NAME as table_name
+     FROM INFORMATION_SCHEMA.TABLES
+     WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME IN (?)`,
+    [schema, [...REQUIRED_BASE_TABLES]]
+  );
+  const found = new Set(rows.map((r: any) => r.table_name));
+  const missing = REQUIRED_BASE_TABLES.filter(t => !found.has(t));
+  return { ready: missing.length === 0, missing };
+}
+
+async function deployTaxonomyViewsToAllSchemas() {
+  console.log('Backfilling taxonomy views into all ForestGEO schemas...\n');
+
+  if (!process.env.AZURE_SQL_PASSWORD) {
+    console.error('Error: AZURE_SQL_PASSWORD environment variable not set');
+    console.error('Please set the password in your environment or .env.local file');
+    process.exit(1);
+  }
+
+  const azurePassword = process.env.AZURE_SQL_PASSWORD;
+
+  const scriptingDir = path.join(process.cwd(), 'db/sql');
+  const tablestructuresPath = path.join(scriptingDir, 'tablestructures.sql');
+  if (!fs.existsSync(tablestructuresPath)) {
+    throw new Error(`tablestructures.sql not found at: ${tablestructuresPath}`);
+  }
+  const viewStatements = extractViewStatements(fs.readFileSync(tablestructuresPath, 'utf8'));
+  console.log(`Loaded ${viewStatements.size} view definitions from tablestructures.sql:`);
+  for (const name of viewStatements.keys()) console.log(`  - ${name}`);
+  console.log();
+
+  const discoveryConnection = await mysql.createConnection({
+    host: AZURE_HOST,
+    user: AZURE_USER,
+    password: azurePassword,
+    port: AZURE_PORT,
+    multipleStatements: false
+  });
+
+  try {
+    console.log('[Step 1] Finding all ForestGEO schemas...');
+    const [schemas] = await discoveryConnection.query<mysql.RowDataPacket[]>(
+      `SELECT SCHEMA_NAME as schema_name
+       FROM INFORMATION_SCHEMA.SCHEMATA
+       WHERE SCHEMA_NAME LIKE 'forestgeo_%'
+       ORDER BY SCHEMA_NAME`
+    );
+
+    if (schemas.length === 0) {
+      console.log('No forestgeo_* schemas found!');
+      return;
+    }
+
+    console.log(`Found ${schemas.length} ForestGEO schemas.\n`);
+    console.log('[Step 2] Applying views to each schema that has base taxonomy tables...\n');
+
+    const results: SchemaResult[] = [];
+
+    for (const row of schemas) {
+      const schema = (row as any).schema_name;
+      console.log(`Processing: ${schema}`);
+
+      try {
+        const { ready, missing } = await hasRequiredBaseTables(discoveryConnection, schema);
+        if (!ready) {
+          const detail = `Missing base tables: ${missing.join(', ')}. Not a provisioned site schema — skipped.`;
+          console.log(`  SKIPPED - ${detail}`);
+          results.push({ schema, status: 'skipped', detail });
+          console.log();
+          continue;
+        }
+
+        const schemaConnection = await mysql.createConnection({
+          host: AZURE_HOST,
+          user: AZURE_USER,
+          password: azurePassword,
+          database: schema,
+          port: AZURE_PORT,
+          multipleStatements: false
+        });
+
+        try {
+          for (const [name, stmt] of viewStatements) {
+            await schemaConnection.query(stmt);
+            console.log(`  ${name} applied`);
+          }
+        } finally {
+          await schemaConnection.end();
+        }
+
+        results.push({ schema, status: 'deployed', detail: `${viewStatements.size} views applied` });
+      } catch (error: any) {
+        console.log(`  FAILED: ${error.message}`);
+        results.push({ schema, status: 'failed', detail: error.message });
+      }
+
+      console.log();
+    }
+
+    console.log('═══════════════════════════════════════════════════');
+    console.log('Backfill Summary');
+    console.log('═══════════════════════════════════════════════════');
+
+    const deployed = results.filter(r => r.status === 'deployed');
+    const skipped = results.filter(r => r.status === 'skipped');
+    const failed = results.filter(r => r.status === 'failed');
+
+    console.log(`Total schemas:  ${schemas.length}`);
+    console.log(`Deployed:       ${deployed.length}`);
+    console.log(`Skipped:        ${skipped.length} (no base taxonomy tables)`);
+    console.log(`Failed:         ${failed.length}`);
+    console.log();
+
+    if (failed.length > 0) {
+      console.log('Failed:');
+      failed.forEach(r => console.log(`  x ${r.schema}: ${r.detail}`));
+      process.exit(1);
+    }
+
+    console.log('Taxonomy views backfilled successfully!');
+  } catch (error: any) {
+    console.error('Fatal error:', error.message);
+    throw error;
+  } finally {
+    await discoveryConnection.end();
+  }
+}
+
+deployTaxonomyViewsToAllSchemas()
+  .then(() => {
+    console.log('\nBackfill complete!');
+    process.exit(0);
+  })
+  .catch(error => {
+    console.error('\nBackfill failed:', error);
+    process.exit(1);
+  });

--- a/frontend/tests/integration/admin-provision/taxonomy-views.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/taxonomy-views.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression test: provisioning must create the taxonomy views.
+ *
+ * The alltaxonomies / stemtaxonomies datagrids (and the species-upload review
+ * step) read from the SQL views `alltaxonomiesview` and `stemtaxonomiesview`,
+ * NOT from the base tables. For a long time those views were defined only in a
+ * commented-out mysqldump placeholder and in an empty `updatedviews.sql` stub —
+ * no provisioning script created them. Result: any app-provisioned site was
+ * missing the views, so the species viewer failed with "error fetching data"
+ * and rendered an empty grid even though the upload had populated the base
+ * `species`/`genus`/`family` tables.
+ *
+ * This test provisions a fresh schema through the real `initTablesStep.run`
+ * (which runs tablestructures.sql via executeSqlFile — the production path) and
+ * proves the views exist and return the flattened taxonomy the mapper expects.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import type { Pool, RowDataPacket } from 'mysql2/promise';
+import { createTestPool, TEST_SCHEMA_PREFIX } from './_shared';
+
+vi.mock('@/ailogger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { initTablesStep } from '@/lib/provisioning/steps/sql-steps';
+import MapperFactory from '@/config/datamapper';
+import type { StepContext, ProvisioningInput } from '@/lib/provisioning/types';
+
+const TEST_SCHEMA = TEST_SCHEMA_PREFIX + 'taxviews';
+
+// Column set the alltaxonomies datagrid mapper consumes (PascalCase DB columns
+// that GenericMapper decapitalizes into AllTaxonomiesViewRDS fields).
+const EXPECTED_ALLTAXONOMIES_COLUMNS = [
+  'SpeciesID',
+  'FamilyID',
+  'GenusID',
+  'Family',
+  'Genus',
+  'GenusAuthority',
+  'SpeciesCode',
+  'SpeciesName',
+  'SubspeciesName',
+  'IDLevel',
+  'SpeciesAuthority',
+  'SubspeciesAuthority',
+  'ValidCode',
+  'FieldFamily',
+  'Description'
+] as const;
+
+const EXPECTED_STEMTAXONOMIES_COLUMNS = [
+  'StemGUID',
+  'TreeID',
+  'SpeciesID',
+  'GenusID',
+  'FamilyID',
+  'QuadratID',
+  'StemTag',
+  'TreeTag',
+  'SpeciesCode',
+  'Family',
+  'Genus',
+  'SpeciesName',
+  'SubspeciesName',
+  'ValidCode',
+  'GenusAuthority',
+  'SpeciesAuthority',
+  'SubspeciesAuthority',
+  'IDLevel',
+  'FieldFamily'
+] as const;
+
+describe('provisioning creates taxonomy views', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = createTestPool();
+  });
+
+  beforeEach(async () => {
+    await pool.query(`DROP DATABASE IF EXISTS \`${TEST_SCHEMA}\``);
+    await pool.query(`CREATE DATABASE \`${TEST_SCHEMA}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci`);
+  });
+
+  afterAll(async () => {
+    await pool.query(`DROP DATABASE IF EXISTS \`${TEST_SCHEMA}\``);
+    await pool.end();
+  });
+
+  function buildCtx(): StepContext {
+    return {
+      runId: 0,
+      schemaName: TEST_SCHEMA,
+      input: {} as ProvisioningInput,
+      catalogPool: pool,
+      sitePool: pool,
+      state: {},
+      logger: { info: () => {}, error: () => {} }
+    };
+  }
+
+  async function listViews(): Promise<Set<string>> {
+    const [rows] = await pool.query<RowDataPacket[]>(`SELECT TABLE_NAME AS name FROM information_schema.VIEWS WHERE TABLE_SCHEMA = ?`, [TEST_SCHEMA]);
+    return new Set(rows.map(r => String(r.name)));
+  }
+
+  async function viewColumns(viewName: string): Promise<string[]> {
+    const [rows] = await pool.query<RowDataPacket[]>(
+      `SELECT COLUMN_NAME AS name FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION`,
+      [TEST_SCHEMA, viewName]
+    );
+    return rows.map(r => String(r.name));
+  }
+
+  it('creates both alltaxonomiesview and stemtaxonomiesview', async () => {
+    await initTablesStep.run(buildCtx());
+    const views = await listViews();
+    expect(views.has('alltaxonomiesview')).toBe(true);
+    expect(views.has('stemtaxonomiesview')).toBe(true);
+  });
+
+  it('alltaxonomiesview exposes exactly the columns the datagrid mapper reads', async () => {
+    await initTablesStep.run(buildCtx());
+    expect(await viewColumns('alltaxonomiesview')).toEqual([...EXPECTED_ALLTAXONOMIES_COLUMNS]);
+  });
+
+  it('stemtaxonomiesview exposes exactly the columns the datagrid mapper reads', async () => {
+    await initTablesStep.run(buildCtx());
+    expect(await viewColumns('stemtaxonomiesview')).toEqual([...EXPECTED_STEMTAXONOMIES_COLUMNS]);
+  });
+
+  it('alltaxonomiesview flattens species -> genus -> family for uploaded species', async () => {
+    await initTablesStep.run(buildCtx());
+
+    // Mirror the first two rows of a real species upload (CBFDP_SPECIES.csv):
+    // spcode,family,genus,species,idlevel,authority
+    await pool.query(`INSERT INTO \`${TEST_SCHEMA}\`.family (Family) VALUES ('Lamiaceae'), ('Juglandaceae')`);
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.genus (Genus, FamilyID)
+       VALUES ('Callicarpa', (SELECT FamilyID FROM \`${TEST_SCHEMA}\`.family WHERE Family = 'Lamiaceae')),
+              ('Carya',      (SELECT FamilyID FROM \`${TEST_SCHEMA}\`.family WHERE Family = 'Juglandaceae'))`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.species (GenusID, SpeciesCode, SpeciesName, IDLevel, SpeciesAuthority)
+       VALUES ((SELECT GenusID FROM \`${TEST_SCHEMA}\`.genus WHERE Genus = 'Callicarpa'), 'CALAME', 'americana', 'species', 'L.'),
+              ((SELECT GenusID FROM \`${TEST_SCHEMA}\`.genus WHERE Genus = 'Carya'),      'CARTEX', 'texana',    'species', 'Buckley')`
+    );
+
+    // Exact query the fixeddata route runs for the alltaxonomiesview grid.
+    const [rows] = await pool.query<RowDataPacket[]>(
+      `SELECT SQL_CALC_FOUND_ROWS atv.* FROM \`${TEST_SCHEMA}\`.alltaxonomiesview atv ORDER BY atv.SpeciesCode ASC LIMIT 0, 10`
+    );
+    const [countRows] = await pool.query<RowDataPacket[]>(`SELECT FOUND_ROWS() AS totalRows`);
+
+    expect(Number(countRows[0].totalRows)).toBe(2);
+    expect(rows).toHaveLength(2);
+
+    const calame = rows.find(r => r.SpeciesCode === 'CALAME');
+    expect(calame).toBeDefined();
+    expect(calame!.Genus).toBe('Callicarpa');
+    expect(calame!.Family).toBe('Lamiaceae');
+    expect(calame!.SpeciesName).toBe('americana');
+    expect(calame!.SpeciesAuthority).toBe('L.');
+    expect(calame!.IDLevel).toBe('species');
+
+    const mapped = MapperFactory.getMapper<any, any>('alltaxonomiesview').mapData(rows);
+    expect(mapped.find(row => row.speciesCode === 'CALAME')).toMatchObject({
+      genus: 'Callicarpa',
+      family: 'Lamiaceae',
+      speciesName: 'americana',
+      speciesAuthority: 'L.',
+      idLevel: 'species'
+    });
+  });
+
+  it('stemtaxonomiesview flattens active stem -> tree -> species taxonomy into mapped rows', async () => {
+    await initTablesStep.run(buildCtx());
+
+    await pool.query(`INSERT INTO \`${TEST_SCHEMA}\`.family (Family) VALUES ('Fabaceae')`);
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.genus (Genus, FamilyID, GenusAuthority)
+       VALUES ('Inga', (SELECT FamilyID FROM \`${TEST_SCHEMA}\`.family WHERE Family = 'Fabaceae'), 'Mill.')`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.species (GenusID, SpeciesCode, SpeciesName, IDLevel, SpeciesAuthority, ValidCode, FieldFamily)
+       VALUES (
+         (SELECT GenusID FROM \`${TEST_SCHEMA}\`.genus WHERE Genus = 'Inga'),
+         'INGSPP',
+         'spuria',
+         'species',
+         'Humb.',
+         'INGSPP',
+         'FieldFabaceae'
+       )`
+    );
+    await pool.query(`INSERT INTO \`${TEST_SCHEMA}\`.plots (PlotName) VALUES ('Taxonomy View Test Plot')`);
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.census (PlotID, PlotCensusNumber, StartDate, EndDate)
+       VALUES ((SELECT PlotID FROM \`${TEST_SCHEMA}\`.plots WHERE PlotName = 'Taxonomy View Test Plot'), 1, '2024-01-01', '2024-12-31')`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.quadrats (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area)
+       VALUES ((SELECT PlotID FROM \`${TEST_SCHEMA}\`.plots WHERE PlotName = 'Taxonomy View Test Plot'), '0001', 0, 0, 20, 20, 400)`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.trees (TreeTag, SpeciesID, CensusID)
+       VALUES (
+         'T-001',
+         (SELECT SpeciesID FROM \`${TEST_SCHEMA}\`.species WHERE SpeciesCode = 'INGSPP'),
+         (SELECT CensusID FROM \`${TEST_SCHEMA}\`.census WHERE PlotCensusNumber = 1)
+       )`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.stems (TreeID, QuadratID, CensusID, StemTag, LocalX, LocalY)
+       VALUES (
+         (SELECT TreeID FROM \`${TEST_SCHEMA}\`.trees WHERE TreeTag = 'T-001'),
+         (SELECT QuadratID FROM \`${TEST_SCHEMA}\`.quadrats WHERE QuadratName = '0001'),
+         (SELECT CensusID FROM \`${TEST_SCHEMA}\`.census WHERE PlotCensusNumber = 1),
+         '1',
+         10.5,
+         11.5
+       )`
+    );
+
+    // Exact query the fixeddata route runs for the stemtaxonomiesview grid.
+    const [rows] = await pool.query<RowDataPacket[]>(
+      `SELECT SQL_CALC_FOUND_ROWS stv.* FROM \`${TEST_SCHEMA}\`.stemtaxonomiesview stv ORDER BY stv.StemTag ASC LIMIT 0, 10`
+    );
+    const [countRows] = await pool.query<RowDataPacket[]>(`SELECT FOUND_ROWS() AS totalRows`);
+
+    expect(Number(countRows[0].totalRows)).toBe(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      StemTag: '1',
+      TreeTag: 'T-001',
+      SpeciesCode: 'INGSPP',
+      Family: 'Fabaceae',
+      Genus: 'Inga',
+      IDLevel: 'species',
+      FieldFamily: 'FieldFabaceae'
+    });
+
+    const mapped = MapperFactory.getMapper<any, any>('stemtaxonomiesview').mapData(rows);
+    expect(mapped[0]).toMatchObject({
+      stemTag: '1',
+      treeTag: 'T-001',
+      speciesCode: 'INGSPP',
+      family: 'Fabaceae',
+      genus: 'Inga',
+      idLevel: 'species',
+      fieldFamily: 'FieldFabaceae'
+    });
+  });
+
+  it('alltaxonomiesview hides soft-deleted species (IsActive = 0)', async () => {
+    await initTablesStep.run(buildCtx());
+    await pool.query(`INSERT INTO \`${TEST_SCHEMA}\`.family (Family) VALUES ('Fabaceae')`);
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.genus (Genus, FamilyID) VALUES ('Inga', (SELECT FamilyID FROM \`${TEST_SCHEMA}\`.family WHERE Family = 'Fabaceae'))`
+    );
+    await pool.query(
+      `INSERT INTO \`${TEST_SCHEMA}\`.species (GenusID, SpeciesCode, SpeciesName, IsActive)
+       VALUES ((SELECT GenusID FROM \`${TEST_SCHEMA}\`.genus WHERE Genus = 'Inga'), 'INGSPP', 'spuria', 0)`
+    );
+
+    const [rows] = await pool.query<RowDataPacket[]>(`SELECT * FROM \`${TEST_SCHEMA}\`.alltaxonomiesview WHERE SpeciesCode = 'INGSPP'`);
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **stem taxonomies view** (`stemtaxonomiesview`) end to end, on the post-refactor `lib/db/` + `db/sql/` layout.

- `StemTaxonomiesView` definition (`lib/db/definitions/views.ts`) + `CREATE OR REPLACE VIEW` DDL in `db/sql/tablestructures.sql`.
- `MapperFactory` + grid-id / primary-key wiring and the isolated stem-taxonomies datagrid.
- `fixeddata` / `fixeddatafilter` query support (their own inline allow-lists).
- `deploy-taxonomy-views-to-all-schemas` backfill script (reads DDL from `db/sql/tablestructures.sql`) with provisioning integration coverage (6 tests).

## Review fix included

- **Export button no-op (P2):** the shared grid always passed `handleExportCSV`, but `exportAllCSV` had no `stemtaxonomiesview` case, so "Export as CSV" appeared and silently did nothing. This grid has no `formdownload` endpoint, so the export handlers are now omitted for it and the toolbar hides the button. Added a regression test asserting the handler is provided for an exporting grid and withheld for `stemtaxonomiesview`.

## Cross-PR dependency

Based on `forestgeo-app-development`, which does not yet carry the `FETCHALL_ALLOWED_TABLES` whitelist from the `security/route-authz-remediation` PR (#343). When #343 lands, `'stemtaxonomiesview'` must be added to `FETCHALL_ALLOWED_TABLES` or this grid's `fetchall` path will be rejected. (Recommend landing #343 first, then adding that one line here.)

Gates: `build:check` clean; taxonomy-views integration 6/6; datagrid unit 8/8.