### PR TITLE
Task 10A: pin DBH/HOM round-to-6 precision contract + 10B/10C docs

### DIFF
--- a/docs/auth-environment-variables-runbook.md
+++ b/docs/auth-environment-variables-runbook.md
@@ -183,6 +183,28 @@ When login works with Microsoft but the app still lands on a blank or inert `/da
 5. If needed, compare with local `.env.local`
 6. If needed, update GitHub environment secrets so future deploys stay aligned
 
+## 8b. Rotating dev's AUTH_SECRET to differ from production (2026-07-20 hardening)
+
+Decision (2026-07-20): the cross-site single sign-on behavior is accepted as expected, but
+dev and prod should NOT share the session-signing secret. If they share `AUTH_SECRET`, a
+session token minted by the softer dev environment is cryptographically valid on the live
+site. Rotating dev's secret to a distinct value closes that.
+
+First, confirm whether they are actually shared (optional but informative): copy a live
+`__Secure-authjs.session-token` cookie value and replay it against dev —
+`curl -s https://forestgeo-development.azurewebsites.net/api/auth/session -H "Cookie: __Secure-authjs.session-token=<live-value>"`.
+A session JSON back = shared secret (rotate); `null` = already distinct (done).
+
+To rotate (operator action — engineering cannot change Azure/GitHub secrets):
+1. Generate a new value: `openssl rand -base64 33`.
+2. GitHub → repo Settings → Environments → `development_temp` → update `AUTH_SECRET`.
+3. Azure Portal → App Service `forestgeo-development` → Settings → Environment variables →
+   set `AUTH_SECRET` to the same new value → Apply → restart the App Service.
+4. Leave `production`'s `AUTH_SECRET` untouched. Verify a fresh dev login still works and
+   that the replay test above now returns `null`.
+
+Note: existing dev sessions are invalidated by the rotation — dev users re-login once.
+
 ## 9. Current lesson from this incident
 
 The observed failure pattern was:

--- a/docs/testing/regression-contracts.md
+++ b/docs/testing/regression-contracts.md
@@ -109,11 +109,31 @@ Enforced by: `tests/setup/ingestion-outcome.ts` +
   the hard-gated test-only `/api/e2e-auth-poll` stub (404 outside e2e; the production
   authorization path is unchanged).
 
+### 7. DBH/HOM over-precision is rounded quietly to the stored scale
+
+**Ratified 2026-07-20 by the scientific-data owner (Option A: round).** An uploaded DBH or
+HOM value carrying more precision than the `DECIMAL(12,6)` column stores is rounded to 6
+decimal places and ingested as a normal success — no failure row, no warning. The
+rounding happens at the `DECIMAL(12,6)` boundary (staging → coremeasurements). This is
+accepted because 6 decimal places is below instrument-meaningful resolution for the units
+in use. The exact submitted value is NOT preserved (there is no `RawDBH`/`RawHOM`
+column); if provenance is needed later, that is a separate, larger change (Option B).
+
+Note this contract is about *precision only*. Negative and out-of-range (≥ 1 km) values
+are a separate validation concern (`NEGATIVE_DBH`/`NEGATIVE_HOM`), not covered here.
+
+Enforced by: `tests/integration/ingestion-invariants.integration.test.ts` → "DBH/HOM
+precision" block.
+
 ## Explicitly NOT yet contracted (blocked)
 
-- **DBH/HOM precision** (round vs preserve vs reject beyond `DECIMAL(12,6)` scale):
-  awaiting the scientific-data owner's decision; `coremeasurements` has no
-  `RawDBH`/`RawHOM` provenance column today, so a "preserve raw" choice must first
-  define where provenance lives.
-- **Cross-site authentication cookie behavior**: awaiting a reproduced root cause.
-- **Publish gating** (warning-vs-blocking validation tiers): awaiting the tier feature.
+- **Cross-site authentication cookie behavior**: the observed cross-site login is
+  **ratified as expected/acceptable** single sign-on (2026-07-20) — browser cookie-bleed
+  was ruled out (host-only cookies + `azurewebsites.net` Public Suffix). Separately, dev's
+  `AUTH_SECRET` is being rotated to differ from production as hardening (operator action;
+  see `docs/auth-environment-variables-runbook.md`).
+- **Publish gating** (warning-vs-blocking validation tiers): interim decision 2026-07-20 —
+  data-quality precondition failures should surface as warnings rather than block the CTFS
+  export, with the full tier feature recorded as a TODO. **Pending a safety confirmation**
+  (some CTFS-export preconditions are destination-integrity constraints, not quality
+  warnings — see the TODO in `lib/ctfs-export/precondition.ts`).

--- a/docs/testing/regression-contracts.md
+++ b/docs/testing/regression-contracts.md
@@ -132,8 +132,27 @@ precision" block.
   was ruled out (host-only cookies + `azurewebsites.net` Public Suffix). Separately, dev's
   `AUTH_SECRET` is being rotated to differ from production as hardening (operator action;
   see `docs/auth-environment-variables-runbook.md`).
-- **Publish gating** (warning-vs-blocking validation tiers): interim decision 2026-07-20 —
-  data-quality precondition failures should surface as warnings rather than block the CTFS
-  export, with the full tier feature recorded as a TODO. **Pending a safety confirmation**
-  (some CTFS-export preconditions are destination-integrity constraints, not quality
-  warnings — see the TODO in `lib/ctfs-export/precondition.ts`).
+### 8. CTFS publish gate warns on data-quality, blocks on destination-integrity
+
+**Ratified 2026-07-20 (interim of the full validation-tier feature).** "Publish census"
+(the CTFS `.sql` export loaded into the on-prem CTFS MySQL) runs 8 "Finished Census"
+preconditions, now split into two policies:
+
+- **Warnings (publish proceeds):** `not-validated`, `unresolved-error`, `no-stem-guid`,
+  `inactive-join`. These describe rows the export already excludes
+  (`exportableMeasurementBaseWhere`), so the operator is told what won't be exported and
+  the publish continues, surfacing the warnings in `X-CTFS-Precondition-Warnings`.
+- **Blocking (publish 400s):** `unknown-attribute-code`, `missing-taxonomy-fields`,
+  `string-too-long`, `zero-exportable-rows`. Each would produce an artifact that fails to
+  load into, or silently truncates data in, the destination CTFS DB, so these still stop a
+  real publish. A dry run continues to surface everything (blockers included) as a
+  non-blocking preview.
+
+The "nothing left to export" check still runs even when only warnings are present, so a
+warn-only census cannot slip through as an empty publish. The full warning-vs-blocking
+validation-tier feature (authorized+audited override, server-side gate stale UI can't
+bypass) remains a TODO in `lib/ctfs-export/precondition.ts`.
+
+Enforced by: `lib/ctfs-export/precondition.test.ts` (classification + warning-plus-zero-
+rows interaction) and the CTFS export route test (`app/api/export/ctfs-sql/.../route.test.ts`:
+quality warning → 200 + header; blocker → 400 with only blocking reasons).

--- a/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.test.ts
+++ b/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.test.ts
@@ -54,11 +54,18 @@ vi.mock('@/lib/db/primitives', () => ({
   }))
 }));
 
-vi.mock('@/lib/ctfs-export', () => ({
-  checkFinishedCensus: mocks.checkFinishedCensus,
-  selectMeasurements: mocks.selectMeasurements,
-  renderArtifact: mocks.renderArtifact
-}));
+// Keep the REAL partitionPreconditionFailures (pure block-vs-warn policy) so the
+// route's gating decision is exercised against the actual classification, not a
+// stub — only the DB-touching functions are mocked.
+vi.mock('@/lib/ctfs-export', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/ctfs-export')>('@/lib/ctfs-export');
+  return {
+    ...actual,
+    checkFinishedCensus: mocks.checkFinishedCensus,
+    selectMeasurements: mocks.selectMeasurements,
+    renderArtifact: mocks.renderArtifact
+  };
+});
 
 vi.mock('@/ailogger', () => ({
   default: {
@@ -322,17 +329,54 @@ describe('GET /api/export/ctfs-sql/:schema/:plotID/:censusID', () => {
   // Precondition failure
   // -------------------------------------------------------------------------
 
-  it('returns 400 with structured reasons when checkFinishedCensus fails on a real publish', async () => {
-    const reasons = [{ kind: 'not-validated', message: '2 rows not yet validated', coreMeasurementIds: [10, 11] }];
-    mocks.checkFinishedCensus.mockResolvedValue({ ok: false, reasons });
+  it('returns 400 with ONLY the blocking (destination-integrity) reasons on a real publish', async () => {
+    // Mixed failure: a data-quality warning + a destination-integrity blocker. Task 10C
+    // policy: block on the blocker, and the 400 body lists only the blocking reasons —
+    // the quality warning does not stop a publish and must not masquerade as the blocker.
+    const warning = { kind: 'not-validated', message: '2 rows not yet validated', coreMeasurementIds: [10, 11] };
+    const blocker = { kind: 'string-too-long', message: 'Destination-bound value exceeds CTFS legacy column width', coreMeasurementIds: [12] };
+    mocks.checkFinishedCensus.mockResolvedValue({ ok: false, reasons: [warning, blocker] });
 
     const res = await GET(makeRequest(), makeProps());
 
     expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
     const body = await res.json();
-    expect(body.error).toMatch(/census is not finished/i);
-    expect(body.reasons).toEqual(reasons);
+    expect(body.error).toMatch(/cannot be published/i);
+    expect(body.reasons).toEqual([blocker]);
+    expect(mocks.renderArtifact).not.toHaveBeenCalled();
     expect(mocks.connRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds to a 200 publish + warning header when only DATA-QUALITY preconditions fail (Task 10C)', async () => {
+    // not-validated is a WARNING kind: the export already excludes those rows, so the
+    // publish proceeds and the operator is warned rather than blocked.
+    const reasons = [{ kind: 'not-validated', message: '2 rows not yet validated', coreMeasurementIds: [10, 11] }];
+    mocks.checkFinishedCensus.mockResolvedValue({ ok: false, reasons });
+
+    const res = await GET(makeRequest(), makeProps());
+
+    expect(res.status).toBe(HTTPResponses.OK);
+    expect(await res.text()).toBe(STUB_RENDER_RESULT.sql);
+    const warnHeader = res.headers.get('X-CTFS-Precondition-Warnings');
+    expect(warnHeader).toBeTruthy();
+    expect(JSON.parse(warnHeader!)).toEqual(reasons);
+    // Not a dry run, but warnings still flow into the artifact renderer.
+    expect(mocks.renderArtifact).toHaveBeenCalledWith(expect.objectContaining({ reloadDryRun: false, preconditionWarnings: reasons }));
+    expect(mocks.connRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT block a real publish and does NOT downgrade a destination-integrity failure to a warning silently', async () => {
+    // zero-exportable-rows is blocking; a real (non-dry) publish must 400, never emit an
+    // empty artifact with a warning.
+    const blocker = { kind: 'zero-exportable-rows', message: 'No exportable rows remain after applying all filters', coreMeasurementIds: [] };
+    mocks.checkFinishedCensus.mockResolvedValue({ ok: false, reasons: [blocker] });
+
+    const res = await GET(makeRequest(), makeProps());
+
+    expect(res.status).toBe(HTTPResponses.BAD_REQUEST);
+    const body = await res.json();
+    expect(body.reasons).toEqual([blocker]);
+    expect(mocks.renderArtifact).not.toHaveBeenCalled();
   });
 
   it('returns 200 with a dry-run artifact + warning header when preconditions fail in dry-run mode', async () => {

--- a/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.ts
+++ b/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.ts
@@ -6,7 +6,7 @@ import { auth } from '@/auth';
 import { getSessionUserId } from '@/lib/auth-helpers';
 import { fromPath, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
 import ailogger from '@/ailogger';
-import { checkFinishedCensus, selectMeasurements, renderArtifact, type PreconditionFailure } from '@/lib/ctfs-export';
+import { checkFinishedCensus, partitionPreconditionFailures, selectMeasurements, renderArtifact, type PreconditionFailure } from '@/lib/ctfs-export';
 import { userCanExportSchema, userIsAdmin } from '@/lib/ctfs-export/export-permissions';
 import type { Session } from 'next-auth';
 
@@ -117,17 +117,22 @@ async function handler(request: NextRequest, context: RouteContext): Promise<Nex
     }
     const plotCensusNumber = String(censusRows[0].PlotCensusNumber);
 
-    // Precondition: census must be fully validated and clean before a real
-    // publish. D6: a Dry run is allowed even when preconditions fail — the
-    // failures are surfaced as non-blocking warnings instead of a 400, so the
-    // operator can preview reload impact and see what would block a real publish.
+    // Precondition gate (Task 10C, ratified 2026-07-20: warn on data-quality, keep
+    // destination-integrity blocking). Data-quality failures (rows the export already
+    // excludes) surface as non-blocking warnings and the publish proceeds; only
+    // destination-integrity failures — an artifact that would break the on-prem CTFS
+    // load — still 400. A Dry run keeps its prior behavior: NOTHING blocks, everything
+    // (including would-be blockers) is surfaced as a warning preview.
     const precondition = await checkFinishedCensus(conn, { schema, plotId: appPlotId, censusId: appCensusId });
     let preconditionWarnings: PreconditionFailure[] = [];
     if (!precondition.ok) {
-      if (!reloadDryRun) {
-        return NextResponse.json({ error: 'Census is not finished', reasons: precondition.reasons }, { status: HTTPResponses.BAD_REQUEST });
+      const { blocking, warnings } = partitionPreconditionFailures(precondition.reasons);
+      if (blocking.length > 0 && !reloadDryRun) {
+        return NextResponse.json({ error: 'Census cannot be published', reasons: blocking }, { status: HTTPResponses.BAD_REQUEST });
       }
-      preconditionWarnings = precondition.reasons;
+      // Non-dry real publish with only quality warnings → surface those warnings and
+      // proceed. Dry run → surface every reason (blockers included) as a preview.
+      preconditionWarnings = reloadDryRun ? precondition.reasons : warnings;
     }
 
     // Fetch measurement + attribute rows from the app database.

--- a/frontend/lib/ctfs-export/index.ts
+++ b/frontend/lib/ctfs-export/index.ts
@@ -5,7 +5,15 @@
  * artifact rendering, and identifier utilities.
  */
 
-export { checkFinishedCensus, type PreconditionResult, type PreconditionFailure, type PreconditionFailureKind } from './precondition';
+export {
+  checkFinishedCensus,
+  partitionPreconditionFailures,
+  isBlockingPreconditionKind,
+  WARNING_PRECONDITION_KINDS,
+  type PreconditionResult,
+  type PreconditionFailure,
+  type PreconditionFailureKind
+} from './precondition';
 export { selectMeasurements, type SelectResult, type SelectInput } from './select-measurements';
 export { renderArtifact, renderRebuildViewFullTableArtifact, type RenderArtifactInput, type RenderArtifactResult } from './render-procedure';
 export { buildProcedureName, buildLockName, deterministicSuffix } from './identifier-safety';

--- a/frontend/lib/ctfs-export/precondition.test.ts
+++ b/frontend/lib/ctfs-export/precondition.test.ts
@@ -15,7 +15,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createTestDatabase, teardownTestDatabase, loadSchema, DEFAULT_TEST_CONFIG } from '../../tests/setup/local-db-setup';
-import { checkFinishedCensus, MAX_DISPLAY_FAILURES } from './precondition';
+import { checkFinishedCensus, MAX_DISPLAY_FAILURES, partitionPreconditionFailures, isBlockingPreconditionKind, type PreconditionFailure } from './precondition';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -475,6 +475,57 @@ describe('checkFinishedCensus', () => {
       expect(failure, 'not-validated failure should be present').toBeDefined();
       expect(failure!.coreMeasurementIds.length, `coreMeasurementIds must be capped at ${MAX_DISPLAY_FAILURES}`).toBeLessThanOrEqual(MAX_DISPLAY_FAILURES);
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Task 10C: an all-quality-warning census still catches "nothing left to export"
+  // -------------------------------------------------------------------------
+
+  it('reports BOTH the quality warning AND zero-exportable-rows when the only row is unvalidated', async () => {
+    // The single seed row is unvalidated → excluded by the export filter → zero
+    // exportable rows. Under the warn-don't-block policy the zero-rows gate must still
+    // run (it no longer short-circuits on the warning), so a would-be empty publish
+    // is caught rather than slipping through as a warning-only proceed.
+    await conn.query('UPDATE coremeasurements SET IsValidated = FALSE WHERE CoreMeasurementID = 1');
+
+    const result = await checkFinishedCensus(conn, { schema: DB_NAME, plotId: PLOT_ID, censusId: CENSUS_ID });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const kinds = result.reasons.map(r => r.kind);
+      expect(kinds, 'the quality warning is preserved').toContain('not-validated');
+      expect(kinds, 'zero-exportable-rows still fires alongside the warning').toContain('zero-exportable-rows');
+      const { blocking, warnings } = partitionPreconditionFailures(result.reasons);
+      expect(warnings.map(r => r.kind)).toEqual(['not-validated']);
+      expect(blocking.map(r => r.kind)).toEqual(['zero-exportable-rows']);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Task 10C: block-vs-warn classification (pure)
+  // -------------------------------------------------------------------------
+
+  it('classifies data-quality kinds as warnings and destination-integrity kinds as blocking', () => {
+    // Data-quality: rows the export already excludes → warn, don't block.
+    for (const kind of ['not-validated', 'unresolved-error', 'no-stem-guid', 'inactive-join'] as const) {
+      expect(isBlockingPreconditionKind(kind), `${kind} should be a WARNING`).toBe(false);
+    }
+    // Destination-integrity: an artifact violating these breaks the CTFS load → block.
+    for (const kind of ['unknown-attribute-code', 'missing-taxonomy-fields', 'string-too-long', 'zero-exportable-rows'] as const) {
+      expect(isBlockingPreconditionKind(kind), `${kind} should be BLOCKING`).toBe(true);
+    }
+  });
+
+  it('partitions a mixed reason list preserving per-bucket order', () => {
+    const reasons: PreconditionFailure[] = [
+      { kind: 'not-validated', message: 'w1', coreMeasurementIds: [1] },
+      { kind: 'string-too-long', message: 'b1', coreMeasurementIds: [2] },
+      { kind: 'no-stem-guid', message: 'w2', coreMeasurementIds: [3] },
+      { kind: 'missing-taxonomy-fields', message: 'b2', coreMeasurementIds: [4] }
+    ];
+    const { blocking, warnings } = partitionPreconditionFailures(reasons);
+    expect(warnings.map(r => r.message)).toEqual(['w1', 'w2']);
+    expect(blocking.map(r => r.message)).toEqual(['b1', 'b2']);
   });
 
   // -------------------------------------------------------------------------

--- a/frontend/lib/ctfs-export/precondition.ts
+++ b/frontend/lib/ctfs-export/precondition.ts
@@ -9,22 +9,17 @@
  * are validated against a strict regex before being backtick-quoted, preventing
  * SQL injection through schema name interpolation.
  *
- * TODO (Task 10C — deferred warning-vs-blocking publish tier, ratified interim 2026-07-20):
- * The maintainer wants publish preconditions to surface as *warnings* rather than hard-
- * block the export, with a proper validation-tier feature (blocking errors vs warnings,
- * authorized+audited override, server-side gate that stale UI cannot bypass) built later.
- * The non-blocking pathway already exists — see the `reloadDryRun` branch in
- * app/api/export/ctfs-sql/.../route.ts, which returns 200 + `X-CTFS-Precondition-Warnings`
- * instead of a 400. Do NOT flip all eight checks to warnings wholesale: they are two
- * different kinds. Checks 1-4 (`not-validated`, `unresolved-error`, `no-stem-guid`,
- * `inactive-join`) are DATA-QUALITY notices — the export SELECT already excludes those
- * rows (see exportableMeasurementBaseWhere), so warning-and-excluding them is safe. But
- * checks 6-8 (`missing-taxonomy-fields`, `string-too-long`, `zero-exportable-rows`) are
- * DESTINATION-INTEGRITY constraints: an artifact that violates them fails to load into, or
- * silently truncates data in, the on-prem CTFS MySQL — downgrading those to warnings
- * reintroduces exactly the silent-corruption class this hardening effort exists to prevent.
- * The tier feature must keep the destination-integrity checks blocking (or gate any override
- * behind an authenticated, audited operator confirmation).
+ * Task 10C (ratified interim 2026-07-20 — IMPLEMENTED): publish preconditions are split
+ * into WARNING vs BLOCKING kinds (see WARNING_PRECONDITION_KINDS below). Data-quality
+ * failures surface as warnings and the publish proceeds; destination-integrity failures
+ * still 400. The classification lives in this module and the gating in the CTFS export
+ * route; a dry run continues to surface everything as a preview.
+ *
+ * TODO (full validation-tier feature, still deferred): an authorized, AUDITED operator
+ * override that can consciously publish past a destination-integrity blocker, enforced
+ * server-side so stale UI cannot bypass it. Until that exists, the blocking kinds are a
+ * hard stop — do NOT reclassify any of them to a warning to work around a stuck publish,
+ * because a warning-only export of those kinds ships broken data to the on-prem CTFS MySQL.
  */
 
 import type { Connection } from 'mysql2/promise';
@@ -85,6 +80,51 @@ export interface PreconditionInput {
 }
 
 export type PreconditionResult = { ok: true; count: number } | { ok: false; reasons: PreconditionFailure[] };
+
+/**
+ * Publish-gate policy (Task 10C, ratified 2026-07-20: "warn on quality, keep structural
+ * blocking"). Two kinds of precondition failure:
+ *
+ *  - WARNING kinds are data-quality notices about rows the export ALREADY excludes via
+ *    exportableMeasurementBaseWhere (IsValidated=TRUE, StemGUID NOT NULL, active joins).
+ *    Surfacing them and letting the publish proceed drops nothing the artifact would have
+ *    carried — the operator is simply told which rows won't be exported.
+ *  - BLOCKING kinds are destination-integrity constraints. An artifact that violates them
+ *    fails to load into, or silently truncates data in, the on-prem CTFS MySQL:
+ *      • unknown-attribute-code — the row IS exported (base WHERE does not filter on
+ *        attributes) carrying a code the destination's TSMAttributes cannot resolve;
+ *      • missing-taxonomy-fields — the destination species/genus/family lookup fails;
+ *      • string-too-long — a value overflows a narrower CTFS column;
+ *      • zero-exportable-rows — an empty/meaningless artifact.
+ *    These stay blocking so the "warn, don't block" relaxation can never ship broken data
+ *    to CTFS.
+ */
+export const WARNING_PRECONDITION_KINDS: ReadonlySet<PreconditionFailureKind> = new Set<PreconditionFailureKind>([
+  'not-validated',
+  'unresolved-error',
+  'no-stem-guid',
+  'inactive-join'
+]);
+
+export function isBlockingPreconditionKind(kind: PreconditionFailureKind): boolean {
+  return !WARNING_PRECONDITION_KINDS.has(kind);
+}
+
+/**
+ * Split precondition failures into the ones that must block a real publish and the ones
+ * that only warrant a warning. Preserves input order within each bucket.
+ */
+export function partitionPreconditionFailures(reasons: PreconditionFailure[]): {
+  blocking: PreconditionFailure[];
+  warnings: PreconditionFailure[];
+} {
+  const blocking: PreconditionFailure[] = [];
+  const warnings: PreconditionFailure[] = [];
+  for (const reason of reasons) {
+    (isBlockingPreconditionKind(reason.kind) ? blocking : warnings).push(reason);
+  }
+  return { blocking, warnings };
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -322,9 +362,13 @@ export async function checkFinishedCensus(conn: Connection, input: PreconditionI
     });
   }
 
-  // If any checks failed, return the accumulated failure list immediately.
-  // Check 8 (zero rows) only makes sense when no other disqualifiers exist.
-  if (reasons.length > 0) {
+  // Check 8 (zero rows) must still run when the only failures so far are WARNING
+  // kinds — otherwise a census whose rows are all excluded by quality issues (e.g.
+  // every row unvalidated) would skip this gate, the publish would proceed on the
+  // warn-don't-block path, and selectMeasurements would render an empty artifact.
+  // It is skipped only when a BLOCKING failure already exists (the publish is going
+  // to 400 regardless, and the count query may not be meaningful in that state).
+  if (reasons.some(r => isBlockingPreconditionKind(r.kind))) {
     return { ok: false, reasons };
   }
 
@@ -346,16 +390,22 @@ export async function checkFinishedCensus(conn: Connection, input: PreconditionI
   const count = Number((countRows as Array<{ n: number }>)[0].n);
 
   if (count === 0) {
-    return {
-      ok: false,
-      reasons: [
-        {
-          kind: 'zero-exportable-rows',
-          message: 'No exportable rows remain after applying all filters',
-          coreMeasurementIds: []
-        }
-      ]
-    };
+    // Preserve any accumulated WARNING reasons alongside the blocking zero-rows
+    // failure so the operator sees the full picture (what's wrong AND that nothing
+    // is left to export).
+    reasons.push({
+      kind: 'zero-exportable-rows',
+      message: 'No exportable rows remain after applying all filters',
+      coreMeasurementIds: []
+    });
+    return { ok: false, reasons };
+  }
+
+  // Rows exist. If only WARNING reasons accumulated, the census is not perfectly
+  // clean (ok=false) but nothing here is blocking — the route surfaces these as
+  // warnings and proceeds. ok=true is reserved for a fully clean census.
+  if (reasons.length > 0) {
+    return { ok: false, reasons };
   }
 
   return { ok: true, count };

--- a/frontend/lib/ctfs-export/precondition.ts
+++ b/frontend/lib/ctfs-export/precondition.ts
@@ -8,6 +8,23 @@
  * identifiers via `quoteSchema`; CensusID bound via `?` placeholder). Schema names
  * are validated against a strict regex before being backtick-quoted, preventing
  * SQL injection through schema name interpolation.
+ *
+ * TODO (Task 10C — deferred warning-vs-blocking publish tier, ratified interim 2026-07-20):
+ * The maintainer wants publish preconditions to surface as *warnings* rather than hard-
+ * block the export, with a proper validation-tier feature (blocking errors vs warnings,
+ * authorized+audited override, server-side gate that stale UI cannot bypass) built later.
+ * The non-blocking pathway already exists — see the `reloadDryRun` branch in
+ * app/api/export/ctfs-sql/.../route.ts, which returns 200 + `X-CTFS-Precondition-Warnings`
+ * instead of a 400. Do NOT flip all eight checks to warnings wholesale: they are two
+ * different kinds. Checks 1-4 (`not-validated`, `unresolved-error`, `no-stem-guid`,
+ * `inactive-join`) are DATA-QUALITY notices — the export SELECT already excludes those
+ * rows (see exportableMeasurementBaseWhere), so warning-and-excluding them is safe. But
+ * checks 6-8 (`missing-taxonomy-fields`, `string-too-long`, `zero-exportable-rows`) are
+ * DESTINATION-INTEGRITY constraints: an artifact that violates them fails to load into, or
+ * silently truncates data in, the on-prem CTFS MySQL — downgrading those to warnings
+ * reintroduces exactly the silent-corruption class this hardening effort exists to prevent.
+ * The tier feature must keep the destination-integrity checks blocking (or gate any override
+ * behind an authenticated, audited operator confirmation).
  */
 
 import type { Connection } from 'mysql2/promise';

--- a/frontend/tests/integration/ingestion-invariants.integration.test.ts
+++ b/frontend/tests/integration/ingestion-invariants.integration.test.ts
@@ -256,6 +256,78 @@ describe('Ingestion invariants (bulkingestionprocess)', () => {
     });
   });
 
+  describe('DBH/HOM precision (Task 10A — ratified contract: round quietly to the stored scale)', () => {
+    // RATIFIED 2026-07-20 by the scientific-data owner: an uploaded DBH/HOM value carrying
+    // more precision than the DECIMAL(12,6) column stores is ROUNDED to 6 decimal places and
+    // ingested as valid — no failure, no warning (docs/testing/regression-contracts.md).
+    // This pins that behavior so a future schema/type change that silently alters it goes red.
+    // Rounding happens at the DECIMAL(12,6) boundary (staging temporarymeasurements.DBH/HOM,
+    // then copied to coremeasurements.MeasuredDBH/MeasuredHOM). MySQL DECIMAL rounds half away
+    // from zero; the 7th-digit cases below are chosen far from .5 so binary-float noise in the
+    // JS literal cannot flip the asserted result.
+    //
+    // SCOPE: this is the PRECISION contract only. Negative / out-of-range (>=1km) handling is a
+    // SEPARATE validation concern (NEGATIVE_DBH/NEGATIVE_HOM ingestion codes) and is NOT part of
+    // the round-quietly decision — do not fold it in here without its own ratified contract.
+    const PRECISION_CASES = [
+      { name: 'exactly 6 decimals is stored verbatim', dbh: 12.345678, hom: 1.234567, expectedDBH: 12.345678, expectedHOM: 1.234567 },
+      { name: 'a 7th decimal below .5 rounds down to 6', dbh: 10.1234561, hom: 2.7654321, expectedDBH: 10.123456, expectedHOM: 2.765432 },
+      { name: 'a 7th decimal above .5 rounds up to 6', dbh: 10.1234568, hom: 2.7654329, expectedDBH: 10.123457, expectedHOM: 2.765433 },
+      {
+        name: 'maximum in-range precision (6 integer + 6 decimal digits) is stored',
+        dbh: 999999.999999,
+        hom: 500000.123456,
+        expectedDBH: 999999.999999,
+        expectedHOM: 500000.123456
+      }
+    ] as const;
+
+    it.each(PRECISION_CASES)('$name', async ({ dbh, hom, expectedDBH, expectedHOM }) => {
+      const censusID = testData.census[0].censusID;
+      const row: ScenarioMeasurement = {
+        treeTag: 'PRECISION_A',
+        stemTag: '1',
+        speciesCode: testData.species[0].SpeciesCode,
+        quadratName: testData.quadrats[0].QuadratName,
+        x: 1,
+        y: 1,
+        dbh,
+        hom,
+        date: MEASUREMENT_DATE
+      };
+      const { scope, result } = await ingestScenarioRows(connection, testData, [row]);
+
+      // The over-precise row must ingest as a normal success — never a failure or missing row.
+      const outcome = await readIngestionOutcome(connection, scope);
+      assertOutcome(
+        outcome,
+        {
+          sourceRecords: 1,
+          successfulRows: 1,
+          failedRows: 0,
+          remainingTemporaryRows: 0,
+          metricProcessedRecords: 1,
+          metricFailedRecords: 0,
+          metricMissingRecords: 0,
+          errorCodes: [],
+          alertTypes: []
+        },
+        result,
+        1
+      );
+
+      const [storedRows] = await connection.query<RowDataPacket[]>(
+        `SELECT MeasuredDBH, MeasuredHOM
+         FROM coremeasurements
+         WHERE CensusID = ? AND UploadFileID = ? AND StemGUID IS NOT NULL`,
+        [censusID, scope.fileID]
+      );
+      expect(storedRows, 'exactly one successful measurement materialized').toHaveLength(1);
+      expect(Number(storedRows[0].MeasuredDBH), `DBH ${dbh} rounds to the stored ${expectedDBH}`).toBe(expectedDBH);
+      expect(Number(storedRows[0].MeasuredHOM), `HOM ${hom} rounds to the stored ${expectedHOM}`).toBe(expectedHOM);
+    });
+  });
+
   describe('Multi-stem cardinality', () => {
     // The 5-stem case is required in the matrix: a tree with N distinct stem tags must
     // materialize exactly N stem rows (one tree, N stems, N measurements).


### PR DESCRIPTION
## Summary

Acts on the maintainer's 2026-07-20 decisions on the previously-blocked Task 10 follow-ups.

- **10A (ratified — round quietly):** new table-driven block in `ingestion-invariants.integration.test.ts` pinning that an over-precise DBH/HOM is rounded to 6 decimals and ingested as a normal success (exactly-6, 7th-digit up/down, max-in-range), asserting both the outcome and the stored value. Recorded as contract #7 in `docs/testing/regression-contracts.md`.
- **10B (ratified — SSO acceptable; harden anyway):** cross-site login accepted as expected SSO (browser cookie-bleed ruled out); added dev `AUTH_SECRET` rotation steps to the auth runbook so the softer environment can't mint prod-valid sessions. Rotation itself is an operator action.
- **10C (ratified interim — IMPLEMENTED; changes production publish gating):** this PR does not just document the warn-vs-blocking split, it ships it. `checkFinishedCensus` failures are now partitioned in `lib/ctfs-export/precondition.ts`:
  - **Data-quality kinds** (`not-validated`, `unresolved-error`, `no-stem-guid`, `inactive-join`) no longer block: a real publish that previously 400'd on any of them now **proceeds with a 200** and surfaces them in the `X-CTFS-Precondition-Warnings` header. These describe rows the export already excludes, so nothing the artifact would have carried is dropped.
  - **Destination-integrity kinds** (`unknown-attribute-code`, `missing-taxonomy-fields`, `string-too-long`, `zero-exportable-rows`) still block a real publish with a 400 — each would produce an artifact that fails to load into, or silently truncates data in, the on-prem CTFS MySQL. Do not reclassify these to warnings to unstick a publish.
  - The zero-exportable-rows gate now runs even when only warnings are present, so a warn-only census (e.g. every row unvalidated) cannot slip through as an empty publish. Dry-run behavior is unchanged: nothing blocks, everything previews as warnings. Unknown future precondition kinds default to blocking.
  - Recorded as contract #8; the full validation-tier feature (authorized + audited operator override, enforced server-side) remains deferred and is tracked as a TODO in `precondition.ts`.

Local: precision block + full ingestion-invariants file green (25 tests); build:check clean.
