### PR TITLE
fix(authz): reject executable SQL comments in the query route

### DIFF
--- a/frontend/app/api/query/route.test.ts
+++ b/frontend/app/api/query/route.test.ts
@@ -113,6 +113,13 @@ describe('POST /api/query authorization', () => {
     expect(mocks.executeQuery).toHaveBeenCalledWith("SELECT * FROM forestgeo_testing.attributes WHERE Description = 'forestgeo_other.attributes'");
   });
 
+  it('does not reject executable-comment-looking text inside string literals', async () => {
+    const response = await POST(makeRequest("SELECT * FROM forestgeo_testing.attributes WHERE Description = '/*!50000 JOIN external_archive.users */'"));
+
+    expect(response.status).toBe(200);
+    expect(mocks.executeQuery).toHaveBeenCalledWith("SELECT * FROM forestgeo_testing.attributes WHERE Description = '/*!50000 JOIN external_archive.users */'");
+  });
+
   it('still rejects multiple statements when a string literal contains comment syntax', async () => {
     const response = await POST(
       makeRequest("SELECT * FROM forestgeo_testing.attributes WHERE Description = '-- not a comment'; SELECT * FROM forestgeo_testing.attributes")
@@ -218,6 +225,13 @@ describe('POST /api/query authorization', () => {
 
   it('rejects non-admin reads that use MySQL STRAIGHT_JOIN to reach an external database', async () => {
     const response = await POST(makeRequest('SELECT a.Code, u.Email FROM forestgeo_testing.attributes a STRAIGHT_JOIN external_archive.users u ON 1 = 1'));
+
+    expect(response.status).toBe(403);
+    expect(mocks.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('rejects MySQL executable comments that hide an external database join', async () => {
+    const response = await POST(makeRequest('SELECT a.Code, u.Email FROM forestgeo_testing.attributes a /*!50000 JOIN external_archive.users u ON 1 = 1 */'));
 
     expect(response.status).toBe(403);
     expect(mocks.executeQuery).not.toHaveBeenCalled();

--- a/frontend/app/api/query/route.ts
+++ b/frontend/app/api/query/route.ts
@@ -36,6 +36,10 @@ function sqlForAuthorization(query: string): string {
   return stripSqlComments(stripSqlStringLiterals(query));
 }
 
+function hasExecutableSqlComment(query: string): boolean {
+  return /\/\*!/.test(stripSqlStringLiterals(query));
+}
+
 function hasMultipleStatements(query: string): boolean {
   return sqlForAuthorization(query).trim().replace(/;+$/g, '').includes(';');
 }
@@ -168,6 +172,10 @@ function extractTableSchemas(query: string): string[] {
 }
 
 function authorizeQuery(session: Session, query: string): NextResponse | null {
+  if (hasExecutableSqlComment(query)) {
+    return NextResponse.json({ error: 'Executable SQL comments are not allowed' }, { status: HTTPResponses.FORBIDDEN });
+  }
+
   if (hasMultipleStatements(query)) {
     return NextResponse.json({ error: 'Multiple SQL statements are not allowed' }, { status: HTTPResponses.FORBIDDEN });
   }


### PR DESCRIPTION
The query route's per-site authorization strips SQL comments before extracting table schemas, but MySQL *executes* the contents of executable comments (`/*! ... */`). A cross-schema join hidden inside one — e.g. `SELECT a.Code, u.Email FROM forestgeo_testing.attributes a /*!50000 JOIN external_archive.users u ON 1 = 1 */` — was invisible to `extractTableSchemas` while still running against the unauthorized schema.

This rejects any `/*!` sequence outside string literals with a 403 before authorization proceeds. Literal `/*!` text inside string values remains allowed.

Cherry-picked from `refactor/architecture-remediation` (`3a5f5c30`) and verified still applicable against the post-#345 route.