### PR TITLE
test: fix flaky Edit-button query in isolated grid refetch test

### DIFF
--- a/frontend/components/datagrids/isolateddatagridcommons.test.tsx
+++ b/frontend/components/datagrids/isolateddatagridcommons.test.tsx
@@ -308,7 +308,9 @@ describe('IsolatedDataGridCommons', () => {
     });
     const initialListCallCount = mockFetch.mock.calls.filter(([, init]) => !init?.method || init.method === 'GET').length;
 
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    // The row's action buttons render asynchronously after the fetched rows land;
+    // a non-retrying query here races the grid's render under CI load.
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The deploy pipeline for #347 failed in its unit-test step: `IsolatedDataGridCommons > refetches from the server after a confirmed save` clicked the row's Edit button via a non-retrying `getByRole` immediately after the row-state assertion, racing the grid's asynchronous action-cell render. It passed the PR gate but failed under the deploy runner's load, blocking the deployment (the deploy job never started, so the dev site stayed on the previous build). Switching to `findByRole` makes the query retry until the button renders.