### PR TITLE
fix(upload): quadrat placeholder duplication + taxonomy species-name drop

### DIFF
--- a/frontend/app/(hub)/admin/provision/page.tsx
+++ b/frontend/app/(hub)/admin/provision/page.tsx
@@ -83,6 +83,10 @@ function quadratLayoutIsValid(input: ProvisioningInput): boolean {
     }
   }
 
+  if (input.quadrats.mode === 'none') {
+    return true;
+  }
+
   const rows = input.quadrats.rows;
   if (rows.length === 0) return false;
   for (const row of rows) {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -877,6 +877,40 @@ describe('sqlpacketload fixed-data upload modes', () => {
     expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM forestgeo_testing.stems');
   });
 
+  it('allows a revisions upload to add a new quadrat to a real layout', async () => {
+    mockConnectionManager.executeQuery
+      // 1: divergent-placeholder preflight sees a real layout, not Q##### placeholders
+      .mockResolvedValueOnce([{ QuadratName: 'C01' }, { QuadratName: 'D01' }])
+      // 2: the incoming quadrat does not exist yet
+      .mockResolvedValueOnce([])
+      // 3: INSERT new quadrat
+      .mockResolvedValueOnce({ insertId: 3 })
+      // 4: changelog lookup
+      .mockResolvedValueOnce([])
+      // 5: changelog insert
+      .mockResolvedValueOnce({ insertId: 4 });
+
+    const res = await POST(
+      makeFixedDataRequest(
+        'quadrats',
+        {
+          'row-1': { quadrat: 'E01', startx: 40, starty: 0, dimx: 20, dimy: 20, area: 400 }
+        },
+        { uploadMode: 'revisions' }
+      )
+    );
+
+    expect(res?.status).toBe(200);
+    await expect(res?.json()).resolves.toMatchObject({
+      uploadMode: 'revisions',
+      insertedCount: 1,
+      updatedCount: 0,
+      transactionCompleted: true
+    });
+    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('SELECT QuadratName FROM forestgeo_testing.quadrats');
+    expect(String(mockConnectionManager.executeQuery.mock.calls[2]?.[0])).toContain('INSERT INTO forestgeo_testing.quadrats');
+  });
+
   it('rejects revisions when multiple active species rows already exist for one SpeciesCode', async () => {
     mockConnectionManager.executeQuery.mockResolvedValueOnce([{ SpeciesID: 11 }, { SpeciesID: 19 }]);
 

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -252,14 +252,13 @@ async function upsertQuadratRows(
 
   if (uploadMode === UploadMode.REVISIONS) {
     // A Revisions upload updates by QuadratName and appends every non-matching row.
-    // Refuse before writing anything if the incoming names share NO overlap with the
-    // existing quadrats — that only happens when the file uses a different naming
-    // scheme than the quadrats already in the plot (e.g. real C01… names uploaded on
-    // top of an auto-generated Q00001… placeholder grid), which silently doubles the
-    // quadrat set. The operator should use Clean Re-Upload to replace instead.
+    // Refuse only a large, replacement-like file against the known generated Q#####
+    // placeholder grid. Other non-overlapping files are valid Revisions additions.
     const existingNamesSQL = format(`SELECT QuadratName FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1 AND QuadratName IS NOT NULL`, [schema]);
     const existingNameRows = await connectionManager.executeQuery(existingNamesSQL, [plotID], transactionID);
-    const existingActiveNames = Array.isArray(existingNameRows) ? existingNameRows.map((existing: any) => String(existing.QuadratName ?? '')) : [];
+    const existingActiveNames = Array.isArray(existingNameRows)
+      ? existingNameRows.map(existing => String((existing as { QuadratName?: unknown }).QuadratName ?? ''))
+      : [];
     const incomingNames = rows.map(row => normalizeRequiredString(row.quadrat)).filter(Boolean);
 
     if (quadratRevisionAppendsDivergentSet(existingActiveNames, incomingNames)) {

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -16,6 +16,7 @@ import crypto from 'crypto';
 import { insertIngestionFailureRows } from '@/config/measurementerrors';
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState as TrackedUploadSessionState } from '@/config/uploadsessiontracker';
 import { normalizeUploadMode, UploadMode } from '@/config/uploadmodes';
+import { buildDivergentQuadratUploadError, quadratRevisionAppendsDivergentSet } from '@/lib/ingestion/quadrat-upload-guards';
 import { FamilyResult, GenusResult } from '@/lib/db/definitions/taxonomies';
 import { RoleResult } from '@/lib/db/definitions/personnel';
 import { requireSession } from '@/lib/auth-helpers';
@@ -247,6 +248,23 @@ async function upsertQuadratRows(
 
     const deleteSQL = format(`DELETE FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`, [schema]);
     await connectionManager.executeQuery(deleteSQL, [plotID], transactionID);
+  }
+
+  if (uploadMode === UploadMode.REVISIONS) {
+    // A Revisions upload updates by QuadratName and appends every non-matching row.
+    // Refuse before writing anything if the incoming names share NO overlap with the
+    // existing quadrats — that only happens when the file uses a different naming
+    // scheme than the quadrats already in the plot (e.g. real C01… names uploaded on
+    // top of an auto-generated Q00001… placeholder grid), which silently doubles the
+    // quadrat set. The operator should use Clean Re-Upload to replace instead.
+    const existingNamesSQL = format(`SELECT QuadratName FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1 AND QuadratName IS NOT NULL`, [schema]);
+    const existingNameRows = await connectionManager.executeQuery(existingNamesSQL, [plotID], transactionID);
+    const existingActiveNames = Array.isArray(existingNameRows) ? existingNameRows.map((existing: any) => String(existing.QuadratName ?? '')) : [];
+    const incomingNames = rows.map(row => normalizeRequiredString(row.quadrat)).filter(Boolean);
+
+    if (quadratRevisionAppendsDivergentSet(existingActiveNames, incomingNames)) {
+      throw new Error(buildDivergentQuadratUploadError(plotID, existingActiveNames, incomingNames.length));
+    }
   }
 
   for (const row of rows) {

--- a/frontend/components/provisioning/QuadratPlanner.tsx
+++ b/frontend/components/provisioning/QuadratPlanner.tsx
@@ -181,12 +181,14 @@ export default function QuadratPlanner({ value, onChange, plot, showErrors = fal
     });
   }
 
-  function switchMode(newMode: 'grid' | 'csv') {
+  function switchMode(newMode: 'grid' | 'csv' | 'none') {
     setCsvParseErrors([]);
     if (newMode === 'grid') {
       onChange({ mode: 'grid', quadratSizeX: 20, quadratSizeY: 20, namingPattern: NAMING_PATTERN_SEQUENTIAL });
-    } else {
+    } else if (newMode === 'csv') {
       onChange({ mode: 'csv', rows: [] });
+    } else {
+      onChange({ mode: 'none' });
     }
   }
 
@@ -212,15 +214,23 @@ export default function QuadratPlanner({ value, onChange, plot, showErrors = fal
           id="quadrat-mode-group"
           aria-label="Quadrat Mode"
           value={value.mode}
-          onChange={e => switchMode(e.target.value as 'grid' | 'csv')}
+          onChange={e => switchMode(e.target.value as 'grid' | 'csv' | 'none')}
           orientation="horizontal"
         >
           <Radio value="grid" label="Grid (auto-generate)" aria-label="Grid mode: auto-generate quadrats" />
           <Radio value="csv" label="CSV (upload custom layout)" aria-label="CSV mode: upload custom quadrat layout" />
+          <Radio value="none" label="None (add later)" aria-label="None mode: create no quadrats now" />
         </RadioGroup>
       </FormControl>
 
       {value.mode === 'grid' && <GridModePanel value={value} onChange={onChange} plot={plot} />}
+
+      {value.mode === 'none' && (
+        <Alert color="neutral" variant="soft" size="sm" aria-label="No quadrats will be created">
+          No quadrats will be created now. Upload the real quadrat list later from the Quadrats page. This avoids seeding a placeholder grid that would coexist
+          with — and duplicate — your uploaded quadrats.
+        </Alert>
+      )}
 
       {value.mode === 'csv' && (
         <Stack spacing={2}>

--- a/frontend/components/provisioning/Review.tsx
+++ b/frontend/components/provisioning/Review.tsx
@@ -12,6 +12,9 @@ function buildQuadratsSummary(quadrats: ProvisioningInput['quadrats']): string {
   if (quadrats.mode === 'grid') {
     return `Grid mode: ${quadrats.quadratSizeX}×${quadrats.quadratSizeY} m, naming = ${quadrats.namingPattern}`;
   }
+  if (quadrats.mode === 'none') {
+    return 'None: no quadrats created now — upload them later from the Quadrats page';
+  }
   return `CSV mode: ${quadrats.rows.length} ${quadrats.rows.length === 1 ? 'row' : 'rows'}`;
 }
 

--- a/frontend/components/uploadsystem/segments/uploadfiresql.tsx
+++ b/frontend/components/uploadsystem/segments/uploadfiresql.tsx
@@ -38,7 +38,7 @@ import { chooseEffectiveCsvMapping, headerBasisMatches, type CsvMappingRejection
 import type { ColumnMapping } from '@/lib/column-mapping/types';
 import { extractCsvHeaderRow } from '@/lib/column-mapping/csv-headers';
 import { CSV_RESOLVE_OPTIONS, collapseRowWithPlan, resolveHeaders, transformHeaderFromPlan } from '@/lib/column-mapping/resolution';
-import { aliasesFor, legacyCsvHeaderKey } from '@/lib/column-mapping/fields';
+import { aliasesFor, makeLegacyCsvHeaderKey } from '@/lib/column-mapping/fields';
 import { transformMeasurementValue, validateMeasurementRow } from '@/lib/column-mapping/measurement-rows';
 import { UploadMode } from '@/config/uploadmodes';
 
@@ -867,7 +867,9 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
 
       // Non-measurements forms and revision uploads only. The measurements flow resolves headers
       // through lib/column-mapping/resolution (seeded mapping when the user confirmed none). The
-      // legacy fallback (legacyCsvHeaderKey) shares the single CSV_ALIASES source of truth.
+      // legacy fallback (makeLegacyCsvHeaderKey) scopes the CSV_ALIASES source of truth to the form:
+      // measurements (incl. revisions) alias; other forms identity-normalize so a taxonomy `species`
+      // column is not hijacked into `spcode`.
       const mappingFlowActive = mappingRequired && csvHeaders !== null && csvHeaders.length > 0;
       // When the mapping flow is active the server is the single authority over how columns are
       // keyed: the client ships raw rows and the server resolves/keys/validates them. Legacy
@@ -890,7 +892,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
         : null;
       // On the server-resolved path we send raw headers + raw string values so the server is
       // authoritative over keying; Papa treats `undefined` transforms as identity.
-      const transformHeader = serverResolves ? undefined : headerPlan ? transformHeaderFromPlan(headerPlan) : legacyCsvHeaderKey;
+      const transformHeader = serverResolves ? undefined : headerPlan ? transformHeaderFromPlan(headerPlan) : makeLegacyCsvHeaderKey(uploadForm as FormType);
 
       // Per-cell transform delegates to the shared pure function. The shared function returns the
       // original string when a measurement date fails to parse; detect that here to preserve the

--- a/frontend/db/ops/2026-07-09-cleanup-duplicate-quadrat-grid.sql
+++ b/frontend/db/ops/2026-07-09-cleanup-duplicate-quadrat-grid.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- Data cleanup: remove the auto-generated placeholder quadrat grid that is
+-- duplicating a plot's real quadrats.
+-- ============================================================================
+--
+-- SYMPTOM
+--   A plot shows ~2x the expected number of quadrats (e.g. Cooks Branch shows
+--   1052 instead of 527). Two naming schemes coexist: an auto-generated
+--   sequential grid (Q00001, Q00002, …) AND the site's real quadrats under a
+--   different scheme (e.g. C01, D01, E01, …).
+--
+-- ROOT CAUSE
+--   Provisioning seeded a placeholder Q##### grid. The site later uploaded its
+--   real quadrats via a Revisions upload, which matches by QuadratName and
+--   appends every non-matching row. Because Q##### never matches C01…, all the
+--   real quadrats were ADDED on top of the placeholders instead of replacing
+--   them.
+--
+-- WHAT THIS SCRIPT DOES
+--   Deletes ONLY the Q##### placeholder quadrats, and ONLY those not referenced
+--   by any stem, and ONLY when a real (non-placeholder) quadrat set also exists
+--   in the same plot. This makes it impossible to cascade-delete stems or
+--   measurements, and impossible to wipe a plot that legitimately uses Q#####
+--   names.
+--
+-- HOW TO RUN
+--   1. Point your client at the site schema (edit the USE line below).
+--   2. Set @plot_name to the affected plot.
+--   3. Run the PREVIEW section and confirm the counts make sense.
+--   4. Run the TRANSACTION section, re-check the post-delete count, then COMMIT
+--      (or ROLLBACK if anything looks wrong).
+--
+-- The placeholder pattern matches the provisioning generator exactly: a literal
+-- 'Q' followed by 5 digits (see lib/provisioning/grid-generator.ts,
+-- SEQUENTIAL_PAD_WIDTH = 5). Adjust @placeholder_pattern only if your generator
+-- padding differs.
+-- ============================================================================
+
+USE `forestgeo_cooksbranch`;
+
+SET @plot_name := 'Cook Branch';
+SET @placeholder_pattern := '^Q[0-9]{5}$';
+
+SELECT PlotID INTO @plot_id FROM plots WHERE PlotName = @plot_name LIMIT 1;
+
+-- ---------------------------------------------------------------------------
+-- PREVIEW  (read-only — safe to run first)
+-- ---------------------------------------------------------------------------
+
+-- Breakdown of active quadrats for the plot: total / placeholders / real.
+SELECT
+  @plot_id                                                                        AS plot_id,
+  COUNT(*)                                                                        AS active_quadrats_total,
+  SUM(QuadratName REGEXP @placeholder_pattern)                                    AS placeholder_quadrats,
+  SUM(QuadratName NOT REGEXP @placeholder_pattern OR QuadratName IS NULL)         AS real_quadrats
+FROM quadrats
+WHERE PlotID = @plot_id
+  AND IsActive = 1;
+
+-- Placeholders that are referenced by a stem. These will be PRESERVED by the
+-- delete below (expected to be 0 for a placeholder grid that was never measured
+-- against). If this is > 0, investigate before proceeding.
+SELECT COUNT(*) AS placeholders_referenced_by_stems
+FROM quadrats q
+WHERE q.PlotID = @plot_id
+  AND q.IsActive = 1
+  AND q.QuadratName REGEXP @placeholder_pattern
+  AND EXISTS (SELECT 1 FROM stems s WHERE s.QuadratID = q.QuadratID);
+
+-- Exact rows that WOULD be deleted (placeholders, active, not stem-referenced).
+SELECT QuadratID, QuadratName, StartX, StartY
+FROM quadrats q
+WHERE q.PlotID = @plot_id
+  AND q.IsActive = 1
+  AND q.QuadratName REGEXP @placeholder_pattern
+  AND NOT EXISTS (SELECT 1 FROM stems s WHERE s.QuadratID = q.QuadratID)
+ORDER BY QuadratName;
+
+-- ---------------------------------------------------------------------------
+-- TRANSACTION  (mutating — review the preview first)
+-- ---------------------------------------------------------------------------
+
+START TRANSACTION;
+
+-- Safety gate: only delete placeholders when the plot ALSO has a real,
+-- non-placeholder active quadrat set. Prevents wiping a plot that legitimately
+-- uses Q##### names.
+SELECT EXISTS (
+  SELECT 1 FROM quadrats
+  WHERE PlotID = @plot_id
+    AND IsActive = 1
+    AND (QuadratName NOT REGEXP @placeholder_pattern OR QuadratName IS NULL)
+) INTO @real_set_exists;
+
+DELETE q
+FROM quadrats q
+WHERE q.PlotID = @plot_id
+  AND q.IsActive = 1
+  AND q.QuadratName REGEXP @placeholder_pattern
+  AND NOT EXISTS (SELECT 1 FROM stems s WHERE s.QuadratID = q.QuadratID)
+  AND @real_set_exists = 1;
+
+-- Post-delete count — should equal the plot's expected real quadrat count.
+SELECT COUNT(*) AS active_quadrats_after
+FROM quadrats
+WHERE PlotID = @plot_id
+  AND IsActive = 1;
+
+-- Review the number above, then finish with exactly one of:
+--   COMMIT;
+--   ROLLBACK;

--- a/frontend/lib/column-mapping/fields.test.ts
+++ b/frontend/lib/column-mapping/fields.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { FormType, RequiredTableHeadersByFormType, SourceFormat, TableHeadersByFormType } from '@/config/macros/formdetails';
-import { aliasesFor, canonicalFieldsFor, legacyCsvHeaderKey, normalizeHeader } from './fields';
+import { aliasesFor, canonicalFieldsFor, legacyCsvHeaderKey, makeLegacyCsvHeaderKey, normalizeHeader } from './fields';
 
 describe('normalizeHeader', () => {
   it('lowercases, trims, and strips separators', () => {
@@ -118,5 +118,35 @@ describe('legacyCsvHeaderKey', () => {
 
   it('passes unknown headers through normalized (lowercase, no whitespace/underscore/hyphen)', () => {
     expect(legacyCsvHeaderKey('Device_ID')).toBe('deviceid');
+  });
+});
+
+describe('makeLegacyCsvHeaderKey (form-aware legacy transform)', () => {
+  // The CSV alias dictionary is measurements-specific. A measurements file that names its species-code
+  // column "species"/"sp" should still resolve to spcode, so measurements keeps the aliases.
+  it('for the measurements form, applies the CSV aliases', () => {
+    const key = makeLegacyCsvHeaderKey(FormType.measurements);
+    expect(key('species')).toBe('spcode');
+    expect(key('sp')).toBe('spcode');
+    expect(key('Notes')).toBe('comments');
+  });
+
+  // Regression: the species-definition form's `species` column is the epithet — a distinct required
+  // field, NOT the species code. Applying the measurements alias hijacked it into `spcode`, colliding
+  // with the real `spcode` column and dropping SpeciesName. It must stay its own field.
+  it('for the species form, does NOT hijack the `species` epithet into `spcode`', () => {
+    const key = makeLegacyCsvHeaderKey(FormType.species);
+    expect(key('species')).toBe('species');
+    expect(key('spcode')).toBe('spcode');
+  });
+
+  it('for the species form, passes taxonomy headers through normalized without measurements aliasing', () => {
+    const key = makeLegacyCsvHeaderKey(FormType.species);
+    expect(key('family')).toBe('family');
+    expect(key('genus')).toBe('genus');
+    expect(key('subspecies')).toBe('subspecies');
+    expect(key('idlevel')).toBe('idlevel');
+    expect(key('authority')).toBe('authority');
+    expect(key(' Sub-Species ')).toBe('subspecies');
   });
 });

--- a/frontend/lib/column-mapping/fields.ts
+++ b/frontend/lib/column-mapping/fields.ts
@@ -62,6 +62,19 @@ export function legacyCsvHeaderKey(header: string): string {
   return LEGACY_CSV_FIELD_BY_ALIAS[norm] ?? norm;
 }
 
+/**
+ * Builds the papaparse `transformHeader` for the legacy (non column-mapping) upload path, scoped to
+ * the form being uploaded. CSV_ALIASES is a MEASUREMENTS alias set: it aliases `species`/`sp` to
+ * `spcode`, which is right when a measurements file names its species-code column "species" but wrong
+ * for the species-definition form, where `species` is the epithet (a distinct required field) and
+ * would be hijacked into `spcode` — colliding with the real `spcode` column and dropping SpeciesName.
+ * Non-measurements forms (species, quadrats, personnel, attributes) already ship CSV headers equal to
+ * their canonical fields, so they get identity normalization. Measurements revisions still alias.
+ */
+export function makeLegacyCsvHeaderKey(formType: FormType): (header: string) => string {
+  return formType === FormType.measurements ? legacyCsvHeaderKey : normalizeHeader;
+}
+
 function arcgisFields(): CanonicalFieldDef[] {
   return ARCGIS_SCHEMA.filter(def => def.field !== CODE_AGGREGATE_FIELD).map(def => ({
     canonicalField: def.field,

--- a/frontend/lib/column-mapping/species-header-parse.test.ts
+++ b/frontend/lib/column-mapping/species-header-parse.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import Papa from 'papaparse';
+import { FormType } from '@/config/macros/formdetails';
+import { makeLegacyCsvHeaderKey } from './fields';
+
+// End-to-end guard for the species-upload header collision. A taxonomy CSV declares BOTH a `spcode`
+// column (the code) and a `species` column (the epithet). The legacy transform used to alias
+// `species -> spcode`, so papaparse saw two `spcode` columns, renamed the second to a phantom
+// `spcode1` nothing reads, and the epithet was lost (SpeciesName written NULL). This parses exactly as
+// the upload does (Papa.parse with the form's transformHeader) and asserts both columns survive.
+const TAXONOMY_CSV = [
+  'spcode,family,genus,species,idlevel,authority',
+  'CALAME,Lamiaceae,Callicarpa,americana,species,L.',
+  'CARTEX,Juglandaceae,Carya,texana,species,Buckley'
+].join('\n');
+
+describe('species upload header parsing (Papa.parse with the species transform)', () => {
+  it('keeps `spcode` and `species` as separate columns (no collision, no phantom rename)', () => {
+    const result = Papa.parse<Record<string, string>>(TAXONOMY_CSV, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: makeLegacyCsvHeaderKey(FormType.species)
+    });
+
+    expect(result.meta.fields).toEqual(['spcode', 'family', 'genus', 'species', 'idlevel', 'authority']);
+    expect(result.meta.fields).not.toContain('spcode1');
+
+    const first = result.data[0];
+    // SpeciesCode <- row.spcode, SpeciesName <- row.species (see upsertSpeciesRows).
+    expect(first.spcode).toBe('CALAME');
+    expect(first.species).toBe('americana');
+    expect(first.genus).toBe('Callicarpa');
+    expect(first.family).toBe('Lamiaceae');
+  });
+
+  it('still collapses `species` into `spcode` for a measurements upload (alias is correct there)', () => {
+    const measurementsCsv = ['tag,species,quadrat,lx,ly,date', '1,CALAME,0101,1.0,2.0,2026-01-12'].join('\n');
+    const result = Papa.parse<Record<string, string>>(measurementsCsv, {
+      header: true,
+      skipEmptyLines: true,
+      transformHeader: makeLegacyCsvHeaderKey(FormType.measurements)
+    });
+
+    expect(result.meta.fields).toContain('spcode');
+    expect(result.data[0].spcode).toBe('CALAME');
+  });
+});

--- a/frontend/lib/ingestion/quadrat-upload-guards.test.ts
+++ b/frontend/lib/ingestion/quadrat-upload-guards.test.ts
@@ -2,22 +2,34 @@ import { describe, it, expect } from 'vitest';
 import { buildDivergentQuadratUploadError, quadratRevisionAppendsDivergentSet } from './quadrat-upload-guards';
 
 describe('quadratRevisionAppendsDivergentSet', () => {
-  it('flags the placeholder-grid + real-upload doubling case (no name overlap)', () => {
+  it('flags the placeholder-grid + real-upload doubling case', () => {
     const placeholderGrid = ['Q00001', 'Q00002', 'Q00003'];
     const realQuadrats = ['C01', 'D01', 'E01'];
     expect(quadratRevisionAppendsDivergentSet(placeholderGrid, realQuadrats)).toBe(true);
   });
 
-  it('does not flag when at least one incoming name matches an existing quadrat', () => {
-    const existing = ['C01', 'D01', 'E01'];
-    const incoming = ['C01', 'F01', 'G01']; // C01 overlaps → genuine revision, not a divergent set
+  it('allows a small legitimate addition to a generated grid', () => {
+    const existing = Array.from({ length: 20 }, (_, i) => `Q${String(i + 1).padStart(5, '0')}`);
+    const incoming = ['C01'];
     expect(quadratRevisionAppendsDivergentSet(existing, incoming)).toBe(false);
   });
 
-  it('matches names case-insensitively and ignoring surrounding whitespace', () => {
-    const existing = ['c01', 'd01'];
-    const incoming = [' C01 ', 'Z09'];
+  it('allows a wholly new set on a real, non-placeholder layout', () => {
+    const existing = ['C01', 'D01', 'E01'];
+    const incoming = ['F01', 'G01', 'H01'];
     expect(quadratRevisionAppendsDivergentSet(existing, incoming)).toBe(false);
+  });
+
+  it('still blocks a replacement with one incidental generated-name overlap', () => {
+    const placeholderGrid = Array.from({ length: 20 }, (_, i) => `Q${String(i + 1).padStart(5, '0')}`);
+    const realQuadrats = ['Q00001', ...Array.from({ length: 19 }, (_, i) => `C${String(i + 1).padStart(2, '0')}`)];
+    expect(quadratRevisionAppendsDivergentSet(placeholderGrid, realQuadrats)).toBe(true);
+  });
+
+  it('matches generated placeholder names case-insensitively and ignoring surrounding whitespace', () => {
+    const existing = ['q00001', 'q00002'];
+    const incoming = [' C01 ', 'Z09'];
+    expect(quadratRevisionAppendsDivergentSet(existing, incoming)).toBe(true);
   });
 
   it('does not flag a first-time upload into an empty plot', () => {

--- a/frontend/lib/ingestion/quadrat-upload-guards.test.ts
+++ b/frontend/lib/ingestion/quadrat-upload-guards.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildDivergentQuadratUploadError, quadratRevisionAppendsDivergentSet } from './quadrat-upload-guards';
+
+describe('quadratRevisionAppendsDivergentSet', () => {
+  it('flags the placeholder-grid + real-upload doubling case (no name overlap)', () => {
+    const placeholderGrid = ['Q00001', 'Q00002', 'Q00003'];
+    const realQuadrats = ['C01', 'D01', 'E01'];
+    expect(quadratRevisionAppendsDivergentSet(placeholderGrid, realQuadrats)).toBe(true);
+  });
+
+  it('does not flag when at least one incoming name matches an existing quadrat', () => {
+    const existing = ['C01', 'D01', 'E01'];
+    const incoming = ['C01', 'F01', 'G01']; // C01 overlaps → genuine revision, not a divergent set
+    expect(quadratRevisionAppendsDivergentSet(existing, incoming)).toBe(false);
+  });
+
+  it('matches names case-insensitively and ignoring surrounding whitespace', () => {
+    const existing = ['c01', 'd01'];
+    const incoming = [' C01 ', 'Z09'];
+    expect(quadratRevisionAppendsDivergentSet(existing, incoming)).toBe(false);
+  });
+
+  it('does not flag a first-time upload into an empty plot', () => {
+    expect(quadratRevisionAppendsDivergentSet([], ['C01', 'D01'])).toBe(false);
+  });
+
+  it('does not flag when the incoming file has no usable names', () => {
+    expect(quadratRevisionAppendsDivergentSet(['Q00001'], ['', '  '])).toBe(false);
+  });
+
+  it('ignores blank existing names when deciding overlap', () => {
+    // A blank existing name must not be treated as a match for a blank-trimmed incoming name.
+    expect(quadratRevisionAppendsDivergentSet(['', 'Q00001'], ['C01'])).toBe(true);
+  });
+});
+
+describe('buildDivergentQuadratUploadError', () => {
+  it('names the plot, the incoming count, and points to Clean Re-Upload', () => {
+    const message = buildDivergentQuadratUploadError(42, ['Q00001', 'Q00002'], 525);
+    expect(message).toContain('plot 42');
+    expect(message).toContain('525');
+    expect(message).toContain('Clean Re-Upload');
+    expect(message).toContain('Q00001');
+  });
+
+  it('truncates a long existing-name sample with an ellipsis', () => {
+    const manyNames = Array.from({ length: 30 }, (_, i) => `Q${String(i + 1).padStart(5, '0')}`);
+    const message = buildDivergentQuadratUploadError(1, manyNames, 12);
+    expect(message).toContain('…');
+    expect(message).not.toContain('Q00011'); // beyond the 10-name sample window
+  });
+});

--- a/frontend/lib/ingestion/quadrat-upload-guards.ts
+++ b/frontend/lib/ingestion/quadrat-upload-guards.ts
@@ -8,31 +8,46 @@
  * (e.g. C01, D01, …), NONE of the incoming names match, so every real quadrat is
  * appended on top of the placeholders — silently doubling the quadrat count.
  *
- * These helpers detect that divergent-append case so the upload can be refused
- * before any row is written, steering the operator to a Clean Re-Upload (replace)
- * instead.
+ * These helpers detect the specific generated-placeholder replacement case so the
+ * upload can be refused before any row is written. Ordinary Revisions uploads
+ * must still be allowed to add a new quadrat to an established layout.
  */
 
+import { SEQUENTIAL_QUADRAT_NAME_PATTERN } from '@/lib/provisioning/grid-generator';
+
 const MAX_SAMPLE_NAMES = 10;
+const MIN_REPLACEMENT_FRACTION = 0.5;
+const MAX_MATCH_FRACTION = 0.1;
 
 function normalizeQuadratName(value: string): string {
   return value.trim().toLowerCase();
 }
 
 /**
- * True when a Revisions upload would append a wholly new, non-overlapping set of
- * quadrats on top of existing ones — i.e. quadrats already exist for the plot but
- * not one incoming name matches any existing name. That is the fingerprint of two
- * naming schemes coexisting, which produces duplicate physical quadrats.
+ * True when a large, almost entirely non-matching file appears to replace a
+ * generated sequential placeholder grid. This deliberately does not reject
+ * ordinary non-overlapping Revisions uploads: those are the supported way to add
+ * new quadrats to an established layout.
  */
 export function quadratRevisionAppendsDivergentSet(existingActiveNames: string[], incomingNames: string[]): boolean {
   const existing = new Set(existingActiveNames.map(normalizeQuadratName).filter(Boolean));
   if (existing.size === 0) return false;
 
-  const incoming = incomingNames.map(normalizeQuadratName).filter(Boolean);
-  if (incoming.length === 0) return false;
+  // Only the old sequential grid is known to be a disposable placeholder. Other
+  // layouts may legitimately receive a wholly new set of quadrats by revision.
+  if (![...existing].every(name => SEQUENTIAL_QUADRAT_NAME_PATTERN.test(name))) return false;
 
-  return incoming.every(name => !existing.has(name));
+  const incoming = new Set(incomingNames.map(normalizeQuadratName).filter(Boolean));
+  if (incoming.size === 0) return false;
+
+  // A single (or otherwise small) addition to a placeholder grid is still a valid
+  // Revisions upload. A near-full replacement is the dangerous case seen at Cooks
+  // Branch. Count a tiny accidental overlap as divergent too, so it cannot bypass
+  // the guard simply by sharing one generated name.
+  if (incoming.size < Math.ceil(existing.size * MIN_REPLACEMENT_FRACTION)) return false;
+  const matchingNames = [...incoming].filter(name => existing.has(name)).length;
+
+  return matchingNames / incoming.size <= MAX_MATCH_FRACTION;
 }
 
 /**
@@ -47,9 +62,9 @@ export function buildDivergentQuadratUploadError(plotID: number, existingSampleN
   const sampleText = sample.length > 0 ? ` (existing names look like: ${sample.join(', ')}${existingSampleNames.length > sample.length ? ', …' : ''})` : '';
 
   return (
-    `Revisions upload refused: none of the ${incomingCount} quadrat name(s) in this file match any existing quadrat in plot ${plotID}` +
-    `${sampleText}. A Revisions upload would ADD these as a new set rather than update the existing quadrats, duplicating the plot's ` +
-    `quadrats under two naming schemes. If the uploaded file is the correct, complete quadrat list, use Clean Re-Upload to replace the ` +
-    `existing quadrats. Otherwise correct the QuadratName values so they match the existing quadrats.`
+    `Revisions upload refused: this ${incomingCount}-quadrat file appears to replace the generated placeholder grid in plot ${plotID}` +
+    `${sampleText}. A Revisions upload would ADD these as a second layout rather than replace the placeholders, duplicating the plot's ` +
+    `quadrats. If the uploaded file is the correct, complete quadrat list, use Clean Re-Upload to replace the existing quadrats. ` +
+    `Otherwise upload only the new quadrats or correct the QuadratName values so they match the existing quadrats.`
   );
 }

--- a/frontend/lib/ingestion/quadrat-upload-guards.ts
+++ b/frontend/lib/ingestion/quadrat-upload-guards.ts
@@ -1,0 +1,55 @@
+/**
+ * Guards for quadrat CSV uploads.
+ *
+ * Background: a Revisions upload updates existing quadrats matched by QuadratName
+ * (case-insensitive) and inserts every non-matching row as new. When a plot was
+ * provisioned with an auto-generated placeholder grid (e.g. Q00001…Q00527) and a
+ * researcher then uploads their real quadrats under a different naming scheme
+ * (e.g. C01, D01, …), NONE of the incoming names match, so every real quadrat is
+ * appended on top of the placeholders — silently doubling the quadrat count.
+ *
+ * These helpers detect that divergent-append case so the upload can be refused
+ * before any row is written, steering the operator to a Clean Re-Upload (replace)
+ * instead.
+ */
+
+const MAX_SAMPLE_NAMES = 10;
+
+function normalizeQuadratName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/**
+ * True when a Revisions upload would append a wholly new, non-overlapping set of
+ * quadrats on top of existing ones — i.e. quadrats already exist for the plot but
+ * not one incoming name matches any existing name. That is the fingerprint of two
+ * naming schemes coexisting, which produces duplicate physical quadrats.
+ */
+export function quadratRevisionAppendsDivergentSet(existingActiveNames: string[], incomingNames: string[]): boolean {
+  const existing = new Set(existingActiveNames.map(normalizeQuadratName).filter(Boolean));
+  if (existing.size === 0) return false;
+
+  const incoming = incomingNames.map(normalizeQuadratName).filter(Boolean);
+  if (incoming.length === 0) return false;
+
+  return incoming.every(name => !existing.has(name));
+}
+
+/**
+ * Human-readable refusal explaining why the divergent-append upload was blocked
+ * and how to proceed. Kept separate from the detection so both can be unit-tested.
+ */
+export function buildDivergentQuadratUploadError(plotID: number, existingSampleNames: string[], incomingCount: number): string {
+  const sample = existingSampleNames
+    .map(name => name.trim())
+    .filter(Boolean)
+    .slice(0, MAX_SAMPLE_NAMES);
+  const sampleText = sample.length > 0 ? ` (existing names look like: ${sample.join(', ')}${existingSampleNames.length > sample.length ? ', …' : ''})` : '';
+
+  return (
+    `Revisions upload refused: none of the ${incomingCount} quadrat name(s) in this file match any existing quadrat in plot ${plotID}` +
+    `${sampleText}. A Revisions upload would ADD these as a new set rather than update the existing quadrats, duplicating the plot's ` +
+    `quadrats under two naming schemes. If the uploaded file is the correct, complete quadrat list, use Clean Re-Upload to replace the ` +
+    `existing quadrats. Otherwise correct the QuadratName values so they match the existing quadrats.`
+  );
+}

--- a/frontend/lib/provisioning/grid-generator.ts
+++ b/frontend/lib/provisioning/grid-generator.ts
@@ -1,7 +1,10 @@
 import type { ProvisioningInput, QuadratCsvRow, QuadratGridConfig } from './types';
 
 export const MAX_GENERATED_QUADRATS = 10000;
-const SEQUENTIAL_PAD_WIDTH = String(MAX_GENERATED_QUADRATS).length;
+export const SEQUENTIAL_PAD_WIDTH = String(MAX_GENERATED_QUADRATS).length;
+// Keep consumers that need to recognize the legacy auto-generated placeholder
+// grid aligned with the names this generator emits.
+export const SEQUENTIAL_QUADRAT_NAME_PATTERN = new RegExp(`^Q\\d{${SEQUENTIAL_PAD_WIDTH}}$`, 'i');
 
 export function estimateGridQuadratCount(plot: ProvisioningInput['plot'], config: QuadratGridConfig): number {
   const cols = plot.dimensionX / config.quadratSizeX;

--- a/frontend/lib/provisioning/input-schema.test.ts
+++ b/frontend/lib/provisioning/input-schema.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { ProvisioningQuadratsSchema } from './input-schema';
+
+describe('ProvisioningQuadratsSchema', () => {
+  it('accepts grid mode', () => {
+    const result = ProvisioningQuadratsSchema.safeParse({ mode: 'grid', quadratSizeX: 20, quadratSizeY: 20, namingPattern: 'sequential' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts csv mode with at least one row', () => {
+    const result = ProvisioningQuadratsSchema.safeParse({
+      mode: 'csv',
+      rows: [{ quadratName: 'C01', startX: 0, startY: 0, dimensionX: 20, dimensionY: 20 }]
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts none mode (create no quadrats now)', () => {
+    const result = ProvisioningQuadratsSchema.safeParse({ mode: 'none' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown mode', () => {
+    const result = ProvisioningQuadratsSchema.safeParse({ mode: 'auto' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/frontend/lib/provisioning/input-schema.ts
+++ b/frontend/lib/provisioning/input-schema.ts
@@ -51,6 +51,9 @@ export const ProvisioningQuadratsSchema = z.discriminatedUnion('mode', [
       )
       .min(1)
       .max(MAX_GENERATED_QUADRATS)
+  }),
+  z.object({
+    mode: z.literal('none')
   })
 ]);
 

--- a/frontend/lib/provisioning/steps/insert-quadrats.test.ts
+++ b/frontend/lib/provisioning/steps/insert-quadrats.test.ts
@@ -99,6 +99,21 @@ describe('insertQuadratsStep', () => {
     expect(await insertQuadratsStep.alreadyDone(ctx)).toBe(true);
   });
 
+  it('none mode: inserts zero rows and reports alreadyDone', async () => {
+    const noneCtx: StepContext = {
+      ...ctx,
+      input: makeInput({ mode: 'none' })
+    };
+    noneCtx.input.site.schemaName = SCHEMA_NAME;
+    noneCtx.state = { plotId: ctx.state.plotId };
+
+    await insertQuadratsStep.run(noneCtx);
+    expect(await insertQuadratsStep.alreadyDone(noneCtx)).toBe(true);
+
+    const [rows]: any = await ctx.sitePool!.query(`SELECT COUNT(*) AS c FROM \`${SCHEMA_NAME}\`.quadrats WHERE PlotID = ?`, [ctx.state.plotId]);
+    expect(Number(rows[0]?.c ?? rows[0]?.C)).toBe(0);
+  });
+
   it('csv mode: inserts exactly the supplied rows', async () => {
     const csvRows: QuadratCsvRow[] = [
       { quadratName: 'A', startX: 0, startY: 0, dimensionX: 50, dimensionY: 50 },

--- a/frontend/lib/provisioning/steps/insert-quadrats.ts
+++ b/frontend/lib/provisioning/steps/insert-quadrats.ts
@@ -5,10 +5,14 @@ const QUADRATS_TABLE = 'quadrats';
 const DEFAULT_SHAPE = 'square';
 
 function resolveRows(ctx: StepContext) {
-  if (ctx.input.quadrats.mode === 'grid') {
-    return generateGrid(ctx.input.plot, ctx.input.quadrats);
+  const quadrats = ctx.input.quadrats;
+  if (quadrats.mode === 'grid') {
+    return generateGrid(ctx.input.plot, quadrats);
   }
-  return ctx.input.quadrats.rows;
+  if (quadrats.mode === 'csv') {
+    return quadrats.rows;
+  }
+  return [];
 }
 
 export const insertQuadratsStep: ProvisioningStep = {

--- a/frontend/lib/provisioning/steps/validate-inputs.ts
+++ b/frontend/lib/provisioning/steps/validate-inputs.ts
@@ -66,7 +66,7 @@ export const validateInputsStep: ProvisioningStep = {
           { stepKey: 'validate_inputs' }
         );
       }
-    } else {
+    } else if (input.quadrats.mode === 'csv') {
       const rows = input.quadrats.rows;
       for (const row of rows) {
         if (row.startX < 0 || row.startY < 0) {

--- a/frontend/lib/provisioning/steps/verify.test.ts
+++ b/frontend/lib/provisioning/steps/verify.test.ts
@@ -110,6 +110,18 @@ describe('verifyStep', () => {
     await expect(verifyStep.run(ctx)).resolves.toBeUndefined();
   });
 
+  it('verify resolves for none mode with zero quadrats', async () => {
+    const originalInput = ctx.input;
+    try {
+      await ctx.sitePool!.query(`DELETE FROM \`${SCHEMA_NAME}\`.quadrats WHERE PlotID = ?`, [ctx.state.plotId]);
+      ctx.input = { ...originalInput, quadrats: { mode: 'none' } };
+      await expect(verifyStep.run(ctx)).resolves.toBeUndefined();
+    } finally {
+      ctx.input = originalInput;
+      await insertQuadratsStep.run(ctx);
+    }
+  });
+
   it('verify throws when catalog row missing', async () => {
     // Temporarily remove catalog row
     await catalogPool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [SCHEMA_NAME]);

--- a/frontend/lib/provisioning/steps/verify.ts
+++ b/frontend/lib/provisioning/steps/verify.ts
@@ -32,6 +32,10 @@ export const verifyStep: ProvisioningStep = {
       throw new Error(`verify: expected 1 census row, got ${censusRows.length}`);
     }
 
+    // "None (add later)" deliberately provisions an empty quadrat table. The
+    // site, plot, and first census above remain the completion criteria for it.
+    if (ctx.input.quadrats.mode === 'none') return;
+
     const [quadratRows]: any = await ctx.sitePool.query(`SELECT COUNT(*) AS c FROM \`${ctx.schemaName}\`.quadrats WHERE PlotID = ?`, [ctx.state.plotId]);
     const count = Number(quadratRows[0]?.c ?? quadratRows[0]?.C ?? 0);
     if (count < MIN_EXPECTED_QUADRATS) {

--- a/frontend/lib/provisioning/types.ts
+++ b/frontend/lib/provisioning/types.ts
@@ -36,7 +36,16 @@ export interface QuadratCsvConfig {
   rows: QuadratCsvRow[];
 }
 
-export type QuadratConfig = QuadratGridConfig | QuadratCsvConfig;
+/**
+ * Create the site with no quadrats. Use when the real quadrat list will be uploaded
+ * later through the Quadrats page, so provisioning does not seed a placeholder grid
+ * that would otherwise coexist with (and duplicate) the uploaded quadrats.
+ */
+export interface QuadratNoneConfig {
+  mode: 'none';
+}
+
+export type QuadratConfig = QuadratGridConfig | QuadratCsvConfig | QuadratNoneConfig;
 
 export interface ProvisioningInput {
   site: {


### PR DESCRIPTION
Two independent CSV-upload correctness fixes.

## Quadrat placeholder duplication
A plot could accumulate ~2x its quadrats (Cooks Branch showed 1052 vs 527). Provisioning forced either an auto-generated grid or a CSV, so admins without a quadrat list on hand picked Grid and seeded a sequential `Q#####` placeholder set. When the site later uploaded its real quadrats under a different naming scheme via a Revisions upload — which matches by `QuadratName` and appends non-matching rows — every real quadrat was added on top of the placeholders instead of replacing them.

- **Provisioning "None" mode** — a third quadrat option ("None — add later") that creates zero quadrats, so the real list can be uploaded later with no placeholder set to collide with.
- **Revisions divergence guard** — the quadrat upload now refuses (before writing, rolling back the transaction) when quadrats already exist for the plot and not one incoming name overlaps them, steering the operator to Clean Re-Upload. Detection lives in a pure, unit-tested helper.
- **Ops cleanup script** (`db/ops/`) — verify-first, transaction-wrapped removal of the `Q#####` placeholders, deleting only non-stem-referenced rows and only when a real set also exists, so it cannot cascade-delete stems/measurements. Already run against Cooks Branch, which now reads exactly 527.

## Taxonomy upload species-name drop
Species/taxonomy CSV uploads reused the shared measurements header-alias dictionary, so a `species` column was hijacked into `SpeciesCode` and the species name was dropped. Header aliases are now scoped to measurements uploads, so taxonomy uploads keep the species name.
