### PR TITLE
fix(e2e): restore the CI-gated a11y spec; add errors-explorer contract test

### DIFF
--- a/frontend/cypress/e2e/a11y-responsive.cy.ts
+++ b/frontend/cypress/e2e/a11y-responsive.cy.ts
@@ -1,0 +1,135 @@
+/// <reference types="cypress" />
+
+import { buildErrorsExplorerRow } from '../support/errors-explorer-helpers';
+import { buildMeasurementsSummaryRow, buildViewFullTableRow } from '../support/grid-api-helpers';
+import { mockMeasurementHubWorkflowApi } from '../support/measurement-hub-workflow-helpers';
+
+const VIEWPORTS = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', preset: 'iphone-x' as const }
+];
+
+function prepareMockedCensusWorkflow() {
+  cy.setupForestGEOUser('adminUser');
+  cy.mockCoreDataValidity();
+
+  const summaryRow = buildMeasurementsSummaryRow({
+    coreMeasurementID: 101,
+    treeTag: 'TREE101',
+    speciesCode: 'RUBI04',
+    quadratName: 'Q0101',
+    isValidated: false,
+    description: 'Invalid species reference',
+    userDefinedFields: 'old tree'
+  });
+
+  const fullRow = buildViewFullTableRow({
+    coreMeasurementID: 101,
+    treeTag: 'TREE101',
+    speciesCode: 'RUBI04',
+    quadratName: 'Q0101',
+    isValidated: false,
+    description: 'Invalid species reference',
+    userDefinedFields: 'old tree'
+  });
+
+  const errorRow = buildErrorsExplorerRow({
+    id: 101,
+    coreMeasurementID: 101,
+    treeTag: 'TREE101',
+    speciesCode: 'RUBI04',
+    quadratName: 'Q0101',
+    primaryErrorMessage: 'Invalid species reference',
+    errorMessages: ['Invalid species reference'],
+    errorSources: ['validation'],
+    errorFields: ['speciesCode'],
+    errorCodes: ['INVALID_SPECIES'],
+    description: 'Invalid species reference'
+  });
+
+  mockMeasurementHubWorkflowApi({
+    summaryRows: [summaryRow],
+    viewFullTableRows: [fullRow],
+    errorRows: [errorRow],
+    validationFailures: [
+      {
+        coreMeasurementID: 101,
+        descriptions: ['Invalid species reference'],
+        criteria: ['speciesCode']
+      }
+    ]
+  });
+}
+
+// Site/plot/census selection always runs at desktop width: on mobile the
+// sidebar lives in a Drawer whose transformed, scrollable container defeats
+// Cypress visibility checks inside the shared selection helpers. The mobile
+// pass switches the viewport after selection and reaches pages by route, so
+// what we scan is each page's mobile rendering.
+function selectDefaultContext() {
+  cy.viewport(1440, 900);
+  cy.visitAuthenticatedPage('/dashboard');
+  cy.selectSitePlotAndCensus('Luquillo', 'Luquillo Main Plot', 5);
+}
+
+function applyViewport(viewport: (typeof VIEWPORTS)[number]) {
+  if ('preset' in viewport) {
+    cy.viewport(viewport.preset);
+  } else {
+    cy.viewport(viewport.width, viewport.height);
+  }
+}
+
+function openCensusHubPage(label: string, route: string, isMobile: boolean) {
+  if (isMobile) {
+    cy.visit(`/measurementshub${route}`);
+  } else {
+    cy.openCensusHubLink(label);
+  }
+}
+
+function checkCriticalA11y(context?: Parameters<Cypress.Chainable['checkA11y']>[0], rules: Record<string, { enabled: boolean }> = {}) {
+  cy.injectAxe();
+  cy.checkA11y(
+    context,
+    {
+      includedImpacts: ['critical'],
+      rules
+    },
+    violations => {
+      violations.forEach(violation => {
+        cy.task(
+          'log',
+          `[a11y] ${violation.id} (${violation.impact}) ${violation.description} :: ${violation.nodes.map(node => node.target.join(' ')).join(', ')}`
+        );
+      });
+    }
+  );
+}
+
+describe('Accessibility and responsive smoke', () => {
+  VIEWPORTS.forEach(viewport => {
+    it(`has no critical axe violations on core census pages at ${viewport.name} viewport`, () => {
+      const isMobile = 'preset' in viewport;
+
+      prepareMockedCensusWorkflow();
+      selectDefaultContext();
+      applyViewport(viewport);
+      checkCriticalA11y();
+
+      openCensusHubPage('View Data', '/summary', isMobile);
+      cy.wait('@fetchMeasurementHubSummaryRows');
+      cy.contains('[role="row"]', 'TREE101').should('contain', 'RUBI04');
+      // MUI DataGrid virtualization currently trips axe's aria-required-children
+      // rule inside the grid internals. Keep the page-level smoke while tracking
+      // the grid-specific remediation separately.
+      checkCriticalA11y(undefined, { 'aria-required-children': { enabled: false } });
+
+      openCensusHubPage('View Errors', '/errors', isMobile);
+      cy.wait('@fetchErrorsExplorerRows');
+      cy.wait('@fetchErrorFacets');
+      cy.get('.MuiDataGrid-root', { timeout: 10000 }).should('exist');
+      checkCriticalA11y(undefined, { 'aria-required-children': { enabled: false } });
+    });
+  });
+});

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -14,6 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
+import 'cypress-axe';
 import './commands';
 import './demo-commands';
 import './test-data-helpers';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -101,6 +101,7 @@
         "@vitejs/plugin-react": "^5.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "cypress": "^14.5.4",
+        "cypress-axe": "^1.7.0",
         "dotenv-cli": "^11.0.0",
         "eslint": "^9.30.1",
         "eslint-config-next": "^15.3.5",
@@ -8549,6 +8550,7 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "license": "MPL-2.0",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10045,6 +10047,20 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.7.0.tgz",
+      "integrity": "sha512-zzJpvAAjauEB3GZl0KYXb8i3w6MztWAt2WM3czYTFyNVC30alDmqCm9E7GwZ4bgkldZJlmHakaVEyu73R5St4w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12 || ^13 || ^14 || ^15"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -144,6 +144,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "cypress": "^14.5.4",
+    "cypress-axe": "^1.7.0",
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.30.1",
     "eslint-config-next": "^15.3.5",

--- a/frontend/tests/contracts/api-shapes.test.ts
+++ b/frontend/tests/contracts/api-shapes.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_ERROR_EXPLORER_FILTERS, type ErrorExplorerQueryRequest } from '@/config/errorsexplorer';
+import { buildErrorExplorerFacets, queryErrorExplorer } from '@/app/api/errors/explorer/_shared';
+
+const rawErrorRows = [
+  {
+    CoreMeasurementID: 101,
+    PlotID: 1,
+    CensusID: 5,
+    QuadratID: 11,
+    TreeID: 1001,
+    StemGUID: 2001,
+    CoreStemGUID: 2001,
+    SpeciesID: 3001,
+    TreeTag: 'TREE101',
+    StemTag: '1',
+    SpeciesName: 'Rubiaceae example',
+    SubspeciesName: null,
+    SpeciesCode: 'RUBI04',
+    QuadratName: 'Q0101',
+    StemLocalX: 10.1,
+    StemLocalY: 20.2,
+    MeasurementDate: '2024-06-15',
+    MeasuredDBH: 15.5,
+    MeasuredHOM: 1.3,
+    IsValidated: false,
+    MeasurementDescription: 'review species',
+    Attributes: 'A',
+    RawCodes: 'A',
+    UserDefinedFields: 'old tree',
+    UploadFileID: 'file-1',
+    UploadBatchID: 'batch-1',
+    ErrorSource: 'validation' as const,
+    ErrorCode: '21',
+    DisplayMessage: 'Species mismatch',
+    ValidationCriteria: 'speciesCode',
+    ProcedureName: 'ValidateSpecies'
+  },
+  {
+    CoreMeasurementID: 102,
+    PlotID: 1,
+    CensusID: 5,
+    QuadratID: 12,
+    TreeID: 1002,
+    StemGUID: 9999,
+    CoreStemGUID: null,
+    SpeciesID: null,
+    TreeTag: 'TREE102',
+    StemTag: '1',
+    SpeciesName: null,
+    SubspeciesName: null,
+    SpeciesCode: 'BADSP',
+    QuadratName: 'Q0102',
+    StemLocalX: 11.1,
+    StemLocalY: 21.2,
+    MeasurementDate: new Date('2024-06-16T12:00:00Z'),
+    MeasuredDBH: 16.5,
+    MeasuredHOM: 1.3,
+    IsValidated: false,
+    MeasurementDescription: 'bad species code',
+    Attributes: null,
+    RawCodes: 'DS',
+    UserDefinedFields: null,
+    UploadFileID: 'file-1',
+    UploadBatchID: 'batch-1',
+    ErrorSource: 'ingestion' as const,
+    ErrorCode: 'INVALID_SPECIES',
+    DisplayMessage: 'Invalid species reference',
+    ValidationCriteria: null,
+    ProcedureName: null
+  }
+];
+
+function makeConnection() {
+  return {
+    executeQuery: vi.fn(async (query: string) => {
+      if (query.includes('measurement_error_log')) {
+        return rawErrorRows;
+      }
+      if (query.includes('GROUP_CONCAT(DISTINCT ms.CoreMeasurementID')) {
+        return [{ TreeTag: 'TREE101', StemTag: '1', MeasurementIDs: '101,102' }];
+      }
+      if (query.includes('GROUP_CONCAT(DISTINCT cm.CoreMeasurementID')) {
+        return [];
+      }
+      throw new Error(`Unexpected query in contract test: ${query}`);
+    })
+  } as any;
+}
+
+function makeRequest(overrides: Partial<ErrorExplorerQueryRequest> = {}): ErrorExplorerQueryRequest {
+  return {
+    schema: 'forestgeo_testing',
+    plotID: 1,
+    censusID: 5,
+    page: 0,
+    pageSize: 25,
+    filters: DEFAULT_ERROR_EXPLORER_FILTERS,
+    ...overrides
+  };
+}
+
+describe('API response shape contracts', () => {
+  it('keeps Errors Explorer query rows aligned with the UI contract', async () => {
+    const response = await queryErrorExplorer(makeConnection(), makeRequest());
+
+    expect(response).toMatchObject({
+      totalRows: 2,
+      summary: {
+        total: 2,
+        validation: 1,
+        ingestion: 1,
+        contradictions: 2,
+        duplicateTagStem: 2,
+        sameBatchConflict: 0
+      }
+    });
+
+    expect(response.rows).toHaveLength(2);
+    expect(response.rows[0]).toMatchObject({
+      id: 101,
+      coreMeasurementID: 101,
+      plotID: 1,
+      censusID: 5,
+      treeTag: 'TREE101',
+      stemTag: '1',
+      speciesCode: 'RUBI04',
+      quadratName: 'Q0101',
+      measurementDate: '2024-06-15',
+      primaryErrorMessage: 'Species mismatch',
+      errorMessages: ['Species mismatch'],
+      errorSources: ['validation'],
+      errorFields: ['speciesCode'],
+      errorCodes: ['21'],
+      errorCount: 1,
+      hasContradiction: true,
+      contradictionTypes: ['duplicate_tag_stem'],
+      contradictionType: 'duplicate_tag_stem',
+      relatedMeasurementIDs: [102],
+      uploadFileID: 'file-1',
+      uploadBatchID: 'batch-1',
+      isFailedRow: false
+    });
+
+    expect(response.rows[1]).toMatchObject({
+      id: 102,
+      coreMeasurementID: 102,
+      measurementDate: '2024-06-16',
+      primaryErrorMessage: 'Invalid species reference',
+      errorSources: ['ingestion'],
+      errorFields: ['speciesCode'],
+      errorCodes: ['INVALID_SPECIES'],
+      relatedMeasurementIDs: [101],
+      isFailedRow: true
+    });
+  });
+
+  it('keeps Errors Explorer facets stable for filters and chips', async () => {
+    const facets = await buildErrorExplorerFacets(makeConnection(), makeRequest());
+
+    expect(facets).toEqual({
+      messages: [
+        { value: 'Invalid species reference', count: 1 },
+        { value: 'Species mismatch', count: 1 }
+      ],
+      fields: [{ value: 'speciesCode', count: 2 }],
+      sourceCounts: {
+        validation: 1,
+        ingestion: 1
+      },
+      contradictionCounts: {
+        duplicateTagStem: 2,
+        sameBatchConflict: 0
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `cypress/e2e/a11y-responsive.cy.ts`, which the e2e workflow's spec list has been gating on since the list was written — the file never landed, so the a11y check has been silently skipped in CI. The spec runs axe critical-impact scans of the dashboard, View Data, and View Errors pages at desktop and mobile viewports, with a documented carve-out for the known MUI DataGrid `aria-required-children` issue. Adds the `cypress-axe` devDependency and support import it requires. Site/plot/census selection runs at desktop width because the shared selection helpers cannot see controls inside the mobile Drawer; the mobile pass switches viewport after selection and reaches pages by route so the scans still cover mobile rendering.
- Adds `tests/contracts/api-shapes.test.ts`, pinning the Errors Explorer query-row and facet response shapes to what the UI consumes.

Both pieces were salvaged from uncommitted work in the `codex/test-coverage-ci-hardening` worktree (checkpointed on `wip/test-coverage-checkpoint`).