### PR TITLE
Schema hardening: safe migration runner and deployment gates

### DIFF
--- a/.github/workflows/dev-forestgeo-livesite.yml
+++ b/.github/workflows/dev-forestgeo-livesite.yml
@@ -184,8 +184,55 @@ jobs:
           name: app-build
           path: frontend/build/standalone
 
-  deploy-app-development:
+  # Schema migrate + verify + stored-procedure/validation deploy.
+  # This runs BEFORE the app deploy and the app deploy `needs:` it, so a failed
+  # migration or a failed contract verify PREVENTS incompatible app code from
+  # going live. The stored procedures reference the new columns, so they are
+  # deployed only after the migration has added those columns.
+  migrate-and-verify-development:
     needs: build-app-development
+    runs-on: ubuntu-latest
+    environment: development_temp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: |
+          cd frontend/
+          npm install --production=false
+
+      - name: Apply schema migrations to all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/apply-schema-migrations.ts --all-sites --apply
+        continue-on-error: false
+
+      - name: Verify schema contract across all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/check-schema-contract.ts --all-sites
+        continue-on-error: false
+
+      - name: Deploy validation queries and stored procedures to all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/deploy-validations-to-all-schemas.ts
+        continue-on-error: false
+
+  deploy-app-development:
+    needs: [build-app-development, migrate-and-verify-development]
     runs-on: ubuntu-latest
     environment: development_temp
 
@@ -213,25 +260,6 @@ jobs:
           echo "Deployment submitted to Azure App Service"
           # Note: External health checks are not performed because Azure Easy Auth
           # requires authentication. Build integrity was verified in the build job.
-
-      - name: Setup Node.js for validation deployment
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-
-      - name: Checkout code for validation deployment
-        uses: actions/checkout@v4
-        with:
-          path: repo
-
-      - name: Deploy validation queries and stored procedures to all schemas
-        env:
-          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
-        run: |
-          cd repo/frontend
-          npm install --production=false
-          npx tsx scripts/deploy-validations-to-all-schemas.ts
-        continue-on-error: false
 
   # Rollback job - creates a GitHub issue on deploy failure for manual intervention.
   # An app restart is attempted but will not fix code-level issues.

--- a/.github/workflows/dev-forestgeo-livesite.yml
+++ b/.github/workflows/dev-forestgeo-livesite.yml
@@ -11,7 +11,8 @@ on:
 
 concurrency:
   group: deploy-development
-  cancel-in-progress: true
+  # Schema DDL and its ledger update must never be interrupted between steps.
+  cancel-in-progress: false
 
 jobs:
   build-app-development:
@@ -261,23 +262,25 @@ jobs:
           # Note: External health checks are not performed because Azure Easy Auth
           # requires authentication. Build integrity was verified in the build job.
 
-  # Rollback job - creates a GitHub issue on deploy failure for manual intervention.
-  # An app restart is attempted but will not fix code-level issues.
+  # Failure-notification job for schema migration or app deployment failures.
+  # An app restart is attempted only when app deployment itself failed.
   # Real rollback requires redeploying a previous good commit.
   rollback-on-failure:
-    if: failure() && needs.deploy-app-development.result == 'failure'
-    needs: [build-app-development, deploy-app-development]
+    if: always() && (needs.migrate-and-verify-development.result == 'failure' || needs.deploy-app-development.result == 'failure')
+    needs: [build-app-development, migrate-and-verify-development, deploy-app-development]
     runs-on: ubuntu-latest
     environment: development_temp
 
     steps:
       - name: Azure Login
+        if: needs.deploy-app-development.result == 'failure'
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
         continue-on-error: true  # Gracefully handle missing credentials
 
       - name: Attempt app restart
+        if: needs.deploy-app-development.result == 'failure'
         id: rollback
         run: |
           echo "Attempting to restart the app (will not fix code-level issues)..."
@@ -297,25 +300,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const migrationFailed = '${{ needs.migrate-and-verify-development.result }}' === 'failure';
+            const failureStage = migrationFailed ? 'schema migration/verification' : 'application deployment';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Development Deployment Failed - Manual Intervention Required',
-              body: `## Deployment Failure Alert
+              title: migrationFailed
+                ? 'Development Schema Migration Failed - Manual Intervention Required'
+                : 'Development Deployment Failed - Manual Intervention Required',
+              body: `## Development Pipeline Failure Alert
 
               **Time**: ${new Date().toISOString()}
               **Branch**: ${{ github.ref_name }}
               **Commit**: ${{ github.sha }}
               **Workflow Run**: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              **Failure Stage**: ${failureStage}
+              **Migration Job**: ${{ needs.migrate-and-verify-development.result }}
+              **Deployment Job**: ${{ needs.deploy-app-development.result }}
 
               ### What Happened
-              The deployment failed. An app restart was attempted but this only helps with transient issues, not code-level problems.
+              The ${failureStage} stage failed. An app restart is attempted only for an application-deployment failure; schema failures require reviewing the migration and ledger state.
 
               ### Recommended Actions
               1. Check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-              2. Check Azure Portal for the app service status and logs
-              3. Verify the app is running by logging in and testing functionality
-              4. To roll back: push the last known good commit to the \`forestgeo-app-development\` branch
+              2. If migration failed, inspect each schema's \`schema_migrations\` ledger before retrying
+              3. If deployment failed, check Azure Portal for app service status and logs
+              4. Verify the app is running by logging in and testing functionality
 
               > **Note**: The health endpoint requires authentication (Azure Easy Auth) and cannot be checked externally.
 

--- a/.github/workflows/main-forestgeo-livesite.yml
+++ b/.github/workflows/main-forestgeo-livesite.yml
@@ -261,23 +261,25 @@ jobs:
           # Note: External health checks are not performed because Azure Easy Auth
           # requires authentication. Build integrity was verified in the build job.
 
-  # Rollback job - creates a GitHub issue on deploy failure for manual intervention.
-  # An app restart is attempted but will not fix code-level issues.
+  # Failure-notification job for schema migration or app deployment failures.
+  # An app restart is attempted only when app deployment itself failed.
   # Real rollback requires redeploying a previous good commit.
   rollback-on-failure:
-    if: failure() && needs.deploy-app-production.result == 'failure'
-    needs: [build-app-production, deploy-app-production]
+    if: always() && (needs.migrate-and-verify-production.result == 'failure' || needs.deploy-app-production.result == 'failure')
+    needs: [build-app-production, migrate-and-verify-production, deploy-app-production]
     runs-on: ubuntu-latest
     environment: production
 
     steps:
       - name: Azure Login
+        if: needs.deploy-app-production.result == 'failure'
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
         continue-on-error: true  # Gracefully handle missing credentials
 
       - name: Attempt app restart
+        if: needs.deploy-app-production.result == 'failure'
         id: rollback
         run: |
           echo "Attempting to restart the app (will not fix code-level issues)..."
@@ -297,25 +299,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const migrationFailed = '${{ needs.migrate-and-verify-production.result }}' === 'failure';
+            const failureStage = migrationFailed ? 'schema migration/verification' : 'application deployment';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'URGENT: Production Deployment Failed - Manual Intervention Required',
-              body: `## Production Deployment Failure Alert
+              title: migrationFailed
+                ? 'URGENT: Production Schema Migration Failed - Manual Intervention Required'
+                : 'URGENT: Production Deployment Failed - Manual Intervention Required',
+              body: `## Production Pipeline Failure Alert
 
               **Time**: ${new Date().toISOString()}
               **Branch**: ${{ github.ref_name }}
               **Commit**: ${{ github.sha }}
               **Workflow Run**: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              **Failure Stage**: ${failureStage}
+              **Migration Job**: ${{ needs.migrate-and-verify-production.result }}
+              **Deployment Job**: ${{ needs.deploy-app-production.result }}
 
               ### What Happened
-              The production deployment failed. An app restart was attempted but this only helps with transient issues, not code-level problems.
+              The production ${failureStage} stage failed. An app restart is attempted only for an application-deployment failure; schema failures require reviewing the migration and ledger state.
 
               ### Recommended Actions
               1. Check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-              2. Check Azure Portal for the app service status and logs
-              3. Verify the app is running by logging in and testing functionality
-              4. To roll back: push the last known good commit to \`main\`
+              2. If migration failed, inspect each schema's \`schema_migrations\` ledger before retrying
+              3. If deployment failed, check Azure Portal for app service status and logs
+              4. Verify the app is running by logging in and testing functionality
 
               > **Note**: The health endpoint requires authentication (Azure Easy Auth) and cannot be checked externally.
 

--- a/.github/workflows/main-forestgeo-livesite.yml
+++ b/.github/workflows/main-forestgeo-livesite.yml
@@ -184,8 +184,55 @@ jobs:
           name: app-build
           path: frontend/build/standalone
 
-  deploy-app-production:
+  # Schema migrate + verify + stored-procedure/validation deploy.
+  # This runs BEFORE the app deploy and the app deploy `needs:` it, so a failed
+  # migration or a failed contract verify PREVENTS incompatible app code from
+  # going live. The stored procedures reference the new columns, so they are
+  # deployed only after the migration has added those columns.
+  migrate-and-verify-production:
     needs: build-app-production
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: |
+          cd frontend/
+          npm install --production=false
+
+      - name: Apply schema migrations to all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/apply-schema-migrations.ts --all-sites --apply
+        continue-on-error: false
+
+      - name: Verify schema contract across all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/check-schema-contract.ts --all-sites
+        continue-on-error: false
+
+      - name: Deploy validation queries and stored procedures to all schemas
+        env:
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+        run: |
+          cd frontend/
+          npx tsx scripts/deploy-validations-to-all-schemas.ts
+        continue-on-error: false
+
+  deploy-app-production:
+    needs: [build-app-production, migrate-and-verify-production]
     runs-on: ubuntu-latest
     environment: production
 
@@ -213,25 +260,6 @@ jobs:
           echo "Deployment submitted to Azure App Service"
           # Note: External health checks are not performed because Azure Easy Auth
           # requires authentication. Build integrity was verified in the build job.
-
-      - name: Setup Node.js for validation deployment
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-
-      - name: Checkout code for validation deployment
-        uses: actions/checkout@v4
-        with:
-          path: repo
-
-      - name: Deploy validation queries and stored procedures to all schemas
-        env:
-          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
-        run: |
-          cd repo/frontend
-          npm install --production=false
-          npx tsx scripts/deploy-validations-to-all-schemas.ts
-        continue-on-error: false
 
   # Rollback job - creates a GitHub issue on deploy failure for manual intervention.
   # An app restart is attempted but will not fix code-level issues.

--- a/frontend/db/migrations/manifest.ts
+++ b/frontend/db/migrations/manifest.ts
@@ -22,5 +22,13 @@ export const SCHEMA_MIGRATION_MANIFEST: readonly MigrationManifestEntry[] = [
   {
     id: '2026-07-13-01-add-published-stemid-and-source-format',
     file: 'schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql'
+  },
+  {
+    id: '2026-07-16-01-add-cm-uploadbatch-census-index',
+    file: 'schema-contract-repair/2026-07-16-01-add-cm-uploadbatch-census-index.sql'
+  },
+  {
+    id: '2026-07-16-02-normalize-temporarymeasurements-ids',
+    file: 'schema-contract-repair/2026-07-16-02-normalize-temporarymeasurements-ids.sql'
   }
 ] as const;

--- a/frontend/db/migrations/manifest.ts
+++ b/frontend/db/migrations/manifest.ts
@@ -1,0 +1,26 @@
+/**
+ * Ordered manifest of schema-contract-repair migrations.
+ *
+ * The apply-schema-migrations runner applies ONLY the migrations listed here, in
+ * array order — never "every historical .sql file in db/migrations". Each entry's
+ * `file` is resolved relative to this directory (db/migrations/). Adding a
+ * migration means appending an entry; entries are never reordered or removed once
+ * they have been applied to any live schema (the per-schema ledger keys on `id`).
+ *
+ * `id` is a stable, human-readable identifier (date-ordinal-slug). It is the
+ * ledger primary key, so it must never change after first release.
+ */
+
+export interface MigrationManifestEntry {
+  /** Stable ledger key. Never change after release. */
+  id: string;
+  /** Path to the migration SQL, relative to db/migrations/. */
+  file: string;
+}
+
+export const SCHEMA_MIGRATION_MANIFEST: readonly MigrationManifestEntry[] = [
+  {
+    id: '2026-07-13-01-add-published-stemid-and-source-format',
+    file: 'schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql'
+  }
+] as const;

--- a/frontend/db/migrations/schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql
@@ -1,42 +1,12 @@
 -- =====================================================================================
--- Migration 2026-07-13-01: repair known temporarymeasurements + collation drift
+-- Migration 2026-07-13-01: repair the temporarymeasurements write contract
 -- =====================================================================================
--- Purpose
---   Bring live schemas up to the canonical write contract (db/sql/tablestructures.sql)
---   BEFORE app code that depends on the new columns deploys. This repairs the three
---   known live-schema drifts that produced runtime 500s ("Unknown column
---   'PublishedStemID'/'SourceFormat' in 'field list'") and collation mismatches:
---     1. temporarymeasurements.SourceFormat missing  (canonical: varchar(32) NOT NULL DEFAULT 'csv')
---     2. temporarymeasurements.PublishedStemID missing (canonical: int unsigned NULL)
---     3. text columns / database default left on a legacy collation instead of
---        utf8mb4_0900_ai_ci.
---
--- Idempotency
---   Every statement is guarded against information_schema so a re-apply is a no-op:
---     - column adds run only when the column is absent;
---     - the database-default fix runs only when the default collation differs;
---     - each table is rebuilt (CONVERT TO) only when it still has a non-generated
---       text column off the target collation.
---   Column adds are intentionally reviewed-additive: no data column is dropped or
---   narrowed.
---
--- MySQL notes
---   - ADD COLUMN IF NOT EXISTS is MariaDB-only, so the guarded-PREPARE pattern
---     (matching the existing unified-measurements migrations) is used instead.
---   - DDL implicitly commits in MySQL, so this file is NOT wrapped in a transaction
---     inside the SQL; the runner records the ledger entry as a single atomic
---     statement and relies on these guards for re-run safety.
---   - CONVERT TO CHARACTER SET rebuilds the table. It is guarded so it only runs on
---     schemas that actually carry legacy-collation text columns; on a large
---     coremeasurements this is a one-time, drift-only repair, never a re-run cost.
---   - CONVERT TO leaves STORED/VIRTUAL generated columns (e.g. species.unique_sig)
---     untouched and preserves each column's type, nullability, and default.
--- =====================================================================================
+-- This migration is deliberately additive. Charset/collation normalization is
+-- reported by the contract audit but is not performed automatically during an
+-- application deploy because table-wide CONVERT operations can rebuild and lock
+-- large ingestion tables and can widen TEXT-family column types.
 
--- ---------------------------------------------------------------------------
--- 1. temporarymeasurements.SourceFormat  (add before collation normalization so
---    the CONVERT pass below also normalizes the freshly-added column's collation)
--- ---------------------------------------------------------------------------
+-- temporarymeasurements.SourceFormat
 SET @col_exists := (
     SELECT COUNT(*) FROM information_schema.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE()
@@ -49,9 +19,7 @@ SET @ddl := IF(@col_exists > 0,
 );
 PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
--- ---------------------------------------------------------------------------
--- 2. temporarymeasurements.PublishedStemID
--- ---------------------------------------------------------------------------
+-- temporarymeasurements.PublishedStemID
 SET @col_exists := (
     SELECT COUNT(*) FROM information_schema.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE()
@@ -64,142 +32,4 @@ SET @ddl := IF(@col_exists > 0,
 );
 PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
--- ---------------------------------------------------------------------------
--- 3. database default collation
--- ---------------------------------------------------------------------------
-SET @db_collation := (
-    SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA
-    WHERE SCHEMA_NAME = DATABASE()
-);
-SET @ddl := IF(@db_collation = 'utf8mb4_0900_ai_ci',
-    'SELECT ''database default collation already utf8mb4_0900_ai_ci'' AS Status',
-    CONCAT('ALTER DATABASE `', DATABASE(), '` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci')
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- ---------------------------------------------------------------------------
--- 4. text-column collation normalization for every critical (write-contract) table.
---    The guard counts only NON-generated text columns still off the target
---    collation, so the rebuild runs only where genuine drift exists and re-apply
---    is a no-op. Table set mirrors CRITICAL_TABLES in lib/db/schema-contract.ts.
--- ---------------------------------------------------------------------------
-SET @target_collation := 'utf8mb4_0900_ai_ci';
-
--- temporarymeasurements
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'temporarymeasurements'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''temporarymeasurements collation ok'' AS Status',
-    'ALTER TABLE `temporarymeasurements` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- coremeasurements
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'coremeasurements'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''coremeasurements collation ok'' AS Status',
-    'ALTER TABLE `coremeasurements` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- species
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'species'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''species collation ok'' AS Status',
-    'ALTER TABLE `species` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- quadrats
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'quadrats'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''quadrats collation ok'' AS Status',
-    'ALTER TABLE `quadrats` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- trees
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'trees'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''trees collation ok'' AS Status',
-    'ALTER TABLE `trees` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- stems
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stems'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''stems collation ok'' AS Status',
-    'ALTER TABLE `stems` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- measurement_error_log
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'measurement_error_log'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''measurement_error_log collation ok'' AS Status',
-    'ALTER TABLE `measurement_error_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- uploadintegrityalerts
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploadintegrityalerts'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''uploadintegrityalerts collation ok'' AS Status',
-    'ALTER TABLE `uploadintegrityalerts` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
--- uploadmetrics
-SET @needs_convert := (
-    SELECT COUNT(*) FROM information_schema.COLUMNS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploadmetrics'
-      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
-      AND EXTRA NOT LIKE '%GENERATED%'
-);
-SET @ddl := IF(@needs_convert = 0,
-    'SELECT ''uploadmetrics collation ok'' AS Status',
-    'ALTER TABLE `uploadmetrics` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
-);
-PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SELECT 'Migration 2026-07-13-01 complete: temporarymeasurements columns + critical-table collation ensured.' AS Status;
+SELECT 'Migration 2026-07-13-01 complete: temporarymeasurements write columns ensured.' AS Status;

--- a/frontend/db/migrations/schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-07-13-01-add-published-stemid-and-source-format.sql
@@ -1,0 +1,205 @@
+-- =====================================================================================
+-- Migration 2026-07-13-01: repair known temporarymeasurements + collation drift
+-- =====================================================================================
+-- Purpose
+--   Bring live schemas up to the canonical write contract (db/sql/tablestructures.sql)
+--   BEFORE app code that depends on the new columns deploys. This repairs the three
+--   known live-schema drifts that produced runtime 500s ("Unknown column
+--   'PublishedStemID'/'SourceFormat' in 'field list'") and collation mismatches:
+--     1. temporarymeasurements.SourceFormat missing  (canonical: varchar(32) NOT NULL DEFAULT 'csv')
+--     2. temporarymeasurements.PublishedStemID missing (canonical: int unsigned NULL)
+--     3. text columns / database default left on a legacy collation instead of
+--        utf8mb4_0900_ai_ci.
+--
+-- Idempotency
+--   Every statement is guarded against information_schema so a re-apply is a no-op:
+--     - column adds run only when the column is absent;
+--     - the database-default fix runs only when the default collation differs;
+--     - each table is rebuilt (CONVERT TO) only when it still has a non-generated
+--       text column off the target collation.
+--   Column adds are intentionally reviewed-additive: no data column is dropped or
+--   narrowed.
+--
+-- MySQL notes
+--   - ADD COLUMN IF NOT EXISTS is MariaDB-only, so the guarded-PREPARE pattern
+--     (matching the existing unified-measurements migrations) is used instead.
+--   - DDL implicitly commits in MySQL, so this file is NOT wrapped in a transaction
+--     inside the SQL; the runner records the ledger entry as a single atomic
+--     statement and relies on these guards for re-run safety.
+--   - CONVERT TO CHARACTER SET rebuilds the table. It is guarded so it only runs on
+--     schemas that actually carry legacy-collation text columns; on a large
+--     coremeasurements this is a one-time, drift-only repair, never a re-run cost.
+--   - CONVERT TO leaves STORED/VIRTUAL generated columns (e.g. species.unique_sig)
+--     untouched and preserves each column's type, nullability, and default.
+-- =====================================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. temporarymeasurements.SourceFormat  (add before collation normalization so
+--    the CONVERT pass below also normalizes the freshly-added column's collation)
+-- ---------------------------------------------------------------------------
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'SourceFormat'
+);
+SET @ddl := IF(@col_exists > 0,
+    'SELECT ''temporarymeasurements.SourceFormat already present'' AS Status',
+    'ALTER TABLE `temporarymeasurements` ADD COLUMN `SourceFormat` varchar(32) NOT NULL DEFAULT ''csv'''
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. temporarymeasurements.PublishedStemID
+-- ---------------------------------------------------------------------------
+SET @col_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'PublishedStemID'
+);
+SET @ddl := IF(@col_exists > 0,
+    'SELECT ''temporarymeasurements.PublishedStemID already present'' AS Status',
+    'ALTER TABLE `temporarymeasurements` ADD COLUMN `PublishedStemID` int unsigned NULL'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 3. database default collation
+-- ---------------------------------------------------------------------------
+SET @db_collation := (
+    SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA
+    WHERE SCHEMA_NAME = DATABASE()
+);
+SET @ddl := IF(@db_collation = 'utf8mb4_0900_ai_ci',
+    'SELECT ''database default collation already utf8mb4_0900_ai_ci'' AS Status',
+    CONCAT('ALTER DATABASE `', DATABASE(), '` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci')
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 4. text-column collation normalization for every critical (write-contract) table.
+--    The guard counts only NON-generated text columns still off the target
+--    collation, so the rebuild runs only where genuine drift exists and re-apply
+--    is a no-op. Table set mirrors CRITICAL_TABLES in lib/db/schema-contract.ts.
+-- ---------------------------------------------------------------------------
+SET @target_collation := 'utf8mb4_0900_ai_ci';
+
+-- temporarymeasurements
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'temporarymeasurements'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''temporarymeasurements collation ok'' AS Status',
+    'ALTER TABLE `temporarymeasurements` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- coremeasurements
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'coremeasurements'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''coremeasurements collation ok'' AS Status',
+    'ALTER TABLE `coremeasurements` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- species
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'species'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''species collation ok'' AS Status',
+    'ALTER TABLE `species` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- quadrats
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'quadrats'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''quadrats collation ok'' AS Status',
+    'ALTER TABLE `quadrats` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- trees
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'trees'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''trees collation ok'' AS Status',
+    'ALTER TABLE `trees` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- stems
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stems'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''stems collation ok'' AS Status',
+    'ALTER TABLE `stems` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- measurement_error_log
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'measurement_error_log'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''measurement_error_log collation ok'' AS Status',
+    'ALTER TABLE `measurement_error_log` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- uploadintegrityalerts
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploadintegrityalerts'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''uploadintegrityalerts collation ok'' AS Status',
+    'ALTER TABLE `uploadintegrityalerts` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- uploadmetrics
+SET @needs_convert := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'uploadmetrics'
+      AND COLLATION_NAME IS NOT NULL AND COLLATION_NAME <> @target_collation
+      AND EXTRA NOT LIKE '%GENERATED%'
+);
+SET @ddl := IF(@needs_convert = 0,
+    'SELECT ''uploadmetrics collation ok'' AS Status',
+    'ALTER TABLE `uploadmetrics` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration 2026-07-13-01 complete: temporarymeasurements columns + critical-table collation ensured.' AS Status;

--- a/frontend/db/migrations/schema-contract-repair/2026-07-16-01-add-cm-uploadbatch-census-index.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-07-16-01-add-cm-uploadbatch-census-index.sql
@@ -1,0 +1,23 @@
+-- =====================================================================================
+-- Migration 2026-07-16-01: ensure coremeasurements has idx_cm_uploadbatch_census
+-- =====================================================================================
+-- The 2026-07-16 read-only contract audit of the production server found this index
+-- (canonical in db/sql/tablestructures.sql) missing on 6 of 9 site schemas: harvard,
+-- mpala, panama, rabi, serc, testing. Batch-scoped upload verification and the
+-- ingestion procedures filter coremeasurements by (UploadBatchID, CensusID), so the
+-- missing index is both a contract failure and a per-upload full-scan cost.
+-- CREATE INDEX on InnoDB runs in-place and permits concurrent DML.
+
+SET @index_exists := (
+    SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'coremeasurements'
+      AND INDEX_NAME = 'idx_cm_uploadbatch_census'
+);
+SET @ddl := IF(@index_exists > 0,
+    'SELECT ''coremeasurements.idx_cm_uploadbatch_census already present'' AS Status',
+    'CREATE INDEX `idx_cm_uploadbatch_census` ON `coremeasurements` (`UploadBatchID`, `CensusID`)'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration 2026-07-16-01 complete: coremeasurements upload-batch index ensured.' AS Status;

--- a/frontend/db/migrations/schema-contract-repair/2026-07-16-02-normalize-temporarymeasurements-ids.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-07-16-02-normalize-temporarymeasurements-ids.sql
@@ -1,0 +1,59 @@
+-- =====================================================================================
+-- Migration 2026-07-16-02: normalize temporarymeasurements FileID/BatchID to contract
+-- =====================================================================================
+-- Canonical contract (db/sql/tablestructures.sql): FileID varchar(36) NULL,
+-- BatchID varchar(36) NOT NULL. The 2026-07-16 read-only audit found 4 of 9
+-- production schemas (harvard, mpala, rabi, testing) still on the pre-contract
+-- varchar(50) definitions with BatchID nullable. Audited data on those schemas is
+-- safe to narrow today (3 schemas have an empty staging table; rabi's max lengths
+-- are 10/20 with zero NULL BatchIDs).
+--
+-- NON-DESTRUCTIVE BY DESIGN: if rows violating the target contract exist at apply
+-- time (over-length IDs or NULL BatchID), this migration fails loudly via a call to
+-- a deliberately nonexistent, self-describing procedure instead of letting a
+-- non-strict sql_mode silently truncate values or coerce NULL to ''. An operator
+-- must then inspect and clear the offending staging rows before re-running.
+
+SET @needs_fileid := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'FileID'
+      AND (COLUMN_TYPE <> 'varchar(36)' OR IS_NULLABLE <> 'YES')
+);
+SET @needs_batchid := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'BatchID'
+      AND (COLUMN_TYPE <> 'varchar(36)' OR IS_NULLABLE <> 'NO')
+);
+
+-- Precondition: no staged rows may violate the target contract. Only checked when a
+-- repair is actually needed, so conforming schemas skip the table scan entirely
+-- (temporarymeasurements is a drained staging table, so the scan is cheap anyway).
+SET @violating_rows := IF(@needs_fileid + @needs_batchid = 0, 0, (
+    SELECT COUNT(*) FROM temporarymeasurements
+    WHERE CHAR_LENGTH(FileID) > 36
+       OR CHAR_LENGTH(BatchID) > 36
+       OR BatchID IS NULL
+));
+SET @ddl := IF(@violating_rows > 0,
+    'CALL mig_2026_07_16_02_blocked_staging_rows_violate_contract()',
+    'SELECT ''temporarymeasurements ID precondition ok'' AS Status'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @ddl := IF(@needs_fileid = 0,
+    'SELECT ''temporarymeasurements.FileID already varchar(36) NULL'' AS Status',
+    'ALTER TABLE `temporarymeasurements` MODIFY COLUMN `FileID` varchar(36) NULL'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @ddl := IF(@needs_batchid = 0,
+    'SELECT ''temporarymeasurements.BatchID already varchar(36) NOT NULL'' AS Status',
+    'ALTER TABLE `temporarymeasurements` MODIFY COLUMN `BatchID` varchar(36) NOT NULL'
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration 2026-07-16-02 complete: temporarymeasurements FileID/BatchID normalized.' AS Status;

--- a/frontend/lib/db/schema-contract.test.ts
+++ b/frontend/lib/db/schema-contract.test.ts
@@ -238,3 +238,73 @@ describe('formatContractFailures', () => {
     expect(rendered).toContain('varchar(25)');
   });
 });
+
+// Regression guards for two false-failure sources that would only surface when
+// schema-contract.ts runs as a LIVE production audit across many schemas.
+describe('robustness regressions', () => {
+  it('does not mistag a plain column as generated when its remainder contains the word "as"', () => {
+    const ddl = `
+      ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      create table if not exists notes
+      (
+          NoteID   int auto_increment primary key,
+          Body     varchar(64)  null comment 'measured as diameter',
+          Label    varchar(32)  not null default 'flagged as bad'
+      );
+    `;
+    const contract = parseCanonicalSchemaContract(ddl);
+    const columns = contract.tables['notes'].columns;
+
+    // The word "as" in a comment/default must not trip generated-column detection.
+    expect(columns['body'].extra).toBe('');
+    expect(columns['label'].extra).toBe('');
+    // And the surrounding metadata must still parse correctly.
+    expect(columns['label'].defaultValue).toBe('flagged as bad');
+    expect(columns['body'].collation).toBe(TARGET_COLLATION);
+
+    // A self-comparison must therefore produce no spurious diff.
+    const { failures } = compareSchemaContracts(contract, JSON.parse(JSON.stringify(contract)), {
+      tables: ['notes'],
+      requiredIndexesByTable: { notes: [] }
+    });
+    expect(failures).toEqual([]);
+  });
+
+  it('still detects a genuine stored generated column via the explicit AS (...) marker', () => {
+    const ddl = `
+      ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      create table if not exists sums
+      (
+          A     int null,
+          B     int null,
+          Total int as (A + B) stored
+      );
+    `;
+    const contract = parseCanonicalSchemaContract(ddl);
+    expect(contract.tables['sums'].columns['total'].extra).toBe('stored_generated');
+  });
+
+  it('throws a descriptive error when a DDL has text columns but no ALTER DATABASE COLLATE clause', () => {
+    const ddl = `
+      create table if not exists people
+      (
+          PersonID int auto_increment primary key,
+          Name     varchar(64) not null
+      );
+    `;
+    expect(() => parseCanonicalSchemaContract(ddl)).toThrowError(/people\.Name[\s\S]*ALTER DATABASE[\s\S]*COLLATE/i);
+  });
+
+  it('does not throw for a DDL with no text columns and no ALTER DATABASE COLLATE clause', () => {
+    const ddl = `
+      create table if not exists counters
+      (
+          CounterID int auto_increment primary key,
+          Value     int not null default 0
+      );
+    `;
+    const contract = parseCanonicalSchemaContract(ddl);
+    expect(contract.defaultCollation).toBeNull();
+    expect(contract.tables['counters'].columns['value'].collation).toBeNull();
+  });
+});

--- a/frontend/lib/db/schema-contract.test.ts
+++ b/frontend/lib/db/schema-contract.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Layer A (no database) unit tests for the schema-contract module.
+ *
+ * These exercise the pure DDL parser and the contract-diff logic against small
+ * fixture strings and programmatically mutated contracts. They must fail if the
+ * parser stops normalizing a type/collation/generated dimension, or if the diff
+ * stops distinguishing a missing column, a type/collation drift, or a missing
+ * required index from an exact match. No live schema is touched here — the
+ * database-backed parity check lives in the integration suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseCanonicalSchemaContract,
+  compareSchemaContracts,
+  normalizeTypeSignature,
+  normalizeDefaultValue,
+  normalizeExtraMetadata,
+  formatContractFailures,
+  type SchemaContract,
+  type CompareOptions
+} from './schema-contract';
+
+const TARGET_COLLATION = 'utf8mb4_0900_ai_ci';
+
+const FIXTURE_DDL = `
+-- leading comment that must be ignored
+ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+create table if not exists widgets
+(
+    WidgetID    int auto_increment
+        primary key,
+    Code        varchar(25)                          null, -- trailing comment
+    Severity    enum ('info', 'warning', 'critical') not null default 'warning',
+    Ratio       decimal(12, 6)                       null,
+    IsActive    tinyint(1) default 1                 not null,
+    Toggle      bit                                  null,
+    CreatedAt   datetime default CURRENT_TIMESTAMP   null,
+    Sig         varchar(500) as (concat_ws(_utf8mb4'#', coalesce(\`Code\`, _utf8mb4''))) stored invisible,
+    constraint uq_widgets_code_active
+        unique (Code, IsActive)
+);
+
+create index idx_widgets_code on widgets (Code);
+
+create unique index ux_widgets_ratio on widgets (Ratio);
+`;
+
+const WIDGET_COMPARE_OPTIONS: CompareOptions = {
+  tables: ['widgets'],
+  requiredIndexesByTable: { widgets: ['uq_widgets_code_active', 'ux_widgets_ratio'] }
+};
+
+function clone(contract: SchemaContract): SchemaContract {
+  return JSON.parse(JSON.stringify(contract));
+}
+
+describe('normalization helpers', () => {
+  it('normalizes type signatures consistently with information_schema', () => {
+    expect(normalizeTypeSignature('decimal(12, 6)')).toBe('decimal(12,6)');
+    expect(normalizeTypeSignature('int unsigned')).toBe('int unsigned');
+    expect(normalizeTypeSignature('bit')).toBe('bit(1)');
+    expect(normalizeTypeSignature('bit(1)')).toBe('bit(1)');
+    expect(normalizeTypeSignature("enum ('info', 'warning', 'stem dead')")).toBe("enum('info','warning','stem dead')");
+    expect(normalizeTypeSignature('VARCHAR(25)')).toBe('varchar(25)');
+  });
+
+  it('normalizes DDL and information_schema defaults to a single form', () => {
+    expect(normalizeDefaultValue("'csv'")).toBe('csv');
+    expect(normalizeDefaultValue('csv')).toBe('csv');
+    expect(normalizeDefaultValue('CURRENT_TIMESTAMP')).toBe('CURRENT_TIMESTAMP');
+    expect(normalizeDefaultValue('current_timestamp')).toBe('CURRENT_TIMESTAMP');
+    expect(normalizeDefaultValue('1')).toBe('1');
+    expect(normalizeDefaultValue("''")).toBe('');
+    expect(normalizeDefaultValue('null')).toBeNull();
+    expect(normalizeDefaultValue(null)).toBeNull();
+  });
+
+  it('reduces extra metadata to load-bearing flags and drops noise', () => {
+    expect(normalizeExtraMetadata('auto_increment')).toBe('auto_increment');
+    expect(normalizeExtraMetadata('STORED GENERATED')).toBe('stored_generated');
+    expect(normalizeExtraMetadata('STORED GENERATED INVISIBLE')).toBe('stored_generated');
+    expect(normalizeExtraMetadata('DEFAULT_GENERATED')).toBe('');
+    expect(normalizeExtraMetadata('DEFAULT_GENERATED on update CURRENT_TIMESTAMP')).toBe('on_update_current_timestamp');
+    expect(normalizeExtraMetadata('')).toBe('');
+  });
+});
+
+describe('parseCanonicalSchemaContract', () => {
+  const contract = parseCanonicalSchemaContract(FIXTURE_DDL);
+  const widgets = contract.tables['widgets'];
+
+  it('captures the database default collation from ALTER DATABASE', () => {
+    expect(contract.defaultCollation).toBe(TARGET_COLLATION);
+  });
+
+  it('parses an auto-increment primary key as a non-null, non-text int', () => {
+    const col = widgets.columns['widgetid'];
+    expect(col.typeSignature).toBe('int');
+    expect(col.nullable).toBe(false);
+    expect(col.extra).toBe('auto_increment');
+    expect(col.isText).toBe(false);
+    expect(col.collation).toBeNull();
+    expect(col.defaultValue).toBeNull();
+  });
+
+  it('assigns the schema default collation to text columns without an explicit COLLATE', () => {
+    const col = widgets.columns['code'];
+    expect(col.typeSignature).toBe('varchar(25)');
+    expect(col.nullable).toBe(true);
+    expect(col.isText).toBe(true);
+    expect(col.collation).toBe(TARGET_COLLATION);
+  });
+
+  it('parses an enum column with its value list, default, and text collation', () => {
+    const col = widgets.columns['severity'];
+    expect(col.typeSignature).toBe("enum('info','warning','critical')");
+    expect(col.nullable).toBe(false);
+    expect(col.defaultValue).toBe('warning');
+    expect(col.collation).toBe(TARGET_COLLATION);
+  });
+
+  it('parses decimal precision, tinyint default, and bit widening', () => {
+    expect(widgets.columns['ratio'].typeSignature).toBe('decimal(12,6)');
+    expect(widgets.columns['ratio'].collation).toBeNull();
+    expect(widgets.columns['isactive'].typeSignature).toBe('tinyint(1)');
+    expect(widgets.columns['isactive'].defaultValue).toBe('1');
+    expect(widgets.columns['isactive'].nullable).toBe(false);
+    expect(widgets.columns['toggle'].typeSignature).toBe('bit(1)');
+  });
+
+  it('parses a CURRENT_TIMESTAMP default without inventing extra metadata', () => {
+    const col = widgets.columns['createdat'];
+    expect(col.defaultValue).toBe('CURRENT_TIMESTAMP');
+    expect(col.extra).toBe('');
+  });
+
+  it('parses a stored generated column as generated, nullable, defaultless', () => {
+    const col = widgets.columns['sig'];
+    expect(col.typeSignature).toBe('varchar(500)');
+    expect(col.extra).toBe('stored_generated');
+    expect(col.defaultValue).toBeNull();
+    expect(col.collation).toBe(TARGET_COLLATION);
+  });
+
+  it('parses inline named unique constraints and standalone create index statements', () => {
+    expect(widgets.indexes['uq_widgets_code_active']).toEqual({ name: 'uq_widgets_code_active', unique: true, columns: ['Code', 'IsActive'] });
+    expect(widgets.indexes['idx_widgets_code']).toEqual({ name: 'idx_widgets_code', unique: false, columns: ['Code'] });
+    expect(widgets.indexes['ux_widgets_ratio']).toEqual({ name: 'ux_widgets_ratio', unique: true, columns: ['Ratio'] });
+  });
+});
+
+describe('compareSchemaContracts', () => {
+  const expected = parseCanonicalSchemaContract(FIXTURE_DDL);
+
+  it('reports no failures and no extras when the contracts match exactly', () => {
+    const result = compareSchemaContracts(expected, clone(expected), WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toEqual([]);
+    expect(result.extras).toEqual([]);
+  });
+
+  it('detects a missing required column', () => {
+    const actual = clone(expected);
+    delete actual.tables['widgets'].columns['code'];
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ table: 'widgets', object: 'Code', category: 'column', kind: 'missing' }));
+  });
+
+  it('detects a column type/width mismatch', () => {
+    const actual = clone(expected);
+    actual.tables['widgets'].columns['ratio'].typeSignature = 'decimal(10,2)';
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ object: 'Ratio', kind: 'type', expected: 'decimal(12,6)', actual: 'decimal(10,2)' }));
+  });
+
+  it('detects a nullability mismatch', () => {
+    const actual = clone(expected);
+    actual.tables['widgets'].columns['code'].nullable = false;
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ object: 'Code', kind: 'nullability' }));
+  });
+
+  it('detects a collation drift on a text column', () => {
+    const actual = clone(expected);
+    actual.tables['widgets'].columns['code'].collation = 'utf8mb4_general_ci';
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(
+      expect.objectContaining({ object: 'Code', kind: 'collation', expected: TARGET_COLLATION, actual: 'utf8mb4_general_ci' })
+    );
+  });
+
+  it('detects a missing required index', () => {
+    const actual = clone(expected);
+    delete actual.tables['widgets'].indexes['ux_widgets_ratio'];
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ object: 'ux_widgets_ratio', category: 'index', kind: 'missing' }));
+  });
+
+  it('detects a required index whose column list drifted', () => {
+    const actual = clone(expected);
+    actual.tables['widgets'].indexes['uq_widgets_code_active'].columns = ['Code'];
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ object: 'uq_widgets_code_active', category: 'index', kind: 'columns' }));
+  });
+
+  it('reports an extra live column as informational, not a failure', () => {
+    const actual = clone(expected);
+    actual.tables['widgets'].columns['surprise'] = {
+      name: 'Surprise',
+      typeSignature: 'int',
+      dataType: 'int',
+      nullable: true,
+      defaultValue: null,
+      extra: '',
+      collation: null,
+      isText: false
+    };
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toEqual([]);
+    expect(result.extras).toContainEqual(expect.objectContaining({ object: 'Surprise', category: 'column' }));
+  });
+
+  it('fails when a critical table is entirely absent from the live schema', () => {
+    const actual = clone(expected);
+    delete actual.tables['widgets'];
+    const result = compareSchemaContracts(expected, actual, WIDGET_COMPARE_OPTIONS);
+    expect(result.failures).toContainEqual(expect.objectContaining({ table: 'widgets', kind: 'missing' }));
+  });
+});
+
+describe('formatContractFailures', () => {
+  it('renders each failure with table, object, kind, and both values for debugging', () => {
+    const rendered = formatContractFailures([{ table: 'widgets', object: 'Code', category: 'column', kind: 'missing', expected: 'varchar(25)', actual: null }]);
+    expect(rendered).toContain('widgets');
+    expect(rendered).toContain('Code');
+    expect(rendered).toContain('missing');
+    expect(rendered).toContain('varchar(25)');
+  });
+});

--- a/frontend/lib/db/schema-contract.ts
+++ b/frontend/lib/db/schema-contract.ts
@@ -184,17 +184,23 @@ export function normalizeDefaultValue(raw: string | null | undefined): string | 
 }
 
 /**
- * Reduces raw EXTRA metadata (DDL fragment or information_schema.EXTRA) to the
- * load-bearing flags: auto_increment, generated (stored/virtual), and on-update.
- * Noise such as DEFAULT_GENERATED and INVISIBLE is intentionally dropped so the
- * two sides remain comparable.
+ * Reduces raw EXTRA metadata to the load-bearing flags: auto_increment,
+ * generated (stored/virtual), and on-update. Noise such as DEFAULT_GENERATED and
+ * INVISIBLE is intentionally dropped so the two sides remain comparable.
+ *
+ * Generation is detected ONLY via the explicit `stored generated` / `virtual
+ * generated` phrases — information_schema.EXTRA emits these verbatim, and the DDL
+ * parser injects the matching phrase after precisely detecting `AS (...)`. There
+ * is deliberately no bare-`as` fallback: a plain column whose remainder happens
+ * to contain the word "as" (e.g. `COMMENT 'measured as diameter'` or a default
+ * string) must not be mistagged as generated.
  */
 export function normalizeExtraMetadata(raw: string | null | undefined): string {
   const value = (raw ?? '').toLowerCase();
   const flags: string[] = [];
   if (value.includes('auto_increment')) flags.push('auto_increment');
-  if (value.includes('stored generated') || /\bas\b[\s\S]*\bstored\b/.test(value)) flags.push('stored_generated');
-  else if (value.includes('virtual generated') || /\bas\b/.test(value)) flags.push('virtual_generated');
+  if (value.includes('stored generated')) flags.push('stored_generated');
+  else if (value.includes('virtual generated')) flags.push('virtual_generated');
   if (value.includes('on update current_timestamp')) flags.push('on_update_current_timestamp');
   return flags.sort().join(',');
 }
@@ -332,8 +338,11 @@ function parseColumnDefinition(item: string, defaultCollation: string | null): C
     defaultValue = defaultMatch ? normalizeDefaultValue(defaultMatch[1]) : null;
   }
 
-  const extraSource = `${remainder}${isGenerated ? ' stored generated' : ''}`;
-  const extra = normalizeExtraMetadata(extraSource);
+  // A generated column is VIRTUAL unless it explicitly declares STORED/PERSISTENT.
+  // Inject the explicit phrase normalizeExtraMetadata keys on, so generation is
+  // driven by the precise `AS (...)` detection above rather than a loose scan.
+  const generatedMarker = isGenerated ? (/\b(stored|persistent)\b/i.test(remainder) ? ' stored generated' : ' virtual generated') : '';
+  const extra = normalizeExtraMetadata(`${remainder}${generatedMarker}`);
 
   const isText = isTextDataType(dataType);
   const collateMatch = remainder.match(/\bcollate\s+([A-Za-z0-9_]+)/i);
@@ -405,6 +414,24 @@ export function parseCanonicalSchemaContract(ddl: string): SchemaContract {
           columns: parseIndexColumns(indexMatch[4])
         };
       }
+    }
+  }
+
+  // Text-column collation is inherited from the schema default. If the canonical
+  // DDL never declared one (no `ALTER DATABASE ... COLLATE`), every text column
+  // would carry a null expected collation and then diff against a live
+  // utf8mb4_0900_ai_ci — mass false failures across every audited schema. Fail
+  // loudly here instead so the DDL, not the audit, is fixed.
+  if (defaultCollation === null) {
+    const firstTextColumn = Object.values(tables)
+      .flatMap(table => Object.values(table.columns).map(column => ({ table: table.name, column })))
+      .find(entry => entry.column.isText);
+    if (firstTextColumn) {
+      throw new Error(
+        `Canonical DDL declares text column(s) (e.g. ${firstTextColumn.table}.${firstTextColumn.column.name}) ` +
+          `but has no schema default collation: an "ALTER DATABASE ... COLLATE <collation>" clause is required so ` +
+          `text-column collation can be compared against the live schema.`
+      );
     }
   }
 

--- a/frontend/lib/db/schema-contract.ts
+++ b/frontend/lib/db/schema-contract.ts
@@ -1,0 +1,603 @@
+/**
+ * Schema contract: a normalized, comparable description of the database objects
+ * the application depends on at write time.
+ *
+ * There are two producers of a {@link SchemaContract}:
+ *   1. {@link parseCanonicalSchemaContract} / {@link loadCanonicalSchemaContract} —
+ *      parse the canonical DDL (`db/sql/tablestructures.sql`) into the contract shape.
+ *   2. {@link readLiveSchemaContract} — read `information_schema` for a provisioned
+ *      schema into the same shape.
+ *
+ * {@link compareSchemaContracts} diffs the two and returns structured failures
+ * (missing / incompatible REQUIRED objects) separately from informational extras
+ * (objects the live schema has beyond the canonical contract).
+ *
+ * This module is deliberately dependency-free (only `fs`/`path`) so it can be
+ * imported by an integration test, a CI audit script, and a deploy pre-flight
+ * check alike.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export const TARGET_TEXT_COLLATION = 'utf8mb4_0900_ai_ci';
+
+/** Tables whose write contract the application must be able to trust. */
+export const CRITICAL_TABLES = [
+  'temporarymeasurements',
+  'coremeasurements',
+  'species',
+  'quadrats',
+  'trees',
+  'stems',
+  'measurement_error_log',
+  'uploadintegrityalerts',
+  'uploadmetrics'
+] as const;
+
+/**
+ * Named indexes/constraints whose presence and shape are load-bearing for
+ * ingestion (dedup, idempotency, upload lineage, published-stem lookup).
+ * These are compared exactly; every other live index is reported as informational.
+ */
+export const REQUIRED_INDEXES_BY_TABLE: Record<string, readonly string[]> = {
+  species: ['uq_species_active_code'],
+  quadrats: ['uq_quadrats_active_name'],
+  temporarymeasurements: ['idx_tmpm_file_batch_census', 'ingest_temporarymeasurements_FBPC_index', 'idx_tmpm_plot_census_file_batch'],
+  coremeasurements: ['ux_cm_uploadbatch_rowindex', 'idx_cm_uploadbatch_census', 'idx_cm_uploadfile_batch_census_stem'],
+  stems: ['idx_stems_publishedstemid']
+};
+
+const TEXT_DATA_TYPES = new Set(['char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext', 'enum', 'set']);
+
+const CANONICAL_DDL_RELATIVE_PATH = path.join('db', 'sql', 'tablestructures.sql');
+
+export interface ColumnContract {
+  /** Original-cased column name. */
+  name: string;
+  /** Normalized full type incl. width/precision/unsigned, e.g. `varchar(25)`, `decimal(12,6)`, `int unsigned`, `bit(1)`. */
+  typeSignature: string;
+  /** Base data type (first keyword), e.g. `varchar`, `int`, `decimal`, `enum`. */
+  dataType: string;
+  nullable: boolean;
+  /** Normalized default (unquoted literal, `CURRENT_TIMESTAMP`, or null when there is no default). */
+  defaultValue: string | null;
+  /** Sorted, normalized generated/auto/on-update flags, e.g. `auto_increment`, `stored_generated`. */
+  extra: string;
+  /** Collation for text columns; null for non-text columns. */
+  collation: string | null;
+  isText: boolean;
+}
+
+export interface IndexContract {
+  /** Original-cased index/constraint name. */
+  name: string;
+  unique: boolean;
+  /** Ordered, original-cased column names. */
+  columns: string[];
+}
+
+export interface TableContract {
+  name: string;
+  /** Keyed by lower-cased column name. */
+  columns: Record<string, ColumnContract>;
+  /** Keyed by lower-cased index name. */
+  indexes: Record<string, IndexContract>;
+}
+
+export interface SchemaContract {
+  defaultCollation: string | null;
+  /** Keyed by lower-cased table name. */
+  tables: Record<string, TableContract>;
+}
+
+export type SchemaDifferenceCategory = 'column' | 'index';
+
+export type SchemaDifferenceKind = 'missing' | 'type' | 'nullability' | 'default' | 'extra' | 'collation' | 'uniqueness' | 'columns';
+
+export interface SchemaDifference {
+  table: string;
+  object: string;
+  category: SchemaDifferenceCategory;
+  kind: SchemaDifferenceKind;
+  expected: string | null;
+  actual: string | null;
+}
+
+export interface ContractComparison {
+  /** Missing or incompatible REQUIRED objects — these are contract violations. */
+  failures: SchemaDifference[];
+  /** Live objects beyond the canonical contract — informational, never a failure here. */
+  extras: SchemaDifference[];
+}
+
+export interface CompareOptions {
+  /** Tables to compare (lower-cased); defaults to {@link CRITICAL_TABLES}. */
+  tables?: readonly string[];
+  /** Required named indexes per table; defaults to {@link REQUIRED_INDEXES_BY_TABLE}. */
+  requiredIndexesByTable?: Record<string, readonly string[]>;
+}
+
+/** Minimal row shape returned by a query executor; sufficient for information_schema reads. */
+export type SchemaQueryRow = Record<string, unknown>;
+export type SchemaQueryExecutor = (sql: string, params: unknown[]) => Promise<SchemaQueryRow[]>;
+
+// ---------------------------------------------------------------------------
+// Normalization helpers (shared by the DDL parser and the information_schema reader)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strips whitespace that is adjacent to `(`, `)`, or `,` and collapses the rest
+ * to single spaces — but only OUTSIDE single-quoted string literals, so enum
+ * values such as `'alive-not measured'` keep their internal spaces.
+ */
+function collapseTypeWhitespace(raw: string): string {
+  let result = '';
+  let inQuote = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (ch === "'") {
+      inQuote = !inQuote;
+      result += ch;
+      continue;
+    }
+    if (inQuote) {
+      result += ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      const prev = result[result.length - 1];
+      const next = raw[i + 1];
+      if (prev === '(' || prev === ',' || next === '(' || next === ')' || next === ',') continue;
+      if (prev === ' ') continue;
+      result += ' ';
+      continue;
+    }
+    result += ch;
+  }
+  return result.trim();
+}
+
+export function normalizeTypeSignature(raw: string): string {
+  let normalized = collapseTypeWhitespace(raw.toLowerCase());
+  // MySQL reports a bare BIT as bit(1); make both sides agree.
+  if (normalized === 'bit') normalized = 'bit(1)';
+  return normalized;
+}
+
+/**
+ * Normalizes a default value from either DDL (`default 'csv'`, `default 1`,
+ * `default CURRENT_TIMESTAMP`) or information_schema (already-unquoted) into a
+ * single comparable form. Returns null when there is no default.
+ */
+export function normalizeDefaultValue(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return '';
+  if (trimmed.toLowerCase() === 'null') return null;
+  if (trimmed.toLowerCase() === 'current_timestamp') return 'CURRENT_TIMESTAMP';
+  // Single-quoted string literal -> inner value (handles the '' -> ' escape).
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+/**
+ * Reduces raw EXTRA metadata (DDL fragment or information_schema.EXTRA) to the
+ * load-bearing flags: auto_increment, generated (stored/virtual), and on-update.
+ * Noise such as DEFAULT_GENERATED and INVISIBLE is intentionally dropped so the
+ * two sides remain comparable.
+ */
+export function normalizeExtraMetadata(raw: string | null | undefined): string {
+  const value = (raw ?? '').toLowerCase();
+  const flags: string[] = [];
+  if (value.includes('auto_increment')) flags.push('auto_increment');
+  if (value.includes('stored generated') || /\bas\b[\s\S]*\bstored\b/.test(value)) flags.push('stored_generated');
+  else if (value.includes('virtual generated') || /\bas\b/.test(value)) flags.push('virtual_generated');
+  if (value.includes('on update current_timestamp')) flags.push('on_update_current_timestamp');
+  return flags.sort().join(',');
+}
+
+function isTextDataType(dataType: string): boolean {
+  return TEXT_DATA_TYPES.has(dataType.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// DDL parsing
+// ---------------------------------------------------------------------------
+
+/** Removes `-- ...` line comments that fall outside single-quoted string literals. */
+function stripLineComments(ddl: string): string {
+  return ddl
+    .split('\n')
+    .map(line => {
+      let inQuote = false;
+      for (let i = 0; i < line.length - 1; i++) {
+        const ch = line[i];
+        if (ch === "'") inQuote = !inQuote;
+        if (!inQuote && ch === '-' && line[i + 1] === '-') return line.slice(0, i);
+      }
+      return line;
+    })
+    .join('\n');
+}
+
+/** Splits DDL into statements on semicolons that fall outside quotes/identifiers. */
+function splitStatements(ddl: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let inQuote = false;
+  let inBacktick = false;
+  for (let i = 0; i < ddl.length; i++) {
+    const ch = ddl[i];
+    if (ch === "'" && !inBacktick) inQuote = !inQuote;
+    else if (ch === '`' && !inQuote) inBacktick = !inBacktick;
+    if (ch === ';' && !inQuote && !inBacktick) {
+      const trimmed = current.trim();
+      if (trimmed) statements.push(trimmed);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  const tail = current.trim();
+  if (tail) statements.push(tail);
+  return statements;
+}
+
+/** Extracts the content inside the outermost balanced parentheses of a CREATE TABLE. */
+function extractTableBody(statement: string): string {
+  const open = statement.indexOf('(');
+  if (open < 0) return '';
+  let depth = 0;
+  let inQuote = false;
+  let inBacktick = false;
+  for (let i = open; i < statement.length; i++) {
+    const ch = statement[i];
+    if (ch === "'" && !inBacktick) inQuote = !inQuote;
+    else if (ch === '`' && !inQuote) inBacktick = !inBacktick;
+    if (inQuote || inBacktick) continue;
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return statement.slice(open + 1, i);
+    }
+  }
+  return statement.slice(open + 1);
+}
+
+/** Splits a table body into top-level items on commas outside quotes/identifiers/parens. */
+function splitTopLevelItems(body: string): string[] {
+  const items: string[] = [];
+  let current = '';
+  let depth = 0;
+  let inQuote = false;
+  let inBacktick = false;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "'" && !inBacktick) inQuote = !inQuote;
+    else if (ch === '`' && !inQuote) inBacktick = !inBacktick;
+    if (!inQuote && !inBacktick) {
+      if (ch === '(') depth++;
+      else if (ch === ')') depth--;
+      else if (ch === ',' && depth === 0) {
+        const trimmed = current.trim();
+        if (trimmed) items.push(trimmed);
+        current = '';
+        continue;
+      }
+    }
+    current += ch;
+  }
+  const tail = current.trim();
+  if (tail) items.push(tail);
+  return items;
+}
+
+function parseIndexColumns(rawColumns: string): string[] {
+  return splitTopLevelItems(rawColumns).map(
+    col =>
+      col
+        .replace(/`/g, '')
+        .replace(/\([^)]*\)/g, '') // drop prefix lengths / functional parts
+        .trim()
+        .split(/\s+/)[0]
+  );
+}
+
+function parseColumnDefinition(item: string, defaultCollation: string | null): ColumnContract | null {
+  const nameMatch = item.match(/^`?([A-Za-z_][A-Za-z0-9_]*)`?\s+([\s\S]+)$/);
+  if (!nameMatch) return null;
+  const name = nameMatch[1];
+  const remainder = nameMatch[2];
+
+  const isGenerated = /\bas\s*\(/i.test(remainder);
+  const typeSource = isGenerated ? remainder.slice(0, remainder.search(/\bas\s*\(/i)) : remainder;
+
+  const typeMatch = typeSource.match(/^\s*([A-Za-z]+)\s*(\([^)]*\))?\s*(unsigned)?\s*(zerofill)?/i);
+  if (!typeMatch) return null;
+  const dataType = typeMatch[1].toLowerCase();
+  const parenPart = typeMatch[2] ?? '';
+  const unsignedPart = typeMatch[3] ? ' unsigned' : '';
+  const typeSignature = normalizeTypeSignature(`${dataType}${parenPart}${unsignedPart}`);
+
+  const hasNotNull = /\bnot\s+null\b/i.test(remainder);
+  const hasInlinePrimaryKey = /\bprimary\s+key\b/i.test(remainder);
+  const nullable = !(hasNotNull || hasInlinePrimaryKey);
+
+  let defaultValue: string | null = null;
+  if (!isGenerated) {
+    const defaultMatch = remainder.match(/\bdefault\s+(b'[^']*'|'(?:[^']|'')*'|[^\s,]+)/i);
+    defaultValue = defaultMatch ? normalizeDefaultValue(defaultMatch[1]) : null;
+  }
+
+  const extraSource = `${remainder}${isGenerated ? ' stored generated' : ''}`;
+  const extra = normalizeExtraMetadata(extraSource);
+
+  const isText = isTextDataType(dataType);
+  const collateMatch = remainder.match(/\bcollate\s+([A-Za-z0-9_]+)/i);
+  const collation = isText ? (collateMatch ? collateMatch[1] : defaultCollation) : null;
+
+  return { name, typeSignature, dataType, nullable, defaultValue, extra, collation, isText };
+}
+
+function markPrimaryKeyColumnsNotNull(body: string, columns: Record<string, ColumnContract>): void {
+  for (const item of splitTopLevelItems(body)) {
+    const pkMatch = item.match(/^(?:constraint\s+\w+\s+)?primary\s+key\s*\(([^)]*)\)/i);
+    if (!pkMatch) continue;
+    for (const col of parseIndexColumns(pkMatch[1])) {
+      const existing = columns[col.toLowerCase()];
+      if (existing) existing.nullable = false;
+    }
+  }
+}
+
+function parseTableStatement(statement: string, defaultCollation: string | null): TableContract | null {
+  const header = statement.match(/^create\s+table\s+(?:if\s+not\s+exists\s+)?`?([A-Za-z0-9_]+)`?\s*\(/i);
+  if (!header) return null;
+  const name = header[1];
+  const body = extractTableBody(statement);
+
+  const columns: Record<string, ColumnContract> = {};
+  const indexes: Record<string, IndexContract> = {};
+
+  for (const item of splitTopLevelItems(body)) {
+    const namedUnique = item.match(/^constraint\s+`?(\w+)`?\s+unique\s*\(([^)]*)\)/i);
+    if (namedUnique) {
+      indexes[namedUnique[1].toLowerCase()] = { name: namedUnique[1], unique: true, columns: parseIndexColumns(namedUnique[2]) };
+      continue;
+    }
+    if (/^constraint\b/i.test(item) || /^(primary\s+key|unique|key|index|fulltext|foreign\s+key)\b/i.test(item)) {
+      continue; // FK / PK / anonymous indexes are not part of the named contract
+    }
+    const column = parseColumnDefinition(item, defaultCollation);
+    if (column) columns[column.name.toLowerCase()] = column;
+  }
+
+  markPrimaryKeyColumnsNotNull(body, columns);
+
+  return { name, columns, indexes };
+}
+
+export function parseCanonicalSchemaContract(ddl: string): SchemaContract {
+  const cleaned = stripLineComments(ddl);
+  const statements = splitStatements(cleaned);
+
+  const defaultCollationMatch = cleaned.match(/alter\s+database[\s\S]*?collate\s+([A-Za-z0-9_]+)/i);
+  const defaultCollation = defaultCollationMatch ? defaultCollationMatch[1] : null;
+
+  const tables: Record<string, TableContract> = {};
+
+  for (const statement of statements) {
+    const table = parseTableStatement(statement, defaultCollation);
+    if (table) {
+      tables[table.name.toLowerCase()] = table;
+      continue;
+    }
+    const indexMatch = statement.match(/^create\s+(unique\s+)?index\s+`?(\w+)`?\s+on\s+`?(\w+)`?\s*\(([\s\S]*)\)/i);
+    if (indexMatch) {
+      const targetTable = tables[indexMatch[3].toLowerCase()];
+      if (targetTable) {
+        targetTable.indexes[indexMatch[2].toLowerCase()] = {
+          name: indexMatch[2],
+          unique: Boolean(indexMatch[1]),
+          columns: parseIndexColumns(indexMatch[4])
+        };
+      }
+    }
+  }
+
+  return { defaultCollation, tables };
+}
+
+export function resolveCanonicalDDLPath(explicitPath?: string): string {
+  return explicitPath ?? path.join(process.cwd(), CANONICAL_DDL_RELATIVE_PATH);
+}
+
+export function loadCanonicalSchemaContract(ddlFilePath?: string): SchemaContract {
+  const resolved = resolveCanonicalDDLPath(ddlFilePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Canonical DDL file not found: ${resolved}`);
+  }
+  return parseCanonicalSchemaContract(fs.readFileSync(resolved, 'utf-8'));
+}
+
+// ---------------------------------------------------------------------------
+// information_schema reading
+// ---------------------------------------------------------------------------
+
+function coerceString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+export async function readLiveSchemaContract(exec: SchemaQueryExecutor, schema: string, tableNames: readonly string[]): Promise<SchemaContract> {
+  const schemataRows = await exec(`SELECT DEFAULT_COLLATION_NAME AS collation_name FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?`, [schema]);
+  const defaultCollation = coerceString(schemataRows[0]?.collation_name);
+
+  const tables: Record<string, TableContract> = {};
+
+  for (const tableName of tableNames) {
+    const columnRows = await exec(
+      `SELECT COLUMN_NAME AS name, DATA_TYPE AS data_type, COLUMN_TYPE AS column_type,
+              IS_NULLABLE AS is_nullable, COLUMN_DEFAULT AS column_default,
+              EXTRA AS extra, COLLATION_NAME AS collation_name
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+       ORDER BY ORDINAL_POSITION`,
+      [schema, tableName]
+    );
+
+    const columns: Record<string, ColumnContract> = {};
+    for (const row of columnRows) {
+      const name = String(row.name);
+      const dataType = String(row.data_type);
+      const isText = isTextDataType(dataType);
+      columns[name.toLowerCase()] = {
+        name,
+        typeSignature: normalizeTypeSignature(String(row.column_type)),
+        dataType,
+        nullable: String(row.is_nullable).toUpperCase() === 'YES',
+        defaultValue: normalizeDefaultValue(coerceString(row.column_default)),
+        extra: normalizeExtraMetadata(coerceString(row.extra)),
+        collation: isText ? coerceString(row.collation_name) : null,
+        isText
+      };
+    }
+
+    const statisticsRows = await exec(
+      `SELECT INDEX_NAME AS index_name, NON_UNIQUE AS non_unique, SEQ_IN_INDEX AS seq, COLUMN_NAME AS column_name
+       FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+       ORDER BY INDEX_NAME, SEQ_IN_INDEX`,
+      [schema, tableName]
+    );
+
+    const indexes: Record<string, IndexContract> = {};
+    for (const row of statisticsRows) {
+      const indexName = String(row.index_name);
+      const key = indexName.toLowerCase();
+      if (!indexes[key]) {
+        indexes[key] = { name: indexName, unique: Number(row.non_unique) === 0, columns: [] };
+      }
+      indexes[key].columns.push(String(row.column_name));
+    }
+
+    tables[tableName.toLowerCase()] = { name: tableName, columns, indexes };
+  }
+
+  return { defaultCollation, tables };
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+function compareColumn(tableName: string, expected: ColumnContract, actual: ColumnContract, failures: SchemaDifference[]): void {
+  const base = { table: tableName, object: expected.name, category: 'column' as const };
+  if (expected.typeSignature !== actual.typeSignature) {
+    failures.push({ ...base, kind: 'type', expected: expected.typeSignature, actual: actual.typeSignature });
+  }
+  if (expected.nullable !== actual.nullable) {
+    failures.push({ ...base, kind: 'nullability', expected: String(expected.nullable), actual: String(actual.nullable) });
+  }
+  if (expected.defaultValue !== actual.defaultValue) {
+    failures.push({ ...base, kind: 'default', expected: expected.defaultValue, actual: actual.defaultValue });
+  }
+  if (expected.extra !== actual.extra) {
+    failures.push({ ...base, kind: 'extra', expected: expected.extra, actual: actual.extra });
+  }
+  if (expected.collation !== actual.collation) {
+    failures.push({ ...base, kind: 'collation', expected: expected.collation, actual: actual.collation });
+  }
+}
+
+function compareIndex(tableName: string, expected: IndexContract, actual: IndexContract, failures: SchemaDifference[]): void {
+  const base = { table: tableName, object: expected.name, category: 'index' as const };
+  if (expected.unique !== actual.unique) {
+    failures.push({ ...base, kind: 'uniqueness', expected: String(expected.unique), actual: String(actual.unique) });
+  }
+  const expectedCols = expected.columns.map(c => c.toLowerCase()).join(',');
+  const actualCols = actual.columns.map(c => c.toLowerCase()).join(',');
+  if (expectedCols !== actualCols) {
+    failures.push({ ...base, kind: 'columns', expected: expected.columns.join(','), actual: actual.columns.join(',') });
+  }
+}
+
+export function compareSchemaContracts(expected: SchemaContract, actual: SchemaContract, options: CompareOptions = {}): ContractComparison {
+  const tables = options.tables ?? CRITICAL_TABLES;
+  const requiredIndexesByTable = options.requiredIndexesByTable ?? REQUIRED_INDEXES_BY_TABLE;
+
+  const failures: SchemaDifference[] = [];
+  const extras: SchemaDifference[] = [];
+
+  for (const tableName of tables) {
+    const key = tableName.toLowerCase();
+    const expectedTable = expected.tables[key];
+    const actualTable = actual.tables[key];
+
+    if (!expectedTable) {
+      failures.push({ table: tableName, object: tableName, category: 'column', kind: 'missing', expected: 'table defined in canonical DDL', actual: null });
+      continue;
+    }
+    if (!actualTable) {
+      failures.push({ table: tableName, object: tableName, category: 'column', kind: 'missing', expected: 'table present in live schema', actual: null });
+      continue;
+    }
+
+    for (const [columnKey, expectedColumn] of Object.entries(expectedTable.columns)) {
+      const actualColumn = actualTable.columns[columnKey];
+      if (!actualColumn) {
+        failures.push({
+          table: tableName,
+          object: expectedColumn.name,
+          category: 'column',
+          kind: 'missing',
+          expected: expectedColumn.typeSignature,
+          actual: null
+        });
+        continue;
+      }
+      compareColumn(tableName, expectedColumn, actualColumn, failures);
+    }
+
+    for (const [columnKey, actualColumn] of Object.entries(actualTable.columns)) {
+      if (!expectedTable.columns[columnKey]) {
+        extras.push({ table: tableName, object: actualColumn.name, category: 'column', kind: 'missing', expected: null, actual: actualColumn.typeSignature });
+      }
+    }
+
+    const requiredIndexes = requiredIndexesByTable[key] ?? [];
+    for (const indexName of requiredIndexes) {
+      const indexKey = indexName.toLowerCase();
+      const expectedIndex = expectedTable.indexes[indexKey];
+      const actualIndex = actualTable.indexes[indexKey];
+      if (!expectedIndex) {
+        failures.push({ table: tableName, object: indexName, category: 'index', kind: 'missing', expected: 'index defined in canonical DDL', actual: null });
+        continue;
+      }
+      if (!actualIndex) {
+        failures.push({ table: tableName, object: indexName, category: 'index', kind: 'missing', expected: expectedIndex.columns.join(','), actual: null });
+        continue;
+      }
+      compareIndex(tableName, expectedIndex, actualIndex, failures);
+    }
+
+    const requiredSet = new Set(requiredIndexes.map(name => name.toLowerCase()));
+    for (const [indexKey, actualIndex] of Object.entries(actualTable.indexes)) {
+      if (!requiredSet.has(indexKey) && !expectedTable.indexes[indexKey]) {
+        extras.push({ table: tableName, object: actualIndex.name, category: 'index', kind: 'missing', expected: null, actual: actualIndex.columns.join(',') });
+      }
+    }
+  }
+
+  return { failures, extras };
+}
+
+/** Renders failures into a single, debuggable message. */
+export function formatContractFailures(failures: SchemaDifference[]): string {
+  return failures
+    .map(f => `[${f.table}] ${f.category} "${f.object}" ${f.kind}: expected=${JSON.stringify(f.expected)} actual=${JSON.stringify(f.actual)}`)
+    .join('\n');
+}

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -104,7 +104,43 @@ export function buildDroppedMeasurementFailureReason(row: FileRow, existingBatch
   return `Row dropped by INSERT IGNORE - possible constraint violation (Tag=${row.tag}, Quadrat=${row.quadrat}, Date=${normalizeMeasurementDate(row.date)})`;
 }
 
-export function buildTemporaryMeasurementInsertParams(
+/**
+ * Canonical column order for the temporarymeasurements bulk INSERT.
+ *
+ * This is the single source of truth that the INSERT column list, the
+ * per-row placeholder width, and the SQL value order are all derived from.
+ * Adding a column here (and to its keyed record below) is the ONLY change
+ * required to widen the write, which keeps the write contract from silently
+ * diverging from the live schema.
+ */
+export const TEMPORARY_MEASUREMENT_INSERT_COLUMNS = [
+  'FileID',
+  'BatchID',
+  'SessionID',
+  'SourceFormat',
+  'PlotID',
+  'CensusID',
+  'TreeTag',
+  'StemTag',
+  'SpeciesCode',
+  'QuadratName',
+  'LocalX',
+  'LocalY',
+  'DBH',
+  'HOM',
+  'MeasurementDate',
+  'Codes',
+  'Comments',
+  'PublishedStemID'
+] as const;
+
+export type TemporaryMeasurementInsertColumn = (typeof TEMPORARY_MEASUREMENT_INSERT_COLUMNS)[number];
+
+export type TemporaryMeasurementInsertValue = string | number | null;
+
+export type TemporaryMeasurementInsertRecord = Record<TemporaryMeasurementInsertColumn, TemporaryMeasurementInsertValue>;
+
+export function buildTemporaryMeasurementInsertRecord(
   row: FileRow,
   fileName: string,
   batchID: string,
@@ -112,33 +148,38 @@ export function buildTemporaryMeasurementInsertParams(
   sourceFormat: SourceFormat,
   plotID: number,
   censusID: number
-): (string | number | null)[] {
+): TemporaryMeasurementInsertRecord {
   const { tag, stemtag, spcode, quadrat, lx, ly, dbh, hom, date, codes, comments, publishedstemid } = row;
   const formattedDate = normalizeMeasurementDate(date);
   const parsedLx = lx !== undefined && lx !== null && lx !== '' && !isNaN(Number(lx)) ? Number(lx) : null;
   const parsedLy = ly !== undefined && ly !== null && ly !== '' && !isNaN(Number(ly)) ? Number(ly) : null;
   const parsedPublishedStemID = parseUnsignedIntField(publishedstemid);
 
-  return [
-    fileName,
-    batchID,
-    sessionId,
-    sourceFormat,
-    plotID,
-    censusID,
-    tag ?? null,
-    stemtag || null,
-    spcode ?? null,
-    quadrat ?? null,
-    parsedLx,
-    parsedLy,
-    dbh ?? null,
-    hom ?? null,
-    formattedDate,
-    codes ?? null,
-    comments ?? null,
-    parsedPublishedStemID
-  ];
+  return {
+    FileID: fileName,
+    BatchID: batchID,
+    SessionID: sessionId,
+    SourceFormat: sourceFormat,
+    PlotID: plotID,
+    CensusID: censusID,
+    TreeTag: tag ?? null,
+    StemTag: stemtag || null,
+    SpeciesCode: spcode ?? null,
+    QuadratName: quadrat ?? null,
+    LocalX: parsedLx,
+    LocalY: parsedLy,
+    DBH: dbh ?? null,
+    HOM: hom ?? null,
+    MeasurementDate: formattedDate,
+    Codes: codes ?? null,
+    Comments: comments ?? null,
+    PublishedStemID: parsedPublishedStemID
+  };
+}
+
+/** Projects a keyed insert record onto the canonical column order for the SQL VALUES tuple. */
+export function toTemporaryMeasurementInsertValues(record: TemporaryMeasurementInsertRecord): TemporaryMeasurementInsertValue[] {
+  return TEMPORARY_MEASUREMENT_INSERT_COLUMNS.map(column => record[column]);
 }
 
 export async function insertTemporaryMeasurementsInBatches(
@@ -153,17 +194,16 @@ export async function insertTemporaryMeasurementsInBatches(
   censusID: number,
   transactionID: string
 ): Promise<void> {
-  const insertSQLPrefix = format(
-    `INSERT IGNORE INTO ??.temporarymeasurements
-      (FileID, BatchID, SessionID, SourceFormat, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName, LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
-      VALUES `,
-    [schema]
-  );
+  const columnList = TEMPORARY_MEASUREMENT_INSERT_COLUMNS.join(', ');
+  const placeholderTuple = `(${TEMPORARY_MEASUREMENT_INSERT_COLUMNS.map(() => '?').join(', ')})`;
+  const insertSQLPrefix = format(`INSERT IGNORE INTO ??.temporarymeasurements (${columnList}) VALUES `, [schema]);
 
   for (let start = 0; start < rows.length; start += TEMP_MEASUREMENT_INSERT_BATCH_SIZE) {
     const slice = rows.slice(start, start + TEMP_MEASUREMENT_INSERT_BATCH_SIZE);
-    const placeholders = slice.map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).join(', ');
-    const values = slice.flatMap(row => buildTemporaryMeasurementInsertParams(row, fileName, batchID, sessionId, sourceFormat, plotID, censusID));
+    const placeholders = slice.map(() => placeholderTuple).join(', ');
+    const values = slice.flatMap(row =>
+      toTemporaryMeasurementInsertValues(buildTemporaryMeasurementInsertRecord(row, fileName, batchID, sessionId, sourceFormat, plotID, censusID))
+    );
     await connectionManager.executeQuery(`${insertSQLPrefix}${placeholders}`, values, transactionID);
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,8 @@
     "stress:workshop:local": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true next dev --turbo' http://localhost:3000 \"node tests/stress/workshop-stress.mjs --auth=e2e --base-url=http://localhost:3000\"",
     "stress:workshop:smoke": "node tests/stress/workshop-stress.mjs --duration=15s --vus-per-site=1 --max-sites=2 --min-sites=1 --profile=smoke",
     "db:seed:e2e": "npx tsx tests/setup/e2e-seed.ts",
+    "apply-schema-migrations": "npx tsx scripts/apply-schema-migrations.ts",
+    "check:schema-contract": "npx tsx scripts/check-schema-contract.ts",
     "deploy:validations": "npx tsx scripts/deploy-validations-to-all-schemas.ts",
     "deploy:taxonomy-views": "npx tsx scripts/deploy-taxonomy-views-to-all-schemas.ts",
     "docs": "npm run dev --prefix docs",

--- a/frontend/scripts/apply-schema-migrations.test.ts
+++ b/frontend/scripts/apply-schema-migrations.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import crypto from 'crypto';
+import type { SchemaQueryRow } from '@/lib/db/schema-contract';
 import {
   sha256Hex,
   selectPendingMigrations,
   assertSiteSchemasDiscovered,
   applyPendingMigrations,
+  migrationLockName,
   contractGateFailed,
   parseRunnerArgs,
   TamperedMigrationError,
@@ -32,8 +34,19 @@ class FakeSchemaDb {
   appliedBodies: string[] = [];
   ledgerExists = false;
   failOnBodyIncluding: string | null = null;
+  lockHeld = false;
 
   exec: SqlExecutor = async (sql, params) => {
+    if (sql.includes('GET_LOCK')) {
+      if (this.lockHeld) return [{ acquired: 0 }];
+      this.lockHeld = true;
+      return [{ acquired: 1 }];
+    }
+    if (sql.includes('RELEASE_LOCK')) {
+      const released = this.lockHeld ? 1 : 0;
+      this.lockHeld = false;
+      return [{ released }];
+    }
     if (sql.includes('CREATE TABLE IF NOT EXISTS') && sql.includes(LEDGER_TABLE)) {
       this.ledgerExists = true;
       return [];
@@ -42,7 +55,7 @@ class FakeSchemaDb {
       return [{ present: this.ledgerExists ? 1 : 0 }];
     }
     if (sql.includes(`SELECT MigrationID`) && sql.includes(LEDGER_TABLE)) {
-      return [...this.ledger.values()];
+      return [...this.ledger.values()] as unknown as SchemaQueryRow[];
     }
     if (sql.includes('INSERT INTO') && sql.includes(LEDGER_TABLE)) {
       const [id, checksum, status] = params as [string, string, string];
@@ -106,7 +119,7 @@ describe('assertSiteSchemasDiscovered', () => {
 
 describe('contractGateFailed', () => {
   function audit(ok: boolean, pendingMigrationIds: string[] = []): ContractAudit {
-    return { schema: 's', contractFailures: [], collationViolations: [], missingProcedures: [], pendingMigrationIds, ok };
+    return { schema: 's', contractFailures: [], contractExtras: [], collationViolations: [], missingProcedures: [], pendingMigrationIds, ok };
   }
 
   it('fails the gate (drives --check exit 1) when the audit is not ok', () => {
@@ -135,6 +148,7 @@ describe('applyPendingMigrations', () => {
     expect(db.appliedBodies).toEqual([m1.contents, m2.contents]);
     expect(db.ledger.get(m1.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
     expect(db.ledger.get(m2.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
+    expect(db.lockHeld).toBe(false);
   });
 
   it('is a no-op when every migration is already applied (idempotent re-run)', async () => {
@@ -160,6 +174,22 @@ describe('applyPendingMigrations', () => {
     expect(db.appliedBodies).toEqual([]); // m2 never attempted
     expect(db.ledger.get(m1.id)?.Status).toBe(MIGRATION_STATUS.FAILED);
     expect(db.ledger.has(m2.id)).toBe(false);
+    expect(db.lockHeld).toBe(false);
+  });
+
+  it('refuses a concurrent migration runner before reading or writing the ledger', async () => {
+    const db = new FakeSchemaDb();
+    db.lockHeld = true;
+
+    await expect(applyPendingMigrations(db.exec, 'forestgeo_test', [m1])).rejects.toThrow(/Could not acquire migration lock/);
+    expect(db.ledgerExists).toBe(false);
+    expect(db.appliedBodies).toEqual([]);
+  });
+
+  it('uses a deterministic lock name within the MySQL 64-character limit', () => {
+    expect(migrationLockName('forestgeo_test')).toBe(migrationLockName('forestgeo_test'));
+    expect(migrationLockName('forestgeo_test')).not.toBe(migrationLockName('forestgeo_other'));
+    expect(migrationLockName('x'.repeat(64)).length).toBeLessThanOrEqual(64);
   });
 });
 

--- a/frontend/scripts/apply-schema-migrations.test.ts
+++ b/frontend/scripts/apply-schema-migrations.test.ts
@@ -13,6 +13,7 @@ import {
   NoSiteSchemasError,
   MIGRATION_STATUS,
   LEDGER_TABLE,
+  DDL_LOCK_WAIT_TIMEOUT_SECONDS,
   type ContractAudit,
   type MigrationSource,
   type LedgerRow,
@@ -32,11 +33,16 @@ function source(id: string, contents: string): MigrationSource {
 class FakeSchemaDb {
   ledger = new Map<string, LedgerRow>();
   appliedBodies: string[] = [];
+  sessionTimeoutStatements: string[] = [];
   ledgerExists = false;
   failOnBodyIncluding: string | null = null;
   lockHeld = false;
 
   exec: SqlExecutor = async (sql, params) => {
+    if (sql.startsWith('SET SESSION') && sql.includes('lock_wait_timeout')) {
+      this.sessionTimeoutStatements.push(sql);
+      return [];
+    }
     if (sql.includes('GET_LOCK')) {
       if (this.lockHeld) return [{ acquired: 0 }];
       this.lockHeld = true;
@@ -146,6 +152,12 @@ describe('applyPendingMigrations', () => {
     expect(result.appliedNow).toEqual([m1.id, m2.id]);
     expect(result.failed).toBeNull();
     expect(db.appliedBodies).toEqual([m1.contents, m2.contents]);
+    // The DDL patience limit must be set on the session BEFORE any migration body runs,
+    // so an ALTER queued behind live traffic fails fast instead of freezing the table.
+    expect(db.sessionTimeoutStatements).toEqual([
+      `SET SESSION lock_wait_timeout = ${DDL_LOCK_WAIT_TIMEOUT_SECONDS}`,
+      `SET SESSION innodb_lock_wait_timeout = ${DDL_LOCK_WAIT_TIMEOUT_SECONDS}`
+    ]);
     expect(db.ledger.get(m1.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
     expect(db.ledger.get(m2.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
     expect(db.lockHeld).toBe(false);

--- a/frontend/scripts/apply-schema-migrations.test.ts
+++ b/frontend/scripts/apply-schema-migrations.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import {
+  sha256Hex,
+  selectPendingMigrations,
+  assertSiteSchemasDiscovered,
+  applyPendingMigrations,
+  contractGateFailed,
+  parseRunnerArgs,
+  TamperedMigrationError,
+  NoSiteSchemasError,
+  MIGRATION_STATUS,
+  LEDGER_TABLE,
+  type ContractAudit,
+  type MigrationSource,
+  type LedgerRow,
+  type SqlExecutor
+} from './apply-schema-migrations';
+
+function source(id: string, contents: string): MigrationSource {
+  return { id, file: `${id}.sql`, contents, checksum: sha256Hex(contents) };
+}
+
+/**
+ * In-memory stand-in for a per-schema connection. It answers the exact SQL the
+ * apply loop issues (ledger existence, ledger read, ledger upsert) and treats any
+ * other statement as a migration body, recording it as applied unless configured
+ * to fail.
+ */
+class FakeSchemaDb {
+  ledger = new Map<string, LedgerRow>();
+  appliedBodies: string[] = [];
+  ledgerExists = false;
+  failOnBodyIncluding: string | null = null;
+
+  exec: SqlExecutor = async (sql, params) => {
+    if (sql.includes('CREATE TABLE IF NOT EXISTS') && sql.includes(LEDGER_TABLE)) {
+      this.ledgerExists = true;
+      return [];
+    }
+    if (sql.includes('information_schema.TABLES')) {
+      return [{ present: this.ledgerExists ? 1 : 0 }];
+    }
+    if (sql.includes(`SELECT MigrationID`) && sql.includes(LEDGER_TABLE)) {
+      return [...this.ledger.values()];
+    }
+    if (sql.includes('INSERT INTO') && sql.includes(LEDGER_TABLE)) {
+      const [id, checksum, status] = params as [string, string, string];
+      this.ledger.set(id, { MigrationID: id, Checksum: checksum, Status: status });
+      return [];
+    }
+    if (this.failOnBodyIncluding && sql.includes(this.failOnBodyIncluding)) {
+      throw new Error('simulated migration failure');
+    }
+    this.appliedBodies.push(sql);
+    return [];
+  };
+}
+
+describe('sha256Hex', () => {
+  it('matches node crypto and is deterministic', () => {
+    const input = 'ALTER TABLE temporarymeasurements ADD COLUMN PublishedStemID int unsigned NULL';
+    const expected = crypto.createHash('sha256').update(input, 'utf8').digest('hex');
+    expect(sha256Hex(input)).toBe(expected);
+    expect(sha256Hex(input)).toBe(sha256Hex(input));
+  });
+
+  it('changes when the migration body changes (tamper detection basis)', () => {
+    expect(sha256Hex('a')).not.toBe(sha256Hex('a ')); // trailing space matters
+  });
+});
+
+describe('selectPendingMigrations', () => {
+  const m1 = source('2026-07-13-01-first', 'BODY ONE');
+  const m2 = source('2026-07-13-02-second', 'BODY TWO');
+
+  it('returns all migrations, in manifest order, against an empty ledger', () => {
+    expect(selectPendingMigrations([m1, m2], []).map(s => s.id)).toEqual([m1.id, m2.id]);
+  });
+
+  it('skips a migration recorded applied with a matching checksum', () => {
+    const ledger: LedgerRow[] = [{ MigrationID: m1.id, Checksum: m1.checksum, Status: MIGRATION_STATUS.APPLIED }];
+    expect(selectPendingMigrations([m1, m2], ledger).map(s => s.id)).toEqual([m2.id]);
+  });
+
+  it('re-selects a migration recorded failed (retry)', () => {
+    const ledger: LedgerRow[] = [{ MigrationID: m1.id, Checksum: m1.checksum, Status: MIGRATION_STATUS.FAILED }];
+    expect(selectPendingMigrations([m1, m2], ledger).map(s => s.id)).toEqual([m1.id, m2.id]);
+  });
+
+  it('throws TamperedMigrationError when an applied migration checksum changed', () => {
+    const ledger: LedgerRow[] = [{ MigrationID: m1.id, Checksum: 'a-different-checksum', Status: MIGRATION_STATUS.APPLIED }];
+    expect(() => selectPendingMigrations([m1, m2], ledger)).toThrow(TamperedMigrationError);
+  });
+});
+
+describe('assertSiteSchemasDiscovered', () => {
+  it('throws NoSiteSchemasError on zero schemas (no false green)', () => {
+    expect(() => assertSiteSchemasDiscovered([])).toThrow(NoSiteSchemasError);
+  });
+
+  it('passes when at least one schema is discovered', () => {
+    expect(() => assertSiteSchemasDiscovered(['forestgeo_testing'])).not.toThrow();
+  });
+});
+
+describe('contractGateFailed', () => {
+  function audit(ok: boolean, pendingMigrationIds: string[] = []): ContractAudit {
+    return { schema: 's', contractFailures: [], collationViolations: [], missingProcedures: [], pendingMigrationIds, ok };
+  }
+
+  it('fails the gate (drives --check exit 1) when the audit is not ok', () => {
+    expect(contractGateFailed(audit(false))).toBe(true);
+  });
+
+  it('fails the gate when migrations are still pending (audit.ok already folds pending in)', () => {
+    expect(contractGateFailed(audit(false, ['2026-07-13-01-pending']))).toBe(true);
+  });
+
+  it('passes the gate only when the schema is fully compatible', () => {
+    expect(contractGateFailed(audit(true))).toBe(false);
+  });
+});
+
+describe('applyPendingMigrations', () => {
+  const m1 = source('2026-07-13-01-first', 'MIGRATION_BODY_ONE');
+  const m2 = source('2026-07-13-02-second', 'MIGRATION_BODY_TWO');
+
+  it('creates the ledger, applies every pending migration, and records them applied', async () => {
+    const db = new FakeSchemaDb();
+    const result = await applyPendingMigrations(db.exec, 'forestgeo_test', [m1, m2]);
+
+    expect(result.appliedNow).toEqual([m1.id, m2.id]);
+    expect(result.failed).toBeNull();
+    expect(db.appliedBodies).toEqual([m1.contents, m2.contents]);
+    expect(db.ledger.get(m1.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
+    expect(db.ledger.get(m2.id)?.Status).toBe(MIGRATION_STATUS.APPLIED);
+  });
+
+  it('is a no-op when every migration is already applied (idempotent re-run)', async () => {
+    const db = new FakeSchemaDb();
+    db.ledgerExists = true;
+    db.ledger.set(m1.id, { MigrationID: m1.id, Checksum: m1.checksum, Status: MIGRATION_STATUS.APPLIED });
+    db.ledger.set(m2.id, { MigrationID: m2.id, Checksum: m2.checksum, Status: MIGRATION_STATUS.APPLIED });
+
+    const result = await applyPendingMigrations(db.exec, 'forestgeo_test', [m1, m2]);
+
+    expect(result.appliedNow).toEqual([]);
+    expect(db.appliedBodies).toEqual([]);
+  });
+
+  it('records a failing migration as failed and stops (does not apply later migrations)', async () => {
+    const db = new FakeSchemaDb();
+    db.failOnBodyIncluding = m1.contents;
+
+    const result = await applyPendingMigrations(db.exec, 'forestgeo_test', [m1, m2]);
+
+    expect(result.failed?.id).toBe(m1.id);
+    expect(result.appliedNow).toEqual([]);
+    expect(db.appliedBodies).toEqual([]); // m2 never attempted
+    expect(db.ledger.get(m1.id)?.Status).toBe(MIGRATION_STATUS.FAILED);
+    expect(db.ledger.has(m2.id)).toBe(false);
+  });
+});
+
+describe('parseRunnerArgs', () => {
+  it('parses an all-sites apply', () => {
+    expect(parseRunnerArgs(['--apply', '--all-sites'])).toEqual({ mode: 'apply', allSites: true, schema: null });
+  });
+
+  it('parses a single-schema check', () => {
+    expect(parseRunnerArgs(['--check', '--schema', 'forestgeo_x'])).toEqual({ mode: 'check', allSites: false, schema: 'forestgeo_x' });
+  });
+
+  it('requires a mode', () => {
+    expect(() => parseRunnerArgs(['--all-sites'])).toThrow(/check.*apply|apply.*check/i);
+  });
+
+  it('rejects both targets or neither', () => {
+    expect(() => parseRunnerArgs(['--apply'])).toThrow(/Exactly one target/);
+    expect(() => parseRunnerArgs(['--apply', '--all-sites', '--schema', 'x'])).toThrow(/Exactly one target/);
+  });
+
+  it('rejects a --schema with no value', () => {
+    expect(() => parseRunnerArgs(['--apply', '--schema'])).toThrow(/requires a schema name/);
+  });
+});

--- a/frontend/scripts/apply-schema-migrations.ts
+++ b/frontend/scripts/apply-schema-migrations.ts
@@ -58,6 +58,7 @@ export type { SqlExecutor } from './lib/schema-cli';
 // ---------------------------------------------------------------------------
 
 export const LEDGER_TABLE = 'schema_migrations';
+export const MIGRATION_LOCK_TIMEOUT_SECONDS = 30;
 
 export const MIGRATION_STATUS = {
   APPLIED: 'applied',
@@ -109,6 +110,7 @@ export interface ApplyResult {
 export interface ContractAudit {
   schema: string;
   contractFailures: SchemaDifference[];
+  contractExtras: SchemaDifference[];
   collationViolations: string[];
   missingProcedures: string[];
   pendingMigrationIds: string[];
@@ -133,6 +135,13 @@ export class MigrationFileMissingError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'MigrationFileMissingError';
+  }
+}
+
+export class MigrationLockUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MigrationLockUnavailableError';
   }
 }
 
@@ -254,6 +263,26 @@ export async function recordLedgerEntry(exec: SqlExecutor, id: string, checksum:
   );
 }
 
+export function migrationLockName(schema: string): string {
+  return `fg:migrate:${sha256Hex(schema).slice(0, 40)}`;
+}
+
+export async function acquireMigrationLock(exec: SqlExecutor, schema: string): Promise<string> {
+  const lockName = migrationLockName(schema);
+  const rows = await exec(`SELECT GET_LOCK(?, ?) AS acquired`, [lockName, MIGRATION_LOCK_TIMEOUT_SECONDS]);
+  if (Number(rows[0]?.acquired ?? 0) !== 1) {
+    throw new MigrationLockUnavailableError(`Could not acquire migration lock for schema "${schema}" within ${MIGRATION_LOCK_TIMEOUT_SECONDS} seconds.`);
+  }
+  return lockName;
+}
+
+export async function releaseMigrationLock(exec: SqlExecutor, lockName: string): Promise<void> {
+  const rows = await exec(`SELECT RELEASE_LOCK(?) AS released`, [lockName]);
+  if (Number(rows[0]?.released ?? 0) !== 1) {
+    throw new MigrationLockUnavailableError(`Migration lock "${lockName}" was not owned when release was attempted.`);
+  }
+}
+
 /**
  * Applies every pending migration for one schema, in order, recording each in the
  * ledger. Stops at the first failing migration (recording it `failed`) so a broken
@@ -265,26 +294,31 @@ export async function recordLedgerEntry(exec: SqlExecutor, id: string, checksum:
  * own information_schema guards, and the ledger record is a single atomic upsert.
  */
 export async function applyPendingMigrations(exec: SqlExecutor, schema: string, sources: MigrationSource[]): Promise<ApplyResult> {
-  await ensureLedgerTable(exec);
-  const ledger = await readLedger(exec, schema);
-  const pending = selectPendingMigrations(sources, ledger);
-  const pendingBefore = pending.map(source => source.id);
-  const appliedNow: string[] = [];
+  const lockName = await acquireMigrationLock(exec, schema);
+  try {
+    await ensureLedgerTable(exec);
+    const ledger = await readLedger(exec, schema);
+    const pending = selectPendingMigrations(sources, ledger);
+    const pendingBefore = pending.map(source => source.id);
+    const appliedNow: string[] = [];
 
-  for (const source of pending) {
-    try {
-      await exec(source.contents);
-      await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.APPLIED, null);
-      appliedNow.push(source.id);
-    } catch (error) {
-      const summary = errorMessage(error).slice(0, ERROR_SUMMARY_MAX_LENGTH);
-      // Best-effort failure record; never mask the original error with a logging failure.
-      await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.FAILED, summary).catch(() => undefined);
-      return { schema, pendingBefore, appliedNow, failed: { id: source.id, error: errorMessage(error) } };
+    for (const source of pending) {
+      try {
+        await exec(source.contents);
+        await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.APPLIED, null);
+        appliedNow.push(source.id);
+      } catch (error) {
+        const summary = errorMessage(error).slice(0, ERROR_SUMMARY_MAX_LENGTH);
+        // Best-effort failure record; never mask the original migration error.
+        await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.FAILED, summary).catch(() => undefined);
+        return { schema, pendingBefore, appliedNow, failed: { id: source.id, error: errorMessage(error) } };
+      }
     }
-  }
 
-  return { schema, pendingBefore, appliedNow, failed: null };
+    return { schema, pendingBefore, appliedNow, failed: null };
+  } finally {
+    await releaseMigrationLock(exec, lockName);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -299,7 +333,10 @@ export async function applyPendingMigrations(exec: SqlExecutor, schema: string, 
 export async function auditSchemaContract(exec: SqlExecutor, schema: string, pendingMigrationIds: string[]): Promise<ContractAudit> {
   const canonical = loadCanonicalSchemaContract();
   const live = await readLiveSchemaContract(exec, schema, CRITICAL_TABLES);
-  const contractFailures = compareSchemaContracts(canonical, live).failures;
+  const comparison = compareSchemaContracts(canonical, live);
+  // Collation drift remains visible below, but it is not an app-compatibility
+  // failure and must not trigger table-wide rewrites during a deploy.
+  const contractFailures = comparison.failures.filter(failure => failure.kind !== 'collation');
 
   const collationViolations: string[] = [];
   if (live.defaultCollation !== TARGET_TEXT_COLLATION) {
@@ -324,16 +361,17 @@ export async function auditSchemaContract(exec: SqlExecutor, schema: string, pen
   const presentProcedures = new Set(procedureRows.map(row => String(row.name).toLowerCase()));
   const missingProcedures = REQUIRED_INGESTION_PROCEDURES.filter(name => !presentProcedures.has(name.toLowerCase()));
 
-  const ok = contractFailures.length === 0 && collationViolations.length === 0 && missingProcedures.length === 0 && pendingMigrationIds.length === 0;
+  const ok = contractFailures.length === 0 && missingProcedures.length === 0 && pendingMigrationIds.length === 0;
 
-  return { schema, contractFailures, collationViolations, missingProcedures, pendingMigrationIds, ok };
+  return { schema, contractFailures, contractExtras: comparison.extras, collationViolations, missingProcedures, pendingMigrationIds, ok };
 }
 
 /**
- * Whether an audited schema must fail its gate: any contract drift, collation
- * drift, missing procedure, or pending migration. `ContractAudit.ok` already
- * folds in pending migrations, so `--check` cannot read as success while work is
- * still outstanding.
+ * Whether an audited schema must fail its gate: incompatible structural drift,
+ * missing procedures, or pending migrations. Collation drift is reported as a
+ * maintenance warning rather than repaired inside an application deploy.
+ * `ContractAudit.ok` already folds in pending migrations, so `--check` cannot
+ * read as success while work is still outstanding.
  */
 export function contractGateFailed(audit: ContractAudit): boolean {
   return !audit.ok;
@@ -393,15 +431,17 @@ export function parseRunnerArgs(argv: string[]): RunnerArgs {
 function printAudit(audit: ContractAudit): void {
   if (audit.ok) {
     console.log(`  contract OK`);
-    return;
   }
   for (const failure of audit.contractFailures) {
     console.log(
       `  DRIFT   [${failure.table}] ${failure.category} "${failure.object}" ${failure.kind}: expected=${JSON.stringify(failure.expected)} actual=${JSON.stringify(failure.actual)}`
     );
   }
+  for (const extra of audit.contractExtras) {
+    console.log(`  EXTRA   [${extra.table}] ${extra.category} "${extra.object}" actual=${JSON.stringify(extra.actual)}`);
+  }
   for (const violation of audit.collationViolations) {
-    console.log(`  COLLATION  ${violation}`);
+    console.log(`  COLLATION WARNING  ${violation}`);
   }
   for (const proc of audit.missingProcedures) {
     console.log(`  MISSING PROCEDURE  ${proc}`);
@@ -474,10 +514,20 @@ async function runCli(argv: string[]): Promise<number> {
         // A per-schema connection or processing failure fails the run (exitCode=1)
         // but must not abort the remaining schemas — mirrors deploy-validations.
         const passed = await processSchema(settings, schema, args.mode, sources);
-        if (!passed) exitCode = 1;
+        if (!passed) {
+          exitCode = 1;
+          if (args.mode === 'apply') {
+            console.error(`  ABORTING remaining schemas after apply failure to limit partial rollout.`);
+            break;
+          }
+        }
       } catch (error) {
         console.error(`  SCHEMA FAILED  ${schema}: ${errorMessage(error)}`);
         exitCode = 1;
+        if (args.mode === 'apply') {
+          console.error(`  ABORTING remaining schemas after apply failure to limit partial rollout.`);
+          break;
+        }
       }
       console.log();
     }

--- a/frontend/scripts/apply-schema-migrations.ts
+++ b/frontend/scripts/apply-schema-migrations.ts
@@ -1,0 +1,509 @@
+/**
+ * Apply schema-contract-repair migrations to ForestGEO schemas.
+ *
+ * This is the engine module for the schema migrate + verify pipeline. It owns:
+ *   - the per-schema `schema_migrations` ledger (create / read / record);
+ *   - the ordered manifest -> pending-selection logic (with tamper detection);
+ *   - the reviewed-additive migration apply loop;
+ *   - a contract audit (built on the Task 2 schema-contract module) used both here
+ *     as a post-migration gate and by the read-only check-schema-contract CLI.
+ *
+ * Deploy ordering: run this (--all-sites --apply) and the contract verify BEFORE
+ * deploying app code / stored procedures that depend on the new columns, so a
+ * failed migrate or verify prevents the app deploy.
+ *
+ * Flags:
+ *   --check                 list pending migrations + contract state, write nothing
+ *   --apply                 apply pending migrations, then verify the contract
+ *   --schema <name>         operate on ONE schema using LOCAL test credentials
+ *   --all-sites             enumerate every forestgeo_* schema on the Azure server
+ *
+ * Safety: refuses to run against an unexpected DB host, and (under --all-sites)
+ * refuses a "zero schemas discovered" false green.
+ *
+ * Usage:
+ *   npx tsx scripts/apply-schema-migrations.ts --all-sites --check
+ *   npx tsx scripts/apply-schema-migrations.ts --all-sites --apply
+ *   npx tsx scripts/apply-schema-migrations.ts --schema forestgeo_test_default --apply
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  loadCanonicalSchemaContract,
+  readLiveSchemaContract,
+  compareSchemaContracts,
+  CRITICAL_TABLES,
+  TARGET_TEXT_COLLATION,
+  type SchemaDifference
+} from '@/lib/db/schema-contract';
+import { SCHEMA_MIGRATION_MANIFEST, type MigrationManifestEntry } from '../db/migrations/manifest';
+import {
+  SITE_SCHEMA_LIKE,
+  assertExpectedHost,
+  createSchemaCliConnection,
+  discoverSiteSchemas,
+  executorFor,
+  resolveConnectionSettings,
+  type SqlExecutor
+} from './lib/schema-cli';
+
+// Re-exported so the integration test and audit CLI can keep a single import site.
+export type { SqlExecutor } from './lib/schema-cli';
+
+// ---------------------------------------------------------------------------
+// Constants (no magic strings)
+// ---------------------------------------------------------------------------
+
+export const LEDGER_TABLE = 'schema_migrations';
+
+export const MIGRATION_STATUS = {
+  APPLIED: 'applied',
+  FAILED: 'failed'
+} as const;
+
+export type MigrationStatus = (typeof MIGRATION_STATUS)[keyof typeof MIGRATION_STATUS];
+
+/** Ingestion procedures whose presence is part of the write contract. */
+export const REQUIRED_INGESTION_PROCEDURES = ['bulkingestionprocess'] as const;
+
+/** Text columns allowed to diverge from the target collation (empty today). */
+export const EXEMPT_TEXT_COLLATION_COLUMNS = new Set<string>();
+
+/** ErrorSummary is TEXT; keep recorded failure summaries bounded. */
+const ERROR_SUMMARY_MAX_LENGTH = 2000;
+
+const CLI_FLAG = {
+  CHECK: '--check',
+  APPLY: '--apply',
+  SCHEMA: '--schema',
+  ALL_SITES: '--all-sites'
+} as const;
+
+// ---------------------------------------------------------------------------
+// Types + error classes
+// ---------------------------------------------------------------------------
+
+export interface MigrationSource {
+  id: string;
+  file: string;
+  contents: string;
+  checksum: string;
+}
+
+export interface LedgerRow {
+  MigrationID: string;
+  Checksum: string;
+  Status: string;
+}
+
+export interface ApplyResult {
+  schema: string;
+  pendingBefore: string[];
+  appliedNow: string[];
+  failed: { id: string; error: string } | null;
+}
+
+export interface ContractAudit {
+  schema: string;
+  contractFailures: SchemaDifference[];
+  collationViolations: string[];
+  missingProcedures: string[];
+  pendingMigrationIds: string[];
+  ok: boolean;
+}
+
+export class TamperedMigrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TamperedMigrationError';
+  }
+}
+
+export class NoSiteSchemasError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NoSiteSchemasError';
+  }
+}
+
+export class MigrationFileMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MigrationFileMissingError';
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// ---------------------------------------------------------------------------
+// Pure primitives (unit-tested without a DB)
+// ---------------------------------------------------------------------------
+
+export function sha256Hex(contents: string): string {
+  return crypto.createHash('sha256').update(contents, 'utf8').digest('hex');
+}
+
+export function defaultMigrationsDir(): string {
+  return path.join(process.cwd(), 'db', 'migrations');
+}
+
+/**
+ * Reads every manifest-listed migration file and computes its checksum.
+ * Throws MigrationFileMissingError (rather than silently skipping) if a listed
+ * file is absent — a manifest that points at nothing must fail loudly.
+ */
+export function loadMigrationSources(
+  manifest: readonly MigrationManifestEntry[] = SCHEMA_MIGRATION_MANIFEST,
+  migrationsDir: string = defaultMigrationsDir()
+): MigrationSource[] {
+  return manifest.map(entry => {
+    const filePath = path.join(migrationsDir, entry.file);
+    if (!fs.existsSync(filePath)) {
+      throw new MigrationFileMissingError(`Manifest migration file not found: ${filePath} (id ${entry.id})`);
+    }
+    const contents = fs.readFileSync(filePath, 'utf-8');
+    return { id: entry.id, file: entry.file, contents, checksum: sha256Hex(contents) };
+  });
+}
+
+/**
+ * Given the manifest sources and a ledger snapshot, returns the migrations that
+ * still need to run, in manifest order. A `failed` ledger row is re-selected as
+ * pending (retry). An `applied` row whose stored checksum no longer matches the
+ * current file is a tampered migration and throws — a recorded-applied migration
+ * must never change on disk.
+ */
+export function selectPendingMigrations(sources: MigrationSource[], ledgerRows: LedgerRow[]): MigrationSource[] {
+  const byId = new Map(ledgerRows.map(row => [row.MigrationID, row]));
+  const pending: MigrationSource[] = [];
+
+  for (const source of sources) {
+    const row = byId.get(source.id);
+    if (!row) {
+      pending.push(source);
+      continue;
+    }
+    if (row.Status === MIGRATION_STATUS.APPLIED) {
+      if (row.Checksum !== source.checksum) {
+        throw new TamperedMigrationError(
+          `Migration "${source.id}" is recorded applied with checksum ${row.Checksum} but the current file hashes to ${source.checksum}. ` +
+            `A migration already applied to a live schema must never be edited; create a new migration instead.`
+        );
+      }
+      continue;
+    }
+    pending.push(source);
+  }
+
+  return pending;
+}
+
+/** Refuses the "zero schemas checked" false green. */
+export function assertSiteSchemasDiscovered(schemas: string[]): void {
+  if (schemas.length === 0) {
+    throw new NoSiteSchemasError(
+      `No site schemas matched "${SITE_SCHEMA_LIKE}". Refusing to report success against zero schemas ` +
+        `(a discovery failure must never read as "nothing to migrate").`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ledger + apply (effectful; exec is injectable so tests use a mock)
+// ---------------------------------------------------------------------------
+
+export async function ensureLedgerTable(exec: SqlExecutor): Promise<void> {
+  await exec(
+    `CREATE TABLE IF NOT EXISTS \`${LEDGER_TABLE}\` (
+       MigrationID  VARCHAR(191) PRIMARY KEY,
+       Checksum     CHAR(64) NOT NULL,
+       AppliedAt    DATETIME NOT NULL,
+       Status       ENUM('applied','failed') NOT NULL,
+       ErrorSummary TEXT NULL
+     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci`
+  );
+}
+
+async function ledgerTableExists(exec: SqlExecutor, schema: string): Promise<boolean> {
+  const rows = await exec(`SELECT COUNT(*) AS present FROM information_schema.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?`, [schema, LEDGER_TABLE]);
+  return Number(rows[0]?.present ?? 0) > 0;
+}
+
+/** Reads the ledger, tolerating a not-yet-created ledger table (returns []). */
+export async function readLedger(exec: SqlExecutor, schema: string): Promise<LedgerRow[]> {
+  if (!(await ledgerTableExists(exec, schema))) return [];
+  const rows = await exec(`SELECT MigrationID, Checksum, Status FROM \`${LEDGER_TABLE}\``);
+  return rows.map(row => ({
+    MigrationID: String(row.MigrationID),
+    Checksum: String(row.Checksum),
+    Status: String(row.Status)
+  }));
+}
+
+export async function recordLedgerEntry(exec: SqlExecutor, id: string, checksum: string, status: MigrationStatus, errorSummary: string | null): Promise<void> {
+  await exec(
+    `INSERT INTO \`${LEDGER_TABLE}\` (MigrationID, Checksum, AppliedAt, Status, ErrorSummary)
+     VALUES (?, ?, NOW(), ?, ?)
+     ON DUPLICATE KEY UPDATE Checksum = VALUES(Checksum), AppliedAt = NOW(), Status = VALUES(Status), ErrorSummary = VALUES(ErrorSummary)`,
+    [id, checksum, status, errorSummary]
+  );
+}
+
+/**
+ * Applies every pending migration for one schema, in order, recording each in the
+ * ledger. Stops at the first failing migration (recording it `failed`) so a broken
+ * migration cannot be skipped over. Idempotent migrations mean a re-run of an
+ * already-applied set does nothing.
+ *
+ * DDL implicitly commits in MySQL, so a wrapping transaction cannot make a
+ * multi-statement DDL migration atomic; re-run safety comes from the migration's
+ * own information_schema guards, and the ledger record is a single atomic upsert.
+ */
+export async function applyPendingMigrations(exec: SqlExecutor, schema: string, sources: MigrationSource[]): Promise<ApplyResult> {
+  await ensureLedgerTable(exec);
+  const ledger = await readLedger(exec, schema);
+  const pending = selectPendingMigrations(sources, ledger);
+  const pendingBefore = pending.map(source => source.id);
+  const appliedNow: string[] = [];
+
+  for (const source of pending) {
+    try {
+      await exec(source.contents);
+      await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.APPLIED, null);
+      appliedNow.push(source.id);
+    } catch (error) {
+      const summary = errorMessage(error).slice(0, ERROR_SUMMARY_MAX_LENGTH);
+      // Best-effort failure record; never mask the original error with a logging failure.
+      await recordLedgerEntry(exec, source.id, source.checksum, MIGRATION_STATUS.FAILED, summary).catch(() => undefined);
+      return { schema, pendingBefore, appliedNow, failed: { id: source.id, error: errorMessage(error) } };
+    }
+  }
+
+  return { schema, pendingBefore, appliedNow, failed: null };
+}
+
+// ---------------------------------------------------------------------------
+// Contract audit (built on Task 2 schema-contract)
+// ---------------------------------------------------------------------------
+
+/**
+ * Audits one live schema against the canonical write contract: column
+ * type/nullability/default/extra/collation drift, required named indexes, text +
+ * database collation, ingestion procedure presence, and pending-migration state.
+ */
+export async function auditSchemaContract(exec: SqlExecutor, schema: string, pendingMigrationIds: string[]): Promise<ContractAudit> {
+  const canonical = loadCanonicalSchemaContract();
+  const live = await readLiveSchemaContract(exec, schema, CRITICAL_TABLES);
+  const contractFailures = compareSchemaContracts(canonical, live).failures;
+
+  const collationViolations: string[] = [];
+  if (live.defaultCollation !== TARGET_TEXT_COLLATION) {
+    collationViolations.push(`database default => ${live.defaultCollation}`);
+  }
+  for (const table of CRITICAL_TABLES) {
+    const liveTable = live.tables[table];
+    if (!liveTable) continue;
+    for (const column of Object.values(liveTable.columns)) {
+      if (!column.isText) continue;
+      const key = `${table}.${column.name}`.toLowerCase();
+      if (EXEMPT_TEXT_COLLATION_COLUMNS.has(key)) continue;
+      if (column.collation !== TARGET_TEXT_COLLATION) {
+        collationViolations.push(`${table}.${column.name} => ${column.collation}`);
+      }
+    }
+  }
+
+  const procedureRows = await exec(`SELECT ROUTINE_NAME AS name FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'`, [
+    schema
+  ]);
+  const presentProcedures = new Set(procedureRows.map(row => String(row.name).toLowerCase()));
+  const missingProcedures = REQUIRED_INGESTION_PROCEDURES.filter(name => !presentProcedures.has(name.toLowerCase()));
+
+  const ok = contractFailures.length === 0 && collationViolations.length === 0 && missingProcedures.length === 0 && pendingMigrationIds.length === 0;
+
+  return { schema, contractFailures, collationViolations, missingProcedures, pendingMigrationIds, ok };
+}
+
+/**
+ * Whether an audited schema must fail its gate: any contract drift, collation
+ * drift, missing procedure, or pending migration. `ContractAudit.ok` already
+ * folds in pending migrations, so `--check` cannot read as success while work is
+ * still outstanding.
+ */
+export function contractGateFailed(audit: ContractAudit): boolean {
+  return !audit.ok;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export type RunnerMode = 'check' | 'apply';
+
+export interface RunnerArgs {
+  mode: RunnerMode;
+  allSites: boolean;
+  schema: string | null;
+}
+
+export function parseRunnerArgs(argv: string[]): RunnerArgs {
+  let mode: RunnerMode | null = null;
+  let allSites = false;
+  let schema: string | null = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case CLI_FLAG.CHECK:
+        mode = 'check';
+        break;
+      case CLI_FLAG.APPLY:
+        mode = 'apply';
+        break;
+      case CLI_FLAG.ALL_SITES:
+        allSites = true;
+        break;
+      case CLI_FLAG.SCHEMA:
+        schema = argv[i + 1];
+        if (!schema || schema.startsWith('--')) {
+          throw new Error(`${CLI_FLAG.SCHEMA} requires a schema name.`);
+        }
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown argument "${arg}". Supported: ${Object.values(CLI_FLAG).join(', ')}.`);
+    }
+  }
+
+  if (mode === null) {
+    throw new Error(`One of ${CLI_FLAG.CHECK} or ${CLI_FLAG.APPLY} is required.`);
+  }
+  if (allSites === (schema !== null)) {
+    throw new Error(`Exactly one target is required: ${CLI_FLAG.ALL_SITES} or ${CLI_FLAG.SCHEMA} <name>.`);
+  }
+
+  return { mode, allSites, schema };
+}
+
+function printAudit(audit: ContractAudit): void {
+  if (audit.ok) {
+    console.log(`  contract OK`);
+    return;
+  }
+  for (const failure of audit.contractFailures) {
+    console.log(
+      `  DRIFT   [${failure.table}] ${failure.category} "${failure.object}" ${failure.kind}: expected=${JSON.stringify(failure.expected)} actual=${JSON.stringify(failure.actual)}`
+    );
+  }
+  for (const violation of audit.collationViolations) {
+    console.log(`  COLLATION  ${violation}`);
+  }
+  for (const proc of audit.missingProcedures) {
+    console.log(`  MISSING PROCEDURE  ${proc}`);
+  }
+  for (const id of audit.pendingMigrationIds) {
+    console.log(`  PENDING MIGRATION  ${id}`);
+  }
+}
+
+async function processSchema(
+  settings: ReturnType<typeof resolveConnectionSettings>,
+  schema: string,
+  mode: RunnerMode,
+  sources: MigrationSource[]
+): Promise<boolean> {
+  let schemaConnection: Awaited<ReturnType<typeof createSchemaCliConnection>> | null = null;
+  try {
+    schemaConnection = await createSchemaCliConnection(settings, { database: schema, multipleStatements: true });
+    const exec = executorFor(schemaConnection);
+
+    if (mode === 'apply') {
+      const result = await applyPendingMigrations(exec, schema, sources);
+      console.log(`  applied: ${result.appliedNow.length === 0 ? '(none pending)' : result.appliedNow.join(', ')}`);
+      if (result.failed) {
+        console.error(`  MIGRATION FAILED  ${result.failed.id}: ${result.failed.error}`);
+        return false;
+      }
+      const audit = await auditSchemaContract(exec, schema, []);
+      printAudit(audit);
+      return !contractGateFailed(audit);
+    }
+
+    const ledger = await readLedger(exec, schema);
+    const pending = selectPendingMigrations(sources, ledger);
+    console.log(`  pending: ${pending.length === 0 ? '(none)' : pending.map(p => p.id).join(', ')}`);
+    const audit = await auditSchemaContract(
+      exec,
+      schema,
+      pending.map(p => p.id)
+    );
+    printAudit(audit);
+    return !contractGateFailed(audit);
+  } finally {
+    if (schemaConnection) await schemaConnection.end();
+  }
+}
+
+async function runCli(argv: string[]): Promise<number> {
+  const args = parseRunnerArgs(argv);
+  const settings = resolveConnectionSettings(args.allSites);
+  assertExpectedHost(settings.host, settings.allowedHosts);
+
+  const sources = loadMigrationSources();
+
+  const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
+
+  let exitCode = 0;
+  try {
+    const schemas = args.allSites ? await discoverSiteSchemas(discovery) : [args.schema as string];
+    if (args.allSites) {
+      assertSiteSchemasDiscovered(schemas);
+    }
+
+    console.log(`Mode: ${args.mode.toUpperCase()} | Target: ${args.allSites ? 'all sites' : args.schema} | Host: ${settings.host}`);
+    console.log(`Discovered ${schemas.length} schema(s). Manifest migrations: ${sources.map(s => s.id).join(', ')}\n`);
+
+    for (const schema of schemas) {
+      console.log(`Schema: ${schema}`);
+      try {
+        // A per-schema connection or processing failure fails the run (exitCode=1)
+        // but must not abort the remaining schemas — mirrors deploy-validations.
+        const passed = await processSchema(settings, schema, args.mode, sources);
+        if (!passed) exitCode = 1;
+      } catch (error) {
+        console.error(`  SCHEMA FAILED  ${schema}: ${errorMessage(error)}`);
+        exitCode = 1;
+      }
+      console.log();
+    }
+  } finally {
+    await discovery.end();
+  }
+
+  return exitCode;
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  runCli(process.argv.slice(2))
+    .then(code => {
+      process.exit(code);
+    })
+    .catch((error: unknown) => {
+      console.error(`\nFatal: ${errorMessage(error)}`);
+      process.exit(1);
+    });
+}

--- a/frontend/scripts/apply-schema-migrations.ts
+++ b/frontend/scripts/apply-schema-migrations.ts
@@ -60,6 +60,16 @@ export type { SqlExecutor } from './lib/schema-cli';
 export const LEDGER_TABLE = 'schema_migrations';
 export const MIGRATION_LOCK_TIMEOUT_SECONDS = 30;
 
+/**
+ * Patience limit for DDL against live tables. MySQL's default lock_wait_timeout is
+ * one year, so an ALTER queued behind a long-running ingestion transaction's
+ * metadata lock would wait indefinitely — and every NEW app query on that table
+ * queues behind the pending ALTER, freezing production ingestion until the CI job
+ * is killed. With this limit the migration fails fast instead (the deploy re-runs
+ * at a quieter moment); 60s still tolerates normal brief locks.
+ */
+export const DDL_LOCK_WAIT_TIMEOUT_SECONDS = 60;
+
 export const MIGRATION_STATUS = {
   APPLIED: 'applied',
   FAILED: 'failed'
@@ -296,6 +306,10 @@ export async function releaseMigrationLock(exec: SqlExecutor, lockName: string):
 export async function applyPendingMigrations(exec: SqlExecutor, schema: string, sources: MigrationSource[]): Promise<ApplyResult> {
   const lockName = await acquireMigrationLock(exec, schema);
   try {
+    // Fail fast if live traffic holds a metadata or row lock on a target table —
+    // see DDL_LOCK_WAIT_TIMEOUT_SECONDS for why the server default must not stand.
+    await exec(`SET SESSION lock_wait_timeout = ${DDL_LOCK_WAIT_TIMEOUT_SECONDS}`);
+    await exec(`SET SESSION innodb_lock_wait_timeout = ${DDL_LOCK_WAIT_TIMEOUT_SECONDS}`);
     await ensureLedgerTable(exec);
     const ledger = await readLedger(exec, schema);
     const pending = selectPendingMigrations(sources, ledger);
@@ -548,12 +562,15 @@ const invokedDirectly = (() => {
 })();
 
 if (invokedDirectly) {
+  // process.exitCode, NOT process.exit(): exit() terminates before piped stdout is
+  // flushed, discarding the per-schema apply log CI needs to diagnose a failure.
+  // All connections are closed in finally blocks, so the process exits on its own.
   runCli(process.argv.slice(2))
     .then(code => {
-      process.exit(code);
+      process.exitCode = code;
     })
     .catch((error: unknown) => {
       console.error(`\nFatal: ${errorMessage(error)}`);
-      process.exit(1);
+      process.exitCode = 1;
     });
 }

--- a/frontend/scripts/check-schema-contract.test.ts
+++ b/frontend/scripts/check-schema-contract.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeAudits, parseAuditArgs } from './check-schema-contract';
+import type { ContractAudit } from './apply-schema-migrations';
+
+function audit(schema: string, ok: boolean): ContractAudit {
+  return {
+    schema,
+    contractFailures: ok
+      ? []
+      : [{ table: 'temporarymeasurements', object: 'PublishedStemID', category: 'column', kind: 'missing', expected: 'int unsigned', actual: null }],
+    collationViolations: ok ? [] : ['temporarymeasurements.Comments => utf8mb4_general_ci'],
+    missingProcedures: [],
+    pendingMigrationIds: ok ? [] : ['2026-07-13-01-add-published-stemid-and-source-format'],
+    ok
+  };
+}
+
+describe('summarizeAudits', () => {
+  it('passes and reports N when every schema is compatible', () => {
+    const summary = summarizeAudits([audit('a', true), audit('b', true)]);
+    expect(summary.passed).toBe(true);
+    expect(summary.checked).toBe(2);
+    expect(summary.incompatible).toBe(0);
+    expect(summary.message).toBe('schema-contract OK: 2 schemas');
+  });
+
+  it('fails and counts incompatible schemas', () => {
+    const summary = summarizeAudits([audit('a', true), audit('b', false), audit('c', false)]);
+    expect(summary.passed).toBe(false);
+    expect(summary.checked).toBe(3);
+    expect(summary.incompatible).toBe(2);
+    expect(summary.message).toBe('schema-contract FAILED: 3 schemas checked, 2 incompatible');
+  });
+
+  it('treats zero schemas checked as a FAILURE (no false green)', () => {
+    const summary = summarizeAudits([]);
+    expect(summary.passed).toBe(false);
+    expect(summary.checked).toBe(0);
+    expect(summary.message).toBe('schema-contract FAILED: 0 schemas checked, 0 incompatible');
+  });
+});
+
+describe('parseAuditArgs', () => {
+  it('parses --all-sites', () => {
+    expect(parseAuditArgs(['--all-sites'])).toEqual({ allSites: true, schema: null });
+  });
+
+  it('parses --schema <name>', () => {
+    expect(parseAuditArgs(['--schema', 'forestgeo_x'])).toEqual({ allSites: false, schema: 'forestgeo_x' });
+  });
+
+  it('rejects neither or both targets', () => {
+    expect(() => parseAuditArgs([])).toThrow(/Exactly one target/);
+    expect(() => parseAuditArgs(['--all-sites', '--schema', 'x'])).toThrow(/Exactly one target/);
+  });
+
+  it('rejects an unknown flag', () => {
+    expect(() => parseAuditArgs(['--nope'])).toThrow(/Unknown argument/);
+  });
+});

--- a/frontend/scripts/check-schema-contract.test.ts
+++ b/frontend/scripts/check-schema-contract.test.ts
@@ -8,6 +8,7 @@ function audit(schema: string, ok: boolean): ContractAudit {
     contractFailures: ok
       ? []
       : [{ table: 'temporarymeasurements', object: 'PublishedStemID', category: 'column', kind: 'missing', expected: 'int unsigned', actual: null }],
+    contractExtras: [],
     collationViolations: ok ? [] : ['temporarymeasurements.Comments => utf8mb4_general_ci'],
     missingProcedures: [],
     pendingMigrationIds: ok ? [] : ['2026-07-13-01-add-published-stemid-and-source-format'],

--- a/frontend/scripts/check-schema-contract.ts
+++ b/frontend/scripts/check-schema-contract.ts
@@ -1,0 +1,178 @@
+/**
+ * Read-only schema-contract audit across ForestGEO schemas.
+ *
+ * Reports, per schema: missing/incompatible columns (type/nullability/default/
+ * extra/collation), missing required named indexes, database + text collation
+ * drift, missing ingestion procedures, and pending-migration state — all via the
+ * shared audit in apply-schema-migrations.ts (Task 2 schema-contract underneath).
+ * It never writes.
+ *
+ * It ends in exactly one of:
+ *   schema-contract OK: N schemas
+ *   schema-contract FAILED: N schemas checked, M incompatible
+ * N = 0 is ALWAYS a failure (a discovery failure must never read as a green run).
+ *
+ * Flags:
+ *   --schema <name>   audit ONE schema using LOCAL test credentials
+ *   --all-sites       audit every forestgeo_* schema on the Azure server
+ *
+ * Usage:
+ *   npx tsx scripts/check-schema-contract.ts --all-sites
+ *   npx tsx scripts/check-schema-contract.ts --schema forestgeo_test_default
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  assertSiteSchemasDiscovered,
+  auditSchemaContract,
+  loadMigrationSources,
+  readLedger,
+  selectPendingMigrations,
+  type ContractAudit,
+  type MigrationSource
+} from './apply-schema-migrations';
+import { assertExpectedHost, createSchemaCliConnection, discoverSiteSchemas, executorFor, resolveConnectionSettings } from './lib/schema-cli';
+
+const CLI_FLAG = {
+  SCHEMA: '--schema',
+  ALL_SITES: '--all-sites'
+} as const;
+
+export interface AuditArgs {
+  allSites: boolean;
+  schema: string | null;
+}
+
+export function parseAuditArgs(argv: string[]): AuditArgs {
+  let allSites = false;
+  let schema: string | null = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case CLI_FLAG.ALL_SITES:
+        allSites = true;
+        break;
+      case CLI_FLAG.SCHEMA:
+        schema = argv[i + 1];
+        if (!schema || schema.startsWith('--')) {
+          throw new Error(`${CLI_FLAG.SCHEMA} requires a schema name.`);
+        }
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown argument "${arg}". Supported: ${Object.values(CLI_FLAG).join(', ')}.`);
+    }
+  }
+
+  if (allSites === (schema !== null)) {
+    throw new Error(`Exactly one target is required: ${CLI_FLAG.ALL_SITES} or ${CLI_FLAG.SCHEMA} <name>.`);
+  }
+
+  return { allSites, schema };
+}
+
+export interface AuditSummary {
+  checked: number;
+  incompatible: number;
+  passed: boolean;
+  message: string;
+}
+
+/**
+ * Decides the overall pass/fail from per-schema audits. N = 0 is ALWAYS a
+ * failure: a run that checked zero schemas must never report success.
+ */
+export function summarizeAudits(audits: ContractAudit[]): AuditSummary {
+  const checked = audits.length;
+  const incompatible = audits.filter(audit => !audit.ok).length;
+  const passed = checked > 0 && incompatible === 0;
+  const message = passed ? `schema-contract OK: ${checked} schemas` : `schema-contract FAILED: ${checked} schemas checked, ${incompatible} incompatible`;
+  return { checked, incompatible, passed, message };
+}
+
+function printAuditDetail(audit: ContractAudit): void {
+  console.log(`Schema: ${audit.schema}${audit.ok ? '  [OK]' : '  [INCOMPATIBLE]'}`);
+  for (const failure of audit.contractFailures) {
+    console.log(
+      `  DRIFT   [${failure.table}] ${failure.category} "${failure.object}" ${failure.kind}: expected=${JSON.stringify(failure.expected)} actual=${JSON.stringify(failure.actual)}`
+    );
+  }
+  for (const violation of audit.collationViolations) {
+    console.log(`  COLLATION  ${violation}`);
+  }
+  for (const proc of audit.missingProcedures) {
+    console.log(`  MISSING PROCEDURE  ${proc}`);
+  }
+  for (const id of audit.pendingMigrationIds) {
+    console.log(`  PENDING MIGRATION  ${id}`);
+  }
+}
+
+async function auditOneSchema(settings: ReturnType<typeof resolveConnectionSettings>, schema: string, sources: MigrationSource[]): Promise<ContractAudit> {
+  const schemaConnection = await createSchemaCliConnection(settings, { database: schema, multipleStatements: false });
+  try {
+    const exec = executorFor(schemaConnection);
+    const ledger = await readLedger(exec, schema);
+    const pending = selectPendingMigrations(sources, ledger);
+    return auditSchemaContract(
+      exec,
+      schema,
+      pending.map(source => source.id)
+    );
+  } finally {
+    await schemaConnection.end();
+  }
+}
+
+async function runCli(argv: string[]): Promise<number> {
+  const args = parseAuditArgs(argv);
+  const settings = resolveConnectionSettings(args.allSites);
+  assertExpectedHost(settings.host, settings.allowedHosts);
+
+  const sources = loadMigrationSources();
+
+  const discovery = await createSchemaCliConnection(settings, { multipleStatements: false });
+
+  const audits: ContractAudit[] = [];
+  try {
+    const schemas = args.allSites ? await discoverSiteSchemas(discovery) : [args.schema as string];
+    if (args.allSites) {
+      assertSiteSchemasDiscovered(schemas);
+    }
+
+    for (const schema of schemas) {
+      const audit = await auditOneSchema(settings, schema, sources);
+      audits.push(audit);
+      printAuditDetail(audit);
+    }
+  } finally {
+    await discovery.end();
+  }
+
+  const summary = summarizeAudits(audits);
+  console.log(`\n${summary.message}`);
+  return summary.passed ? 0 : 1;
+}
+
+const invokedDirectly = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  runCli(process.argv.slice(2))
+    .then(code => {
+      process.exit(code);
+    })
+    .catch((error: unknown) => {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error(`\nschema-contract FAILED: ${reason}`);
+      process.exit(1);
+    });
+}

--- a/frontend/scripts/check-schema-contract.ts
+++ b/frontend/scripts/check-schema-contract.ts
@@ -99,8 +99,11 @@ function printAuditDetail(audit: ContractAudit): void {
       `  DRIFT   [${failure.table}] ${failure.category} "${failure.object}" ${failure.kind}: expected=${JSON.stringify(failure.expected)} actual=${JSON.stringify(failure.actual)}`
     );
   }
+  for (const extra of audit.contractExtras) {
+    console.log(`  EXTRA   [${extra.table}] ${extra.category} "${extra.object}" actual=${JSON.stringify(extra.actual)}`);
+  }
   for (const violation of audit.collationViolations) {
-    console.log(`  COLLATION  ${violation}`);
+    console.log(`  COLLATION WARNING  ${violation}`);
   }
   for (const proc of audit.missingProcedures) {
     console.log(`  MISSING PROCEDURE  ${proc}`);

--- a/frontend/scripts/check-schema-contract.ts
+++ b/frontend/scripts/check-schema-contract.ts
@@ -119,7 +119,10 @@ async function auditOneSchema(settings: ReturnType<typeof resolveConnectionSetti
     const exec = executorFor(schemaConnection);
     const ledger = await readLedger(exec, schema);
     const pending = selectPendingMigrations(sources, ledger);
-    return auditSchemaContract(
+    // `return await`, not `return`: the finally below closes the connection, and a bare
+    // `return` would run it before the audit's queries finish — killing the connection
+    // mid-audit on every real run.
+    return await auditSchemaContract(
       exec,
       schema,
       pending.map(source => source.id)
@@ -169,13 +172,19 @@ const invokedDirectly = (() => {
 })();
 
 if (invokedDirectly) {
+  // process.exitCode, NOT process.exit(): exit() terminates before piped stdout is
+  // flushed, discarding every per-schema audit line CI needs to diagnose a failure.
+  // All connections are closed in finally blocks, so the process exits on its own.
   runCli(process.argv.slice(2))
     .then(code => {
-      process.exit(code);
+      process.exitCode = code;
     })
     .catch((error: unknown) => {
       const reason = error instanceof Error ? error.message : String(error);
       console.error(`\nschema-contract FAILED: ${reason}`);
-      process.exit(1);
+      if (error instanceof Error && error.stack) {
+        console.error(error.stack);
+      }
+      process.exitCode = 1;
     });
 }

--- a/frontend/scripts/lib/schema-cli.test.ts
+++ b/frontend/scripts/lib/schema-cli.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { assertExpectedHost, resolveConnectionSettings, UnexpectedHostError, AZURE_HOST, AZURE_USER, AZURE_PORT, LOCAL_HOSTS } from './schema-cli';
+
+describe('assertExpectedHost', () => {
+  it('throws when the host is missing', () => {
+    expect(() => assertExpectedHost(undefined, [AZURE_HOST])).toThrow(UnexpectedHostError);
+  });
+
+  it('throws when the host is not in the allowed set', () => {
+    expect(() => assertExpectedHost('evil.example.com', [AZURE_HOST])).toThrow(UnexpectedHostError);
+    expect(() => assertExpectedHost('localhost', [AZURE_HOST])).toThrow(UnexpectedHostError);
+  });
+
+  it('passes for an allowed host', () => {
+    expect(() => assertExpectedHost(AZURE_HOST, [AZURE_HOST])).not.toThrow();
+    expect(() => assertExpectedHost('127.0.0.1', LOCAL_HOSTS)).not.toThrow();
+  });
+});
+
+describe('resolveConnectionSettings', () => {
+  const saved = {
+    pwd: process.env.AZURE_SQL_PASSWORD,
+    host: process.env.TEST_DB_HOST,
+    user: process.env.TEST_DB_USER,
+    tpwd: process.env.TEST_DB_PASSWORD,
+    port: process.env.TEST_DB_PORT
+  };
+
+  beforeEach(() => {
+    delete process.env.AZURE_SQL_PASSWORD;
+    delete process.env.TEST_DB_HOST;
+    delete process.env.TEST_DB_USER;
+    delete process.env.TEST_DB_PASSWORD;
+    delete process.env.TEST_DB_PORT;
+  });
+
+  afterEach(() => {
+    process.env.AZURE_SQL_PASSWORD = saved.pwd;
+    process.env.TEST_DB_HOST = saved.host;
+    process.env.TEST_DB_USER = saved.user;
+    process.env.TEST_DB_PASSWORD = saved.tpwd;
+    process.env.TEST_DB_PORT = saved.port;
+  });
+
+  it('--all-sites resolves to the Azure host with an Azure-only allow-list', () => {
+    process.env.AZURE_SQL_PASSWORD = 'secret';
+    const settings = resolveConnectionSettings(true);
+    expect(settings.host).toBe(AZURE_HOST);
+    expect(settings.user).toBe(AZURE_USER);
+    expect(settings.port).toBe(AZURE_PORT);
+    expect(settings.password).toBe('secret');
+    expect(settings.allowedHosts).toEqual([AZURE_HOST]);
+    // The resolved host must clear its own allow-list.
+    expect(() => assertExpectedHost(settings.host, settings.allowedHosts)).not.toThrow();
+  });
+
+  it('--all-sites requires AZURE_SQL_PASSWORD', () => {
+    expect(() => resolveConnectionSettings(true)).toThrow(/AZURE_SQL_PASSWORD is required/);
+  });
+
+  it('single-schema defaults to a LOCAL-only host/allow-list (never production)', () => {
+    const settings = resolveConnectionSettings(false);
+    expect(settings.host).toBe('localhost');
+    expect(settings.allowedHosts).toEqual(LOCAL_HOSTS);
+    expect(settings.host).not.toBe(AZURE_HOST);
+    // The Azure host must NOT clear the local allow-list.
+    expect(() => assertExpectedHost(AZURE_HOST, settings.allowedHosts)).toThrow(UnexpectedHostError);
+  });
+
+  it('single-schema honors TEST_DB_* overrides', () => {
+    process.env.TEST_DB_HOST = '127.0.0.1';
+    process.env.TEST_DB_USER = 'tester';
+    process.env.TEST_DB_PASSWORD = 'pw';
+    process.env.TEST_DB_PORT = '3307';
+    const settings = resolveConnectionSettings(false);
+    expect(settings.host).toBe('127.0.0.1');
+    expect(settings.user).toBe('tester');
+    expect(settings.password).toBe('pw');
+    expect(settings.port).toBe(3307);
+  });
+});

--- a/frontend/scripts/lib/schema-cli.test.ts
+++ b/frontend/scripts/lib/schema-cli.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { assertExpectedHost, resolveConnectionSettings, UnexpectedHostError, AZURE_HOST, AZURE_USER, AZURE_PORT, LOCAL_HOSTS } from './schema-cli';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import mysql from 'mysql2/promise';
+import {
+  assertExpectedHost,
+  resolveConnectionSettings,
+  createSchemaCliConnection,
+  discoverSiteSchemas,
+  UnexpectedHostError,
+  AZURE_HOST,
+  AZURE_USER,
+  AZURE_PORT,
+  LOCAL_HOSTS,
+  SITE_SCHEMA_LIKE
+} from './schema-cli';
 
 describe('assertExpectedHost', () => {
   it('throws when the host is missing', () => {
@@ -14,6 +26,39 @@ describe('assertExpectedHost', () => {
   it('passes for an allowed host', () => {
     expect(() => assertExpectedHost(AZURE_HOST, [AZURE_HOST])).not.toThrow();
     expect(() => assertExpectedHost('127.0.0.1', LOCAL_HOSTS)).not.toThrow();
+  });
+});
+
+describe('discoverSiteSchemas', () => {
+  it('escapes the literal prefix underscore and rejects names outside the site convention', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValue([
+        [
+          { schema_name: 'forestgeo_panama' },
+          { schema_name: 'forestgeo_testing_mason' },
+          { schema_name: 'forestgeoXnot_a_site' },
+          { schema_name: 'forestgeo_bad-name' }
+        ],
+        []
+      ]);
+    const connection = { query } as unknown as mysql.Connection;
+
+    await expect(discoverSiteSchemas(connection)).resolves.toEqual(['forestgeo_panama', 'forestgeo_testing_mason']);
+    expect(SITE_SCHEMA_LIKE).toBe('forestgeo\\_%');
+    expect(query).toHaveBeenCalledWith(expect.stringContaining("LIKE ? ESCAPE '\\\\'"), [SITE_SCHEMA_LIKE]);
+  });
+});
+
+describe('createSchemaCliConnection', () => {
+  it('requires normal certificate verification for Azure connections', async () => {
+    const createConnection = vi.spyOn(mysql, 'createConnection').mockResolvedValue({} as mysql.Connection);
+    const settings = { host: AZURE_HOST, user: AZURE_USER, password: 'secret', port: AZURE_PORT, allowedHosts: [AZURE_HOST] };
+
+    await createSchemaCliConnection(settings);
+
+    expect(createConnection).toHaveBeenCalledWith(expect.objectContaining({ ssl: { rejectUnauthorized: true } }));
+    createConnection.mockRestore();
   });
 });
 

--- a/frontend/scripts/lib/schema-cli.ts
+++ b/frontend/scripts/lib/schema-cli.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared connection + host-safety plumbing for the schema migrate/verify CLIs
+ * (apply-schema-migrations.ts and check-schema-contract.ts).
+ *
+ * The host allow-list is security-relevant, so it lives here in exactly one place:
+ * `--all-sites` targets the Azure server (validation-deploy env: AZURE_SQL_PASSWORD)
+ * and `--schema` targets a LOCAL test database only (TEST_DB_* env), so the
+ * single-schema tool can never silently touch production.
+ */
+
+import mysql from 'mysql2/promise';
+import type { SchemaQueryRow } from '@/lib/db/schema-contract';
+
+export const AZURE_HOST = 'forestgeo-mysqldataserver.mysql.database.azure.com';
+export const AZURE_USER = 'azureroot';
+export const AZURE_PORT = 3306;
+
+export const LOCAL_HOSTS = ['localhost', '127.0.0.1'] as const;
+
+export const SITE_SCHEMA_LIKE = 'forestgeo_%';
+
+/** Executes SQL and returns result rows (empty for writes/DDL). */
+export type SqlExecutor = (sql: string, params?: unknown[]) => Promise<SchemaQueryRow[]>;
+
+export class UnexpectedHostError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnexpectedHostError';
+  }
+}
+
+/** Refuses to run against a host outside the expected deployment environment. */
+export function assertExpectedHost(host: string | undefined, allowedHosts: readonly string[]): void {
+  if (!host) {
+    throw new UnexpectedHostError(`REFUSING TO RUN: no database host resolved. Expected one of: ${allowedHosts.join(', ')}.`);
+  }
+  if (!allowedHosts.includes(host)) {
+    throw new UnexpectedHostError(`REFUSING TO RUN: host "${host}" is not an expected deployment target. Expected one of: ${allowedHosts.join(', ')}.`);
+  }
+}
+
+export interface ConnectionSettings {
+  host: string;
+  user: string;
+  password: string;
+  port: number;
+  allowedHosts: readonly string[];
+}
+
+/**
+ * --all-sites -> Azure credentials (AZURE_SQL_PASSWORD required), Azure host only.
+ * --schema    -> LOCAL test credentials (TEST_DB_* env), localhost only.
+ */
+export function resolveConnectionSettings(allSites: boolean): ConnectionSettings {
+  if (allSites) {
+    const password = process.env.AZURE_SQL_PASSWORD;
+    if (!password) {
+      throw new Error('AZURE_SQL_PASSWORD is required for --all-sites (set it in the environment or .env.local).');
+    }
+    return { host: AZURE_HOST, user: AZURE_USER, password, port: AZURE_PORT, allowedHosts: [AZURE_HOST] };
+  }
+  return {
+    host: process.env.TEST_DB_HOST ?? 'localhost',
+    user: process.env.TEST_DB_USER ?? 'root',
+    password: process.env.TEST_DB_PASSWORD ?? 'testpassword',
+    port: Number.parseInt(process.env.TEST_DB_PORT ?? '3306', 10),
+    allowedHosts: LOCAL_HOSTS
+  };
+}
+
+export interface SchemaConnectionOptions {
+  database?: string;
+  multipleStatements?: boolean;
+}
+
+/** Opens a mysql2 connection, adding SSL only for the Azure host. */
+export async function createSchemaCliConnection(settings: ConnectionSettings, options: SchemaConnectionOptions = {}): Promise<mysql.Connection> {
+  return mysql.createConnection({
+    host: settings.host,
+    user: settings.user,
+    password: settings.password,
+    port: settings.port,
+    multipleStatements: options.multipleStatements ?? false,
+    ...(options.database !== undefined && { database: options.database }),
+    ...(settings.host === AZURE_HOST && { ssl: { rejectUnauthorized: false } })
+  });
+}
+
+export function executorFor(connection: mysql.Connection): SqlExecutor {
+  return async (sql, params) => {
+    const [rows] = await connection.query(sql, params ?? []);
+    return Array.isArray(rows) ? (rows as SchemaQueryRow[]) : [];
+  };
+}
+
+export async function discoverSiteSchemas(connection: mysql.Connection): Promise<string[]> {
+  const [rows] = await connection.query<mysql.RowDataPacket[]>(
+    `SELECT SCHEMA_NAME AS schema_name FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME`,
+    [SITE_SCHEMA_LIKE]
+  );
+  return rows.map(row => String(row.schema_name));
+}

--- a/frontend/scripts/lib/schema-cli.ts
+++ b/frontend/scripts/lib/schema-cli.ts
@@ -17,7 +17,8 @@ export const AZURE_PORT = 3306;
 
 export const LOCAL_HOSTS = ['localhost', '127.0.0.1'] as const;
 
-export const SITE_SCHEMA_LIKE = 'forestgeo_%';
+export const SITE_SCHEMA_LIKE = 'forestgeo\\_%';
+export const SITE_SCHEMA_NAME = /^forestgeo_[A-Za-z0-9]+(?:_[A-Za-z0-9]+)*$/;
 
 /** Executes SQL and returns result rows (empty for writes/DDL). */
 export type SqlExecutor = (sql: string, params?: unknown[]) => Promise<SchemaQueryRow[]>;
@@ -82,7 +83,7 @@ export async function createSchemaCliConnection(settings: ConnectionSettings, op
     port: settings.port,
     multipleStatements: options.multipleStatements ?? false,
     ...(options.database !== undefined && { database: options.database }),
-    ...(settings.host === AZURE_HOST && { ssl: { rejectUnauthorized: false } })
+    ...(settings.host === AZURE_HOST && { ssl: { rejectUnauthorized: true } })
   });
 }
 
@@ -95,8 +96,8 @@ export function executorFor(connection: mysql.Connection): SqlExecutor {
 
 export async function discoverSiteSchemas(connection: mysql.Connection): Promise<string[]> {
   const [rows] = await connection.query<mysql.RowDataPacket[]>(
-    `SELECT SCHEMA_NAME AS schema_name FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME`,
+    `SELECT SCHEMA_NAME AS schema_name FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE ? ESCAPE '\\\\' ORDER BY SCHEMA_NAME`,
     [SITE_SCHEMA_LIKE]
   );
-  return rows.map(row => String(row.schema_name));
+  return rows.map(row => String(row.schema_name)).filter(schema => SITE_SCHEMA_NAME.test(schema));
 }

--- a/frontend/tests/integration/00-infrastructure.integration.test.ts
+++ b/frontend/tests/integration/00-infrastructure.integration.test.ts
@@ -115,33 +115,9 @@ describe('Infrastructure Validation', () => {
       expect(tableNames.length).toBeGreaterThanOrEqual(EXPECTED_TABLES.length);
     });
 
-    it('should have correct table structure for coremeasurements', async () => {
-      const [columns] = await connection.query<RowDataPacket[]>('SHOW COLUMNS FROM coremeasurements');
-      const columnNames = columns.map(c => c.Field);
-
-      const requiredColumns = [
-        'CoreMeasurementID',
-        'StemGUID',
-        'CensusID',
-        'MeasuredDBH',
-        'MeasurementDate',
-        'UploadFileID',
-        'UploadBatchID',
-        'RawTreeTag',
-        'RawStemTag',
-        'RawSpCode',
-        'RawQuadrat',
-        'RawX',
-        'RawY',
-        'RawCodes',
-        'RawComments',
-        'SourceRowIndex'
-      ];
-
-      for (const col of requiredColumns) {
-        expect(columnNames).toContain(col);
-      }
-    });
+    // Per-column structure for coremeasurements and temporarymeasurements (and the other
+    // critical tables) is now asserted in full by schema-contract.integration.test.ts against
+    // the canonical DDL. This file no longer maintains a second, partial hardcoded column list.
 
     it('should not include legacy failed-row tables removed by the unified schema', async () => {
       const [tables] = await connection.query<RowDataPacket[]>('SHOW TABLES');
@@ -149,17 +125,6 @@ describe('Infrastructure Validation', () => {
 
       expect(tableNames).not.toContain('failedmeasurements');
       expect(tableNames).not.toContain('cmverrors');
-    });
-
-    it('should have correct table structure for temporarymeasurements', async () => {
-      const [columns] = await connection.query<RowDataPacket[]>('SHOW COLUMNS FROM temporarymeasurements');
-      const columnNames = columns.map(c => c.Field);
-
-      const requiredColumns = ['FileID', 'BatchID', 'PlotID', 'CensusID', 'TreeTag', 'StemTag', 'DBH'];
-
-      for (const col of requiredColumns) {
-        expect(columnNames).toContain(col);
-      }
     });
   });
 

--- a/frontend/tests/integration/schema-contract.integration.test.ts
+++ b/frontend/tests/integration/schema-contract.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Schema-contract parity (integration, real MySQL).
+ *
+ * Guards the incident where an application write column (PublishedStemID) was
+ * added to the temporarymeasurements INSERT but a live schema lacked it,
+ * producing a runtime 500 "Unknown column 'PublishedStemID' in 'field list'".
+ *
+ * It provisions a fresh schema from the canonical DDL (`db/sql/tablestructures.sql`)
+ * and asserts, against that live schema:
+ *   - every production insert column exists in temporarymeasurements;
+ *   - the keyed insert builder emits exactly one value per canonical column;
+ *   - canonical DDL metadata matches provisioned metadata for every critical table
+ *     (type/width, nullability, default, generated/extra, collation);
+ *   - the database default and every non-exempt text column use utf8mb4_0900_ai_ci;
+ *   - the required named constraints/indexes exist;
+ *   - the ingestion stored procedures are present.
+ *
+ * Because the live schema is provisioned FROM the canonical DDL, a green run
+ * means the DDL is internally consistent and the production write contract is a
+ * subset of it. A failure names the exact drifted object so it is debuggable at
+ * PR time.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Connection, RowDataPacket } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+import {
+  loadCanonicalSchemaContract,
+  readLiveSchemaContract,
+  compareSchemaContracts,
+  formatContractFailures,
+  CRITICAL_TABLES,
+  REQUIRED_INDEXES_BY_TABLE,
+  TARGET_TEXT_COLLATION,
+  type SchemaContract,
+  type SchemaQueryRow
+} from '@/lib/db/schema-contract';
+import {
+  TEMPORARY_MEASUREMENT_INSERT_COLUMNS,
+  buildTemporaryMeasurementInsertRecord,
+  toTemporaryMeasurementInsertValues
+} from '@/lib/ingestion/temporary-measurements';
+import { SourceFormat } from '@/config/macros/formdetails';
+
+const REQUIRED_INGESTION_PROCEDURES = ['bulkingestionprocess'] as const;
+
+// Text columns legitimately allowed to diverge from the target collation.
+// Empty today; every critical-table text column must use utf8mb4_0900_ai_ci.
+const EXEMPT_TEXT_COLLATION_COLUMNS = new Set<string>();
+
+describe('Schema Contract Parity', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let config: { database: string };
+  let canonicalContract: SchemaContract;
+  let liveContract: SchemaContract;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    config = setup.config;
+
+    const exec = async (sql: string, params: unknown[]): Promise<SchemaQueryRow[]> => {
+      const [rows] = await connection.query<RowDataPacket[]>(sql, params);
+      return rows as SchemaQueryRow[];
+    };
+
+    canonicalContract = loadCanonicalSchemaContract();
+    liveContract = await readLiveSchemaContract(exec, config.database, CRITICAL_TABLES);
+  }, 90000);
+
+  afterAll(async () => {
+    await teardownTestDatabase(connection, config);
+  });
+
+  it('provisions all critical tables from the canonical DDL', () => {
+    expect(testData.species.length).toBeGreaterThan(0); // setup actually ran
+    for (const table of CRITICAL_TABLES) {
+      expect(liveContract.tables[table], `critical table missing from provisioned schema: ${table}`).toBeDefined();
+      expect(canonicalContract.tables[table], `critical table missing from canonical DDL: ${table}`).toBeDefined();
+    }
+  });
+
+  it('has every production temporarymeasurements insert column present in the provisioned table', () => {
+    const provisionedColumns = new Set(Object.values(liveContract.tables['temporarymeasurements'].columns).map(c => c.name.toLowerCase()));
+    const missing = TEMPORARY_MEASUREMENT_INSERT_COLUMNS.filter(col => !provisionedColumns.has(col.toLowerCase()));
+    expect(missing, `temporarymeasurements is missing insert column(s): ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('emits exactly one insert value per canonical column, in column order', () => {
+    const record = buildTemporaryMeasurementInsertRecord(
+      {
+        tag: 'T1',
+        stemtag: '1',
+        spcode: 'sp',
+        quadrat: 'q1',
+        lx: '1',
+        ly: '2',
+        dbh: '10',
+        hom: '1.3',
+        date: '2026-01-01',
+        codes: null,
+        comments: null,
+        publishedstemid: '5001'
+      },
+      'file.csv',
+      'batch-1',
+      null,
+      SourceFormat.csv,
+      1,
+      2
+    );
+    expect(Object.keys(record).sort()).toEqual([...TEMPORARY_MEASUREMENT_INSERT_COLUMNS].sort());
+
+    const values = toTemporaryMeasurementInsertValues(record);
+    expect(values).toHaveLength(TEMPORARY_MEASUREMENT_INSERT_COLUMNS.length);
+    // Value order must follow the canonical column order exactly.
+    TEMPORARY_MEASUREMENT_INSERT_COLUMNS.forEach((column, index) => {
+      expect(values[index]).toBe(record[column]);
+    });
+  });
+
+  it('matches canonical DDL metadata against the provisioned schema for every critical table', () => {
+    const { failures, extras } = compareSchemaContracts(canonicalContract, liveContract);
+
+    if (failures.length > 0) {
+      throw new Error(`Schema contract violations (${failures.length}):\n${formatContractFailures(failures)}`);
+    }
+
+    // Extras are informational only (e.g. inline PRIMARY keys, which are outside the named
+    // index contract), but surface them so genuine drift stays visible in logs.
+    if (extras.length > 0) {
+      const rendered = extras.map(e => `[${e.table}] extra ${e.category} "${e.object}" (${e.actual})`).join('\n');
+      console.info(`Live schema has ${extras.length} object(s) beyond the canonical contract (informational):\n${rendered}`);
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('uses utf8mb4_0900_ai_ci for the database default and every non-exempt text column', () => {
+    expect(liveContract.defaultCollation).toBe(TARGET_TEXT_COLLATION);
+
+    const violations: string[] = [];
+    for (const table of CRITICAL_TABLES) {
+      for (const column of Object.values(liveContract.tables[table].columns)) {
+        if (!column.isText) continue;
+        const key = `${table}.${column.name}`.toLowerCase();
+        if (EXEMPT_TEXT_COLLATION_COLUMNS.has(key)) continue;
+        if (column.collation !== TARGET_TEXT_COLLATION) {
+          violations.push(`${table}.${column.name} => ${column.collation}`);
+        }
+      }
+    }
+    expect(violations, `text columns not using ${TARGET_TEXT_COLLATION}: ${violations.join(', ')}`).toEqual([]);
+  });
+
+  it('has every required named constraint/index present with the contracted shape', () => {
+    for (const [table, indexNames] of Object.entries(REQUIRED_INDEXES_BY_TABLE)) {
+      const liveIndexes = liveContract.tables[table].indexes;
+      for (const indexName of indexNames) {
+        const index = liveIndexes[indexName.toLowerCase()];
+        expect(index, `required index missing from ${table}: ${indexName}`).toBeDefined();
+        expect(index.columns.length, `required index has no columns in ${table}: ${indexName}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('has the ingestion stored procedures present', async () => {
+    const [procedures] = await connection.query<RowDataPacket[]>(
+      `SELECT ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'`,
+      [config.database]
+    );
+    const procedureNames = procedures.map(p => String(p.ROUTINE_NAME).toLowerCase());
+    for (const expected of REQUIRED_INGESTION_PROCEDURES) {
+      expect(procedureNames, `missing stored procedure: ${expected}`).toContain(expected.toLowerCase());
+    }
+  });
+});

--- a/frontend/tests/integration/schema-migration-contract.integration.test.ts
+++ b/frontend/tests/integration/schema-migration-contract.integration.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Stale-schema repair proof (integration, real MySQL).
+ *
+ * Provisions a throwaway schema from the canonical DDL, intentionally regresses it
+ * to the known live-schema drift (drops temporarymeasurements.PublishedStemID and
+ * SourceFormat; downgrades a representative text column to a legacy collation; no
+ * migration ledger), then proves the migrate + verify pipeline repairs it end to
+ * end and is idempotent:
+ *
+ *   (1) the read-only contract audit FAILS, naming both the missing columns and
+ *       the legacy-collation column;
+ *   (2) applying the manifest migrations SUCCEEDS;
+ *   (3) a second apply is a no-op (nothing pending, no rows re-applied);
+ *   (4) the read-only contract audit PASSES;
+ *   (5) a real temporarymeasurements insert built from the production keyed
+ *       builder (SourceFormat + PublishedStemID included) plus a one-row
+ *       bulkingestionprocess both succeed against the repaired schema.
+ *
+ * This guards the incident where app code depending on new write columns deployed
+ * ahead of the schema, producing runtime 500s.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import type { Connection, RowDataPacket } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, runBulkIngestion, type TestData } from '../setup/local-db-setup';
+import { formatContractFailures, TARGET_TEXT_COLLATION, type SchemaQueryRow } from '@/lib/db/schema-contract';
+import {
+  loadMigrationSources,
+  selectPendingMigrations,
+  applyPendingMigrations,
+  auditSchemaContract,
+  readLedger,
+  LEDGER_TABLE,
+  MIGRATION_STATUS,
+  type MigrationSource,
+  type SqlExecutor
+} from '@/scripts/apply-schema-migrations';
+import { SCHEMA_MIGRATION_MANIFEST } from '@/db/migrations/manifest';
+import {
+  TEMPORARY_MEASUREMENT_INSERT_COLUMNS,
+  buildTemporaryMeasurementInsertRecord,
+  toTemporaryMeasurementInsertValues
+} from '@/lib/ingestion/temporary-measurements';
+import { SourceFormat, type FileRow } from '@/config/macros/formdetails';
+
+const REPRESENTATIVE_TEXT_COLUMN = 'Comments';
+const LEGACY_COLLATION = 'utf8mb4_general_ci';
+
+describe('Stale-schema migrate + verify pipeline', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let config: { database: string };
+  let exec: SqlExecutor;
+  let sources: MigrationSource[];
+  let schema: string;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    config = setup.config;
+    schema = config.database;
+
+    exec = async (sql: string, params?: unknown[]): Promise<SchemaQueryRow[]> => {
+      const [rows] = await connection.query(sql, params ?? []);
+      return Array.isArray(rows) ? (rows as SchemaQueryRow[]) : [];
+    };
+
+    sources = loadMigrationSources(SCHEMA_MIGRATION_MANIFEST, path.join(process.cwd(), 'db', 'migrations'));
+
+    // Regress the freshly-provisioned schema to the known drift.
+    await connection.query('ALTER TABLE temporarymeasurements DROP COLUMN PublishedStemID');
+    await connection.query('ALTER TABLE temporarymeasurements DROP COLUMN SourceFormat');
+    await connection.query(
+      `ALTER TABLE temporarymeasurements MODIFY COLUMN ${REPRESENTATIVE_TEXT_COLUMN} varchar(255) CHARACTER SET utf8mb4 COLLATE ${LEGACY_COLLATION} NULL`
+    );
+    // Downgrade a NON-generated text column on a table that carries a STORED
+    // generated column (species.unique_sig), so the migration's per-table
+    // CONVERT TO branch is exercised against a generated-column table.
+    await connection.query(`ALTER TABLE species MODIFY COLUMN SpeciesName varchar(64) CHARACTER SET utf8mb4 COLLATE ${LEGACY_COLLATION} NULL`);
+  }, 90000);
+
+  afterAll(async () => {
+    await teardownTestDatabase(connection, config);
+  });
+
+  it('(1) read-only contract audit fails, naming the missing columns and the legacy-collation column', async () => {
+    const ledger = await readLedger(exec, schema); // no ledger table yet -> []
+    expect(ledger).toEqual([]);
+
+    const pending = selectPendingMigrations(sources, ledger);
+    expect(pending.map(s => s.id)).toEqual(SCHEMA_MIGRATION_MANIFEST.map(m => m.id));
+
+    const audit = await auditSchemaContract(
+      exec,
+      schema,
+      pending.map(s => s.id)
+    );
+
+    expect(audit.ok).toBe(false);
+    const missingColumns = audit.contractFailures.filter(f => f.kind === 'missing' && f.category === 'column').map(f => f.object);
+    expect(missingColumns).toContain('PublishedStemID');
+    expect(missingColumns).toContain('SourceFormat');
+    expect(audit.collationViolations.some(v => v.startsWith(`temporarymeasurements.${REPRESENTATIVE_TEXT_COLUMN}`))).toBe(true);
+    // The generated-column table's non-generated text column is flagged too.
+    expect(audit.collationViolations.some(v => v.startsWith('species.SpeciesName'))).toBe(true);
+  });
+
+  it('(2) applying the manifest migrations succeeds', async () => {
+    const result = await applyPendingMigrations(exec, schema, sources);
+    expect(result.failed, result.failed ? `${result.failed.id}: ${result.failed.error}` : undefined).toBeNull();
+    expect(result.appliedNow).toEqual(SCHEMA_MIGRATION_MANIFEST.map(m => m.id));
+
+    const ledger = await readLedger(exec, schema);
+    for (const source of sources) {
+      const row = ledger.find(r => r.MigrationID === source.id);
+      expect(row?.Status).toBe(MIGRATION_STATUS.APPLIED);
+      expect(row?.Checksum).toBe(source.checksum);
+    }
+  });
+
+  it('(3) a second apply is a no-op (nothing pending, no rows re-applied)', async () => {
+    const appliedAtById = async (): Promise<Record<string, string>> => {
+      const [rows] = await connection.query<RowDataPacket[]>(`SELECT MigrationID, AppliedAt FROM \`${LEDGER_TABLE}\``);
+      return Object.fromEntries(rows.map(r => [String(r.MigrationID), String(r.AppliedAt)]));
+    };
+
+    const before = await appliedAtById();
+    const result = await applyPendingMigrations(exec, schema, sources);
+    expect(result.pendingBefore).toEqual([]);
+    expect(result.appliedNow).toEqual([]);
+
+    const after = await appliedAtById();
+    // Row count unchanged AND no ledger row's AppliedAt was rewritten: the
+    // second apply neither inserted nor re-recorded any migration.
+    expect(Object.keys(after)).toEqual(Object.keys(before));
+    expect(after).toEqual(before);
+  });
+
+  it('(4) read-only contract audit passes after repair', async () => {
+    const ledger = await readLedger(exec, schema);
+    const pending = selectPendingMigrations(sources, ledger);
+    expect(pending).toEqual([]);
+
+    const audit = await auditSchemaContract(exec, schema, []);
+    if (!audit.ok) {
+      throw new Error(
+        `Post-migration audit still failing:\n${formatContractFailures(audit.contractFailures)}\n` +
+          `collation: ${audit.collationViolations.join(', ')}\nmissing procedures: ${audit.missingProcedures.join(', ')}`
+      );
+    }
+    expect(audit.ok).toBe(true);
+  });
+
+  it('(5) a production keyed insert + one-row bulkingestionprocess succeed against the repaired schema', async () => {
+    const fileID = 'schema-repair-f1';
+    const batchID = 'schema-repair-b1';
+    const plotID = testData.plots[0].plotID;
+    const censusID = testData.census[0].censusID;
+
+    const row: FileRow = {
+      tag: 'REPAIRTREE1',
+      stemtag: '1',
+      spcode: testData.species[0].SpeciesCode,
+      quadrat: testData.quadrats[0].QuadratName,
+      lx: '1',
+      ly: '1',
+      dbh: '10',
+      hom: '1.3',
+      date: '2026-01-01',
+      codes: null,
+      comments: null,
+      publishedstemid: '7001'
+    };
+
+    const record = buildTemporaryMeasurementInsertRecord(row, fileID, batchID, null, SourceFormat.csv, plotID, censusID);
+    const values = toTemporaryMeasurementInsertValues(record);
+
+    const columnList = TEMPORARY_MEASUREMENT_INSERT_COLUMNS.join(', ');
+    const placeholders = TEMPORARY_MEASUREMENT_INSERT_COLUMNS.map(() => '?').join(', ');
+    await connection.query(`INSERT INTO temporarymeasurements (${columnList}) VALUES (${placeholders})`, values);
+
+    const ingestion = await runBulkIngestion(connection, fileID, batchID);
+    expect(ingestion.success, ingestion.message).toBe(true);
+
+    const [ingested] = await connection.query<RowDataPacket[]>(
+      `SELECT cm.CoreMeasurementID, cm.StemGUID, s.PublishedStemID
+       FROM coremeasurements cm
+       LEFT JOIN stems s ON s.StemGUID = cm.StemGUID
+       WHERE cm.UploadFileID = ? AND cm.UploadBatchID = ?`,
+      [fileID, batchID]
+    );
+    expect(ingested.length).toBe(1);
+    expect(ingested[0].StemGUID).not.toBeNull(); // resolved, not a failed measurement
+    expect(ingested[0].PublishedStemID).toBe(7001);
+  });
+
+  it('(6) the CONVERT of a generated-column table preserved species.unique_sig and left species writable + on-target', async () => {
+    // (b) the STORED generated column survived the CONVERT TO rebuild.
+    const [generated] = await connection.query<RowDataPacket[]>(
+      `SELECT EXTRA, GENERATION_EXPRESSION
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'species' AND COLUMN_NAME = 'unique_sig'`,
+      [schema]
+    );
+    expect(generated.length).toBe(1);
+    expect(String(generated[0].EXTRA).toUpperCase()).toContain('STORED GENERATED');
+    expect(String(generated[0].GENERATION_EXPRESSION).length).toBeGreaterThan(0);
+
+    // (c) the non-generated text column is now on-target and the table is writable.
+    const [speciesNameCollation] = await connection.query<RowDataPacket[]>(
+      `SELECT COLLATION_NAME
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'species' AND COLUMN_NAME = 'SpeciesName'`,
+      [schema]
+    );
+    expect(speciesNameCollation[0].COLLATION_NAME).toBe(TARGET_TEXT_COLLATION);
+
+    const insertedCode = 'REPAIRSP1';
+    await connection.query(`INSERT INTO species (SpeciesCode, SpeciesName, IDLevel, IsActive) VALUES (?, ?, 'species', 1)`, [insertedCode, 'Repairus testus']);
+    const [roundTrip] = await connection.query<RowDataPacket[]>(`SELECT SpeciesName, unique_sig FROM species WHERE SpeciesCode = ?`, [insertedCode]);
+    expect(roundTrip.length).toBe(1);
+    expect(roundTrip[0].SpeciesName).toBe('Repairus testus');
+    // The STORED generated signature recomputed on insert (proves it is live).
+    expect(String(roundTrip[0].unique_sig)).toContain(insertedCode);
+  });
+});

--- a/frontend/tests/integration/schema-migration-contract.integration.test.ts
+++ b/frontend/tests/integration/schema-migration-contract.integration.test.ts
@@ -3,15 +3,16 @@
  *
  * Provisions a throwaway schema from the canonical DDL, intentionally regresses it
  * to the known live-schema drift (drops temporarymeasurements.PublishedStemID and
- * SourceFormat; downgrades a representative text column to a legacy collation; no
- * migration ledger), then proves the migrate + verify pipeline repairs it end to
- * end and is idempotent:
+ * SourceFormat; downgrades representative VARCHAR/TEXT columns to utf8mb3; no
+ * migration ledger), then proves the migrate + verify pipeline repairs the
+ * application write contract end to end without rebuilding unrelated tables and
+ * remains idempotent:
  *
  *   (1) the read-only contract audit FAILS, naming both the missing columns and
- *       the legacy-collation column;
+ *       the legacy-collation columns as maintenance warnings;
  *   (2) applying the manifest migrations SUCCEEDS;
  *   (3) a second apply is a no-op (nothing pending, no rows re-applied);
- *   (4) the read-only contract audit PASSES;
+ *   (4) the read-only compatibility gate PASSES while retaining the warnings;
  *   (5) a real temporarymeasurements insert built from the production keyed
  *       builder (SourceFormat + PublishedStemID included) plus a one-row
  *       bulkingestionprocess both succeed against the repaired schema.
@@ -24,7 +25,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import path from 'path';
 import type { Connection, RowDataPacket } from 'mysql2/promise';
 import { setupTestDatabase, teardownTestDatabase, runBulkIngestion, type TestData } from '../setup/local-db-setup';
-import { formatContractFailures, TARGET_TEXT_COLLATION, type SchemaQueryRow } from '@/lib/db/schema-contract';
+import { formatContractFailures, type SchemaQueryRow } from '@/lib/db/schema-contract';
 import {
   loadMigrationSources,
   selectPendingMigrations,
@@ -45,7 +46,8 @@ import {
 import { SourceFormat, type FileRow } from '@/config/macros/formdetails';
 
 const REPRESENTATIVE_TEXT_COLUMN = 'Comments';
-const LEGACY_COLLATION = 'utf8mb4_general_ci';
+const LEGACY_CHARSET = 'utf8mb3';
+const LEGACY_COLLATION = 'utf8mb3_general_ci';
 
 describe('Stale-schema migrate + verify pipeline', () => {
   let connection: Connection;
@@ -73,12 +75,12 @@ describe('Stale-schema migrate + verify pipeline', () => {
     await connection.query('ALTER TABLE temporarymeasurements DROP COLUMN PublishedStemID');
     await connection.query('ALTER TABLE temporarymeasurements DROP COLUMN SourceFormat');
     await connection.query(
-      `ALTER TABLE temporarymeasurements MODIFY COLUMN ${REPRESENTATIVE_TEXT_COLUMN} varchar(255) CHARACTER SET utf8mb4 COLLATE ${LEGACY_COLLATION} NULL`
+      `ALTER TABLE temporarymeasurements MODIFY COLUMN ${REPRESENTATIVE_TEXT_COLUMN} varchar(255) CHARACTER SET ${LEGACY_CHARSET} COLLATE ${LEGACY_COLLATION} NULL`
     );
-    // Downgrade a NON-generated text column on a table that carries a STORED
-    // generated column (species.unique_sig), so the migration's per-table
-    // CONVERT TO branch is exercised against a generated-column table.
-    await connection.query(`ALTER TABLE species MODIFY COLUMN SpeciesName varchar(64) CHARACTER SET utf8mb4 COLLATE ${LEGACY_COLLATION} NULL`);
+    // Exercise a generated unique signature and a TEXT-family column. The
+    // additive migration must leave both definitions untouched.
+    await connection.query(`ALTER TABLE species MODIFY COLUMN SpeciesName varchar(64) CHARACTER SET ${LEGACY_CHARSET} COLLATE ${LEGACY_COLLATION} NULL`);
+    await connection.query(`ALTER TABLE uploadintegrityalerts MODIFY COLUMN message text CHARACTER SET ${LEGACY_CHARSET} COLLATE ${LEGACY_COLLATION} NOT NULL`);
   }, 90000);
 
   afterAll(async () => {
@@ -105,6 +107,7 @@ describe('Stale-schema migrate + verify pipeline', () => {
     expect(audit.collationViolations.some(v => v.startsWith(`temporarymeasurements.${REPRESENTATIVE_TEXT_COLUMN}`))).toBe(true);
     // The generated-column table's non-generated text column is flagged too.
     expect(audit.collationViolations.some(v => v.startsWith('species.SpeciesName'))).toBe(true);
+    expect(audit.collationViolations.some(v => v.startsWith('uploadintegrityalerts.message'))).toBe(true);
   });
 
   it('(2) applying the manifest migrations succeeds', async () => {
@@ -138,7 +141,7 @@ describe('Stale-schema migrate + verify pipeline', () => {
     expect(after).toEqual(before);
   });
 
-  it('(4) read-only contract audit passes after repair', async () => {
+  it('(4) compatibility gate passes after repair while legacy collations remain visible', async () => {
     const ledger = await readLedger(exec, schema);
     const pending = selectPendingMigrations(sources, ledger);
     expect(pending).toEqual([]);
@@ -151,6 +154,7 @@ describe('Stale-schema migrate + verify pipeline', () => {
       );
     }
     expect(audit.ok).toBe(true);
+    expect(audit.collationViolations.some(v => v.includes(LEGACY_COLLATION))).toBe(true);
   });
 
   it('(5) a production keyed insert + one-row bulkingestionprocess succeed against the repaired schema', async () => {
@@ -196,8 +200,7 @@ describe('Stale-schema migrate + verify pipeline', () => {
     expect(ingested[0].PublishedStemID).toBe(7001);
   });
 
-  it('(6) the CONVERT of a generated-column table preserved species.unique_sig and left species writable + on-target', async () => {
-    // (b) the STORED generated column survived the CONVERT TO rebuild.
+  it('(6) additive repair leaves utf8mb3 TEXT and generated unique-key definitions untouched', async () => {
     const [generated] = await connection.query<RowDataPacket[]>(
       `SELECT EXTRA, GENERATION_EXPRESSION
        FROM information_schema.COLUMNS
@@ -208,21 +211,30 @@ describe('Stale-schema migrate + verify pipeline', () => {
     expect(String(generated[0].EXTRA).toUpperCase()).toContain('STORED GENERATED');
     expect(String(generated[0].GENERATION_EXPRESSION).length).toBeGreaterThan(0);
 
-    // (c) the non-generated text column is now on-target and the table is writable.
-    const [speciesNameCollation] = await connection.query<RowDataPacket[]>(
-      `SELECT COLLATION_NAME
+    const [speciesNameMetadata] = await connection.query<RowDataPacket[]>(
+      `SELECT COLUMN_TYPE, COLLATION_NAME
        FROM information_schema.COLUMNS
        WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'species' AND COLUMN_NAME = 'SpeciesName'`,
       [schema]
     );
-    expect(speciesNameCollation[0].COLLATION_NAME).toBe(TARGET_TEXT_COLLATION);
+    expect(speciesNameMetadata[0].COLUMN_TYPE).toBe('varchar(64)');
+    expect(speciesNameMetadata[0].COLLATION_NAME).toBe(LEGACY_COLLATION);
+
+    const [messageMetadata] = await connection.query<RowDataPacket[]>(
+      `SELECT COLUMN_TYPE, COLLATION_NAME
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'uploadintegrityalerts' AND COLUMN_NAME = 'message'`,
+      [schema]
+    );
+    expect(messageMetadata[0].COLUMN_TYPE).toBe('text');
+    expect(messageMetadata[0].COLLATION_NAME).toBe(LEGACY_COLLATION);
 
     const insertedCode = 'REPAIRSP1';
     await connection.query(`INSERT INTO species (SpeciesCode, SpeciesName, IDLevel, IsActive) VALUES (?, ?, 'species', 1)`, [insertedCode, 'Repairus testus']);
     const [roundTrip] = await connection.query<RowDataPacket[]>(`SELECT SpeciesName, unique_sig FROM species WHERE SpeciesCode = ?`, [insertedCode]);
     expect(roundTrip.length).toBe(1);
     expect(roundTrip[0].SpeciesName).toBe('Repairus testus');
-    // The STORED generated signature recomputed on insert (proves it is live).
+    // The STORED unique signature still recomputes on insert.
     expect(String(roundTrip[0].unique_sig)).toContain(insertedCode);
   });
 });

--- a/frontend/tests/unit/temporary-measurements-publishedstemid.test.ts
+++ b/frontend/tests/unit/temporary-measurements-publishedstemid.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTemporaryMeasurementInsertParams, parseUnsignedIntField } from '@/lib/ingestion/temporary-measurements';
+import { buildTemporaryMeasurementInsertRecord, parseUnsignedIntField } from '@/lib/ingestion/temporary-measurements';
 import { SourceFormat } from '@/config/macros/formdetails';
 
 const FILE = 'f.csv',
@@ -7,12 +7,12 @@ const FILE = 'f.csv',
   SESSION = null,
   PLOT = 1,
   CENSUS = 2;
-const lastParam = (row: any) => buildTemporaryMeasurementInsertParams(row, FILE, BATCH, SESSION, SourceFormat.csv, PLOT, CENSUS).at(-1);
+const publishedStemIDOf = (row: any) => buildTemporaryMeasurementInsertRecord(row, FILE, BATCH, SESSION, SourceFormat.csv, PLOT, CENSUS).PublishedStemID;
 
-describe('buildTemporaryMeasurementInsertParams publishedstemid wiring', () => {
-  it('appends the parsed PublishedStemID as the final param', () => {
+describe('buildTemporaryMeasurementInsertRecord publishedstemid wiring', () => {
+  it('maps the parsed PublishedStemID onto the keyed record', () => {
     expect(
-      lastParam({
+      publishedStemIDOf({
         tag: 'T1',
         stemtag: '1',
         spcode: 'sp',
@@ -29,7 +29,7 @@ describe('buildTemporaryMeasurementInsertParams publishedstemid wiring', () => {
     ).toBe(5001);
   });
   it('yields null when publishedstemid is absent', () => {
-    expect(lastParam({ tag: 'T1', spcode: 'sp', quadrat: 'q1', lx: '1', ly: '2', date: '2026-01-01' })).toBeNull();
+    expect(publishedStemIDOf({ tag: 'T1', spcode: 'sp', quadrat: 'q1', lx: '1', ly: '2', date: '2026-01-01' })).toBeNull();
   });
 });
 


### PR DESCRIPTION
Split 2 of 2 replacing #350. This PR contains only the schema-contract, migration-runner, and deployment-ordering work; runtime ingestion changes are isolated in the companion PR.

## What changed

- Adds canonical schema-contract parsing/auditing, a checksummed migration ledger, and migrate-before-deploy CI gates.
- Requires normal TLS certificate verification for Azure migration connections.
- Escapes the literal `forestgeo_` schema prefix and post-filters discovered database names against the site naming convention.
- Serializes migration application with a per-schema MySQL advisory lock and fails fast after the first apply failure.
- Makes the repair migration additive-only (`SourceFormat` and `PublishedStemID`). It no longer performs nine table-wide charset conversions during application deployment.
- Reports collation drift and extra schema objects as maintenance information without widening `TEXT` columns or rebuilding ingestion tables.
- Uses a real utf8mb3 `VARCHAR`/`TEXT`/generated-key integration fixture to prove definitions remain intact.
- Makes development deployment non-cancellable while DDL is in flight.
- Creates a stage-specific GitHub issue for migration/verification failures as well as app-deployment failures; app restart is attempted only for an app failure.

## Verification

- `npm run test:unit:ci` — 199 files, 2,648 passed, 4 skipped
- Schema-focused unit suites — 62 passed
- Real-MySQL schema contract and migration suites — 13 passed
- Changed files have no TypeScript errors (the repository-wide command retains pre-existing test typing failures)

Replaces the schema/CI portion of #350.
