### PR TITLE
fix(census): persist start/end dates under strict MySQL sql_mode

### DIFF
--- a/frontend/components/client/modals/censuscreationmodal.tsx
+++ b/frontend/components/client/modals/censuscreationmodal.tsx
@@ -19,8 +19,8 @@ import { useEffect, useMemo, useState } from 'react';
 
 export interface CensusCreationDetails {
   description?: string;
-  startDate: Date;
-  endDate?: Date;
+  startDate: string;
+  endDate?: string;
 }
 
 interface CensusCreationModalProps {
@@ -38,8 +38,6 @@ const toDateInputValue = (date: Date) => {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
-
-const parseLocalDate = (value: string) => new Date(`${value}T00:00:00`);
 
 export default function CensusCreationModal({ open, censusNumber, plotName, isCreating, onClose, onCreate }: CensusCreationModalProps) {
   const [description, setDescription] = useState('');
@@ -63,8 +61,8 @@ export default function CensusCreationModal({ open, censusNumber, plotName, isCr
     if (dateError) return;
     return onCreate({
       description: description.trim() || undefined,
-      startDate: parseLocalDate(startDate),
-      endDate: endDate ? parseLocalDate(endDate) : undefined
+      startDate,
+      endDate: endDate || undefined
     });
   };
 

--- a/frontend/lib/db/definitions/timekeeping.test.ts
+++ b/frontend/lib/db/definitions/timekeeping.test.ts
@@ -1,11 +1,15 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { OrgCensusRDS } from './timekeeping';
 
 let reconcileCurrentCensusSelection: typeof import('./timekeeping').reconcileCurrentCensusSelection;
+let OrgCensusToCensusResultMapper: typeof import('./timekeeping').OrgCensusToCensusResultMapper;
 
 beforeAll(async () => {
   vi.unmock('@/lib/db/definitions/timekeeping');
-  ({ reconcileCurrentCensusSelection } = await import('./timekeeping'));
+  // The shared auth-mocks setup mocks MapperFactory with 'sites'-only support; the real
+  // census mapper is a pure factory (no DB), so use it here rather than the throwing stub.
+  vi.unmock('@/config/datamapper');
+  ({ reconcileCurrentCensusSelection, OrgCensusToCensusResultMapper } = await import('./timekeeping'));
 });
 
 describe('reconcileCurrentCensusSelection', () => {
@@ -60,5 +64,84 @@ describe('reconcileCurrentCensusSelection', () => {
     };
 
     expect(reconcileCurrentCensusSelection(missingCurrentCensus, censusList)).toBeUndefined();
+  });
+});
+
+describe('OrgCensusToCensusResultMapper.startNewCensus', () => {
+  const SCHEMA = 'forestgeo_harvard';
+  const PLOT_ID = 12;
+  const PLOT_CENSUS_NUMBER = 1;
+  // MySQL DATE literal shape; anything with 'T'/'Z' (a full ISO timestamp) is rejected by
+  // a DATE column under strict sql_mode with error 1292.
+  const MYSQL_DATE_LITERAL = /^\d{4}-\d{2}-\d{2}$/;
+  // Native date inputs expose date-only strings; keep them intact through persistence.
+  const PICKED_START = '2026-07-20';
+  const PICKED_END = '2026-08-15';
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubFetch(response: { ok: boolean; status: number; json?: unknown; text?: string }) {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: response.ok,
+      status: response.status,
+      json: async () => response.json,
+      text: async () => response.text ?? ''
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  function bodyOf(fetchMock: ReturnType<typeof vi.fn>) {
+    return JSON.parse(fetchMock.mock.calls[0][1].body).newRow;
+  }
+
+  it('serializes dates as date-only strings a MySQL DATE column accepts, not ISO timestamps', async () => {
+    const fetchMock = stubFetch({ ok: true, status: 200, json: { createdIDs: { census: 42 } } });
+
+    const createdID = await new OrgCensusToCensusResultMapper().startNewCensus(SCHEMA, PLOT_ID, PLOT_CENSUS_NUMBER, {
+      startDate: PICKED_START,
+      endDate: PICKED_END,
+      description: 'Harvard Forest census 1'
+    });
+
+    expect(createdID).toBe(42);
+    const body = bodyOf(fetchMock);
+    // The bug: JSON.stringify(Date) produced '2026-07-20T...Z', which strict MySQL rejects.
+    expect(body.startDate).toMatch(MYSQL_DATE_LITERAL);
+    expect(body.endDate).toMatch(MYSQL_DATE_LITERAL);
+    // Preserves the calendar day the user picked (no UTC off-by-one) in any timezone.
+    expect(body.startDate).toBe('2026-07-20');
+    expect(body.endDate).toBe('2026-08-15');
+  });
+
+  it('omits an optional end date without emitting a bogus value', async () => {
+    const fetchMock = stubFetch({ ok: true, status: 200, json: { createdIDs: { census: 7 } } });
+
+    await new OrgCensusToCensusResultMapper().startNewCensus(SCHEMA, PLOT_ID, PLOT_CENSUS_NUMBER, { startDate: PICKED_START });
+
+    const body = bodyOf(fetchMock);
+    expect(body.startDate).toBe('2026-07-20');
+    expect(body.endDate).toBeUndefined();
+  });
+
+  it('does not normalize a selected calendar day through the local timezone', async () => {
+    const fetchMock = stubFetch({ ok: true, status: 200, json: { createdIDs: { census: 8 } } });
+
+    // 2011-12-30 did not exist in Pacific/Apia. Converting this input through a
+    // local Date would silently normalize it to 2011-12-31.
+    await new OrgCensusToCensusResultMapper().startNewCensus(SCHEMA, PLOT_ID, PLOT_CENSUS_NUMBER, { startDate: '2011-12-30' });
+
+    expect(bodyOf(fetchMock).startDate).toBe('2011-12-30');
+  });
+
+  it('surfaces a failed insert instead of swallowing it into a property-access error', async () => {
+    stubFetch({ ok: false, status: 500, text: "Incorrect date value for column 'StartDate'" });
+
+    await expect(new OrgCensusToCensusResultMapper().startNewCensus(SCHEMA, PLOT_ID, PLOT_CENSUS_NUMBER, { startDate: PICKED_START })).rejects.toThrow(
+      /Census creation failed \(HTTP 500\).*Incorrect date value/
+    );
   });
 });

--- a/frontend/lib/db/definitions/timekeeping.ts
+++ b/frontend/lib/db/definitions/timekeeping.ts
@@ -72,9 +72,12 @@ export class OrgCensusToCensusResultMapper {
     schema: string,
     plotID: number,
     plotCensusNumber: number,
-    details?: { description?: string; startDate?: Date; endDate?: Date }
+    details?: { description?: string; startDate?: string; endDate?: string }
   ): Promise<number | undefined> {
-    const newCensusRDS: CensusRDS = {
+    // census.StartDate / EndDate are MySQL DATE columns. Keep the browser's date-only
+    // values intact so the insert survives strict sql_mode without a Date/timezone
+    // round-trip that could change the selected calendar day.
+    const newRow = {
       censusID: 0, // This will be replaced with the actual ID after the POST request
       plotID,
       plotCensusNumber,
@@ -86,11 +89,16 @@ export class OrgCensusToCensusResultMapper {
     const response = await fetch(`/api/fixeddata/census/${schema}/censusID`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ newRow: newCensusRDS })
+      body: JSON.stringify({ newRow })
     });
 
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Census creation failed (HTTP ${response.status}): ${errorBody}`);
+    }
+
     const responseJSON = await response.json();
-    return responseJSON.createdIDs.census;
+    return responseJSON.createdIDs?.census;
   }
 }
 


### PR DESCRIPTION
## Problem

Creating a census on the dev site silently fails to save the start/end dates (reported for a Harvard Forest upload). The creation modal sent `StartDate`/`EndDate` as JS `Date` objects, which `JSON.stringify` serializes to full ISO timestamps (e.g. `2026-07-20T07:00:00.000Z`). The `census.StartDate`/`EndDate` columns are MySQL `DATE`, and Azure runs strict `sql_mode` (verified: `STRICT_TRANS_TABLES`), so the timestamp is rejected with error 1292 and the entire insert rolls back — no census is created.

Reproduced against the live Azure server (into a throwaway temp table, nothing written to real data): `INSERT ... StartDate='2026-07-20T07:00:00.000Z'` → `ERROR 1292 Incorrect date value`.

A second issue compounded it: `startNewCensus` never checked `response.ok`, so the real MySQL error was swallowed into a misleading `Cannot read properties of undefined (reading 'census')`, and the UI just showed a generic failure.

## Fix

- Pass the browser's native date-only (`YYYY-MM-DD`) values straight through from the creation modal to the insert, with no `Date`/timezone round-trip. This both survives strict `sql_mode` and avoids a latent off-by-one where `toISOString()` would shift the selected calendar day for users east of UTC.
- Check `response.ok` in `startNewCensus` and throw the server's error text, so a failed insert surfaces instead of a misleading property-access error.

## Tests

- New `OrgCensusToCensusResultMapper.startNewCensus` unit suite: asserts the wire format is a bare `YYYY-MM-DD` (the exact value strict MySQL previously rejected), that a selected day is not normalized through the local timezone, that an omitted end date is not fabricated, and that a failed insert now throws with the server message.

Scope is the creation path (the reported break). Full unit + integration suites and `build:check` pass locally.