### PR TITLE
fix(ingestion): mysql2 placeholder misfill in dropped-row + quadrat-guard queries; task10a review follow-ups

### DIFF
--- a/docs/auth-environment-variables-runbook.md
+++ b/docs/auth-environment-variables-runbook.md
@@ -193,7 +193,14 @@ site. Rotating dev's secret to a distinct value closes that.
 First, confirm whether they are actually shared (optional but informative): copy a live
 `__Secure-authjs.session-token` cookie value and replay it against dev —
 `curl -s https://forestgeo-development.azurewebsites.net/api/auth/session -H "Cookie: __Secure-authjs.session-token=<live-value>"`.
-A session JSON back = shared secret (rotate); `null` = already distinct (done).
+A session JSON back = shared secret (rotate); `null` = already distinct (done). The token
+is the raw cookie value only — do not include the surrounding braces some cookie inspectors
+display, or the token reads as malformed and dev returns a misleading `null`.
+
+**Verified 2026-07-21:** replaying a live production JWE against dev returned `null` — dev
+rejects a prod-minted token, so the two environments already use distinct `AUTH_SECRET`
+values. No rotation is required at this time; the steps below are retained for future use
+(e.g. if the environments are ever re-provisioned from a shared secret).
 
 To rotate (operator action — engineering cannot change Azure/GitHub secrets):
 1. Generate a new value: `openssl rand -base64 33`.

--- a/docs/testing/regression-contracts.md
+++ b/docs/testing/regression-contracts.md
@@ -125,13 +125,6 @@ are a separate validation concern (`NEGATIVE_DBH`/`NEGATIVE_HOM`), not covered h
 Enforced by: `tests/integration/ingestion-invariants.integration.test.ts` → "DBH/HOM
 precision" block.
 
-## Explicitly NOT yet contracted (blocked)
-
-- **Cross-site authentication cookie behavior**: the observed cross-site login is
-  **ratified as expected/acceptable** single sign-on (2026-07-20) — browser cookie-bleed
-  was ruled out (host-only cookies + `azurewebsites.net` Public Suffix). Separately, dev's
-  `AUTH_SECRET` is being rotated to differ from production as hardening (operator action;
-  see `docs/auth-environment-variables-runbook.md`).
 ### 8. CTFS publish gate warns on data-quality, blocks on destination-integrity
 
 **Ratified 2026-07-20 (interim of the full validation-tier feature).** "Publish census"
@@ -156,3 +149,18 @@ bypass) remains a TODO in `lib/ctfs-export/precondition.ts`.
 Enforced by: `lib/ctfs-export/precondition.test.ts` (classification + warning-plus-zero-
 rows interaction) and the CTFS export route test (`app/api/export/ctfs-sql/.../route.test.ts`:
 quality warning → 200 + header; blocker → 400 with only blocking reasons).
+
+## Explicitly NOT yet contracted (blocked)
+
+- **Full publish validation-tier feature**: an authorized, audited operator override that
+  can consciously publish past a destination-integrity blocker, enforced server-side so
+  stale UI cannot bypass it. Contract 8 is the ratified interim; the override remains a
+  TODO in `lib/ctfs-export/precondition.ts` and gets its own contract when built.
+
+## Resolved without a contract
+
+- **Cross-site authentication cookie behavior**: the observed cross-site login is
+  **ratified as expected/acceptable** single sign-on (2026-07-20) — browser cookie-bleed
+  was ruled out (host-only cookies + `azurewebsites.net` Public Suffix). No regression
+  contract needed. Separately, dev's `AUTH_SECRET` is being rotated to differ from
+  production as hardening (operator action; see `docs/auth-environment-variables-runbook.md`).

--- a/docs/testing/regression-contracts.md
+++ b/docs/testing/regression-contracts.md
@@ -122,6 +122,21 @@ column); if provenance is needed later, that is a separate, larger change (Optio
 Note this contract is about *precision only*. Negative and out-of-range (≥ 1 km) values
 are a separate validation concern (`NEGATIVE_DBH`/`NEGATIVE_HOM`), not covered here.
 
+Two consequences of rounding at the 6-decimal boundary:
+
+- **Dedup collapse.** The `coremeasurements` uniqueness key includes `MeasuredDBH` and
+  `MeasuredHOM`, so two rows that differ only past the 6th decimal round to identical
+  values and collapse to one measurement. This is intended (sub-6-decimal difference is
+  below meaningful resolution), but it means such near-duplicates are silently deduped
+  rather than both stored.
+- **Downstream `viewfulltable` is narrower.** `coremeasurements.MeasuredDBH/MeasuredHOM`
+  are `DECIMAL(12,6)`, but `viewfulltable.MeasuredDBH/MeasuredHOM` are `DECIMAL(10,6)`
+  (max `9999.999999`). The max-in-range case this contract blesses (`999999.999999`) is
+  storable in `coremeasurements` but exceeds the view column, so a `viewfulltable` rebuild
+  carrying it would error under strict `sql_mode` or truncate otherwise. The precision
+  contract stops at `coremeasurements`; reconciling the two column widths is a separate,
+  untracked follow-up.
+
 Enforced by: `tests/integration/ingestion-invariants.integration.test.ts` → "DBH/HOM
 precision" block.
 

--- a/docs/testing/regression-contracts.md
+++ b/docs/testing/regression-contracts.md
@@ -177,5 +177,7 @@ quality warning → 200 + header; blocker → 400 with only blocking reasons).
 - **Cross-site authentication cookie behavior**: the observed cross-site login is
   **ratified as expected/acceptable** single sign-on (2026-07-20) — browser cookie-bleed
   was ruled out (host-only cookies + `azurewebsites.net` Public Suffix). No regression
-  contract needed. Separately, dev's `AUTH_SECRET` is being rotated to differ from
-  production as hardening (operator action; see `docs/auth-environment-variables-runbook.md`).
+  contract needed. Separately, the suspected shared `AUTH_SECRET` was **ruled out on
+  2026-07-21**: replaying a live production session token against dev returned `null`,
+  so dev and production already use distinct secrets and no rotation is required
+  (see `docs/auth-environment-variables-runbook.md`).

--- a/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.test.ts
+++ b/frontend/app/api/export/ctfs-sql/[schema]/[plotID]/[censusID]/route.test.ts
@@ -377,6 +377,7 @@ describe('GET /api/export/ctfs-sql/:schema/:plotID/:censusID', () => {
     const body = await res.json();
     expect(body.reasons).toEqual([blocker]);
     expect(mocks.renderArtifact).not.toHaveBeenCalled();
+    expect(mocks.connRelease).toHaveBeenCalledTimes(1);
   });
 
   it('returns 200 with a dry-run artifact + warning header when preconditions fail in dry-run mode', async () => {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -50,11 +50,6 @@ vi.mock('@/auth', () => ({
   auth: authMock
 }));
 
-vi.mock('@/lib/db/sqlsecurity', () => ({
-  isValidSchema: vi.fn(() => true),
-  safeFormatQuery: vi.fn((schema: string, query: string) => query.replace(/\?\?/g, `\`${schema}\``))
-}));
-
 vi.mock('@/config/utils', async importOriginal => {
   const actual = (await importOriginal()) as object;
   return {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -85,19 +85,14 @@ vi.mock('@/ailogger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
-vi.mock('mysql2/promise', () => ({
-  format: vi.fn((sql: string, params: any[]) => {
-    let result = sql;
-    params.forEach(param => {
-      if (result.includes('??')) {
-        result = result.replace('??', String(param));
-      } else if (result.includes('?')) {
-        result = result.replace('?', String(param));
-      }
-    });
-    return result;
-  })
-}));
+vi.mock('mysql2/promise', async importOriginal => {
+  const actual = (await importOriginal()) as typeof import('mysql2/promise');
+  // Use the REAL format(): it fills ?? and ? strictly left-to-right, each
+  // placeholder consuming the next param regardless of type. An earlier
+  // hand-rolled mock filled all ?? before any ?, which masked a production
+  // placeholder-misfill bug in queries mixing ?? and ?. Do not re-fake this.
+  return { format: actual.format };
+});
 
 /** Number of columns in the temporarymeasurements INSERT (FileID through PublishedStemID) */
 const TEMP_MEASUREMENT_COLUMNS_PER_ROW = 18;
@@ -244,7 +239,7 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(body.insertedCount).toBe(1);
 
     const insertCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCall[1].slice(0, 6)).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_SESSION_ID, 'csv', TEST_PLOT_ID, TEST_CENSUS_ID]);
   });
@@ -293,7 +288,7 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(body.insertedCount).toBe(1);
 
     const insertCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCall).toBeDefined();
     expect(insertCall[1].slice(0, 6)).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_SESSION_ID, 'csv', TEST_PLOT_ID, TEST_CENSUS_ID]);
@@ -356,7 +351,7 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(body.insertedCount).toBe(1001);
 
     const insertCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCalls).toHaveLength(2);
     expect(insertCalls[0][1]).toHaveLength(TEMP_MEASUREMENT_INSERT_BATCH_SIZE * TEMP_MEASUREMENT_COLUMNS_PER_ROW);
@@ -381,7 +376,7 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(res.status).toBe(200);
 
     const cleanupCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.temporarymeasurements')
     );
     expect(cleanupCall).toBeDefined();
     expect(cleanupCall[1]).toEqual([TEST_FILE_NAME, TEST_PLOT_ID, TEST_CENSUS_ID, TEST_BATCH_ID]);
@@ -426,21 +421,21 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(mockConnectionManager.commitTransaction).toHaveBeenCalledWith('tx-test');
 
     const findOldBatchesCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('SELECT batchID FROM forestgeo_testing.uploadmetrics')
+      String(call[0]).includes('SELECT batchID FROM `forestgeo_testing`.uploadmetrics')
     );
     expect(findOldBatchesCall).toBeDefined();
     expect(String(findOldBatchesCall?.[0])).toContain('WHERE plotID = ? AND censusID = ? AND batchID <> ?');
     expect(String(findOldBatchesCall?.[0])).not.toContain('fileID = ?');
 
     const deleteValidationErrorsCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE mel FROM forestgeo_testing.measurement_error_log')
+      String(call[0]).includes('DELETE mel FROM `forestgeo_testing`.measurement_error_log')
     );
     expect(deleteValidationErrorsCall).toBeDefined();
     expect(String(deleteValidationErrorsCall?.[0])).toContain('WHERE cm.CensusID = ? AND cm.UploadBatchID IN');
     expect(String(deleteValidationErrorsCall?.[0])).not.toContain('cm.UploadFileID');
 
     const deleteCmCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.coremeasurements')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.coremeasurements')
     );
     expect(deleteCmCall).toBeDefined();
     expect(String(deleteCmCall?.[0])).toContain('WHERE CensusID = ? AND UploadBatchID IN');
@@ -448,7 +443,7 @@ describe('sqlpacketload measurement scope validation', () => {
 
     const deleteFailedCall = mockConnectionManager.executeQuery.mock.calls.find(
       (call: any[]) =>
-        String(call[0]).includes('DELETE FROM forestgeo_testing.failedmeasurements') &&
+        String(call[0]).includes('DELETE FROM `forestgeo_testing`.failedmeasurements') &&
         String(call[0]).includes('WHERE CensusID = ?') &&
         String(call[0]).includes('BatchID IN')
     );
@@ -476,12 +471,12 @@ describe('sqlpacketload measurement scope validation', () => {
     });
 
     const cleanupCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.coremeasurements')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.coremeasurements')
     );
     expect(cleanupCall).toBeUndefined();
 
     const staleBatchCleanupCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.temporarymeasurements')
     );
     expect(staleBatchCleanupCall).toBeDefined();
   });
@@ -517,7 +512,7 @@ describe('sqlpacketload measurement scope validation', () => {
     await expect(res.json()).resolves.toMatchObject({ insertedCount: 1 });
 
     const legacyDeleteCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE e FROM forestgeo_testing.cmverrors')
+      String(call[0]).includes('DELETE e FROM `forestgeo_testing`.cmverrors')
     );
     expect(legacyDeleteCall).toBeDefined();
   });
@@ -585,7 +580,7 @@ describe('sqlpacketload measurement scope validation', () => {
 
     const alertCall = mockConnectionManager.executeQuery.mock.calls.find(
       (call: any[]) =>
-        String(call[0]).includes('INSERT INTO forestgeo_testing.uploadintegrityalerts') &&
+        String(call[0]).includes('INSERT INTO `forestgeo_testing`.uploadintegrityalerts') &&
         String(call[0]).includes('FAILED_INSERT_TO_UNRESOLVED_COREMEASUREMENTS')
     );
 
@@ -709,11 +704,13 @@ describe('sqlpacketload fixed-data upload modes', () => {
 
     // Verify the DELETE happened before the INSERT
     const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.censusactivepersonnel')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.censusactivepersonnel')
     );
     expect(deleteCalls.length).toBeGreaterThan(0);
 
-    expect(mockConnectionManager.executeQuery.mock.calls.some((call: any[]) => String(call[0]).includes('INSERT INTO forestgeo_testing.personnel'))).toBe(true);
+    expect(mockConnectionManager.executeQuery.mock.calls.some((call: any[]) => String(call[0]).includes('INSERT INTO `forestgeo_testing`.personnel'))).toBe(
+      true
+    );
   });
 
   it('normalizes camelCase personnel roles before upserting', async () => {
@@ -797,7 +794,7 @@ describe('sqlpacketload fixed-data upload modes', () => {
     // both trees and specieslimits in the dependency SQL so this guard covers every
     // current ON DELETE CASCADE path hanging off species.
     const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.species')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.species')
     );
     expect(deleteCalls.length).toBe(0);
     expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('specieslimits');
@@ -826,6 +823,13 @@ describe('sqlpacketload fixed-data upload modes', () => {
 
     expect(res?.status).toBe(200);
     expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('specieslimits');
+    // Positive anchor for the refusal test's zero-DELETE filter above: the wipe
+    // must run here with exactly this SQL text, so a quoting change that would
+    // make the negative filter vacuous fails loudly instead.
+    const speciesDeleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.species')
+    );
+    expect(speciesDeleteCalls.length).toBe(1);
   });
 
   it('refuses quadrat clean re-upload when active quadrats are already referenced by stems', async () => {
@@ -850,7 +854,7 @@ describe('sqlpacketload fixed-data upload modes', () => {
     expect(body.error).toContain('Use Revisions Upload instead');
     expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM `forestgeo_testing`.stems');
     const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
-      String(call[0]).includes('DELETE FROM forestgeo_testing.quadrats')
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.quadrats')
     );
     expect(deleteCalls.length).toBe(0);
   });
@@ -876,6 +880,13 @@ describe('sqlpacketload fixed-data upload modes', () => {
 
     expect(res?.status).toBe(200);
     expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM `forestgeo_testing`.stems');
+    // Positive anchor for the refusal test's zero-DELETE filter above: the wipe
+    // must run here with exactly this SQL text, so a quoting change that would
+    // make the negative filter vacuous fails loudly instead.
+    const quadratDeleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.quadrats')
+    );
+    expect(quadratDeleteCalls.length).toBe(1);
   });
 
   it('allows a revisions upload to add a new quadrat to a real layout', async () => {
@@ -908,8 +919,8 @@ describe('sqlpacketload fixed-data upload modes', () => {
       updatedCount: 0,
       transactionCompleted: true
     });
-    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('SELECT QuadratName FROM forestgeo_testing.quadrats');
-    expect(String(mockConnectionManager.executeQuery.mock.calls[2]?.[0])).toContain('INSERT INTO forestgeo_testing.quadrats');
+    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('SELECT QuadratName FROM `forestgeo_testing`.quadrats');
+    expect(String(mockConnectionManager.executeQuery.mock.calls[2]?.[0])).toContain('INSERT INTO `forestgeo_testing`.quadrats');
   });
 
   it('rejects revisions when multiple active species rows already exist for one SpeciesCode', async () => {
@@ -1117,7 +1128,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     expect(body.insertedCount).toBe(1);
 
     const insertCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCall).toBeDefined();
     // The INSERT params must carry the canonical lx value (12.5) sourced from MyX, never the raw header.
@@ -1194,7 +1205,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     expect(body.failingRows[0].failureReason).toMatch(/too many columns/i);
 
     const insertCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCall).toBeDefined();
     // The leftover cell and any normalized __parsed_extra key must never reach the insert params.
@@ -1252,7 +1263,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     expect(body.failingRows).toEqual([]);
 
     const insertCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('INSERT IGNORE INTO forestgeo_testing.temporarymeasurements')
+      String(call[0]).includes('INSERT IGNORE INTO `forestgeo_testing`.temporarymeasurements')
     );
     expect(insertCall[1].slice(0, 6)).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_SESSION_ID, 'csv', TEST_PLOT_ID, TEST_CENSUS_ID]);
   });

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -51,7 +51,8 @@ vi.mock('@/auth', () => ({
 }));
 
 vi.mock('@/lib/db/sqlsecurity', () => ({
-  isValidSchema: vi.fn(() => true)
+  isValidSchema: vi.fn(() => true),
+  safeFormatQuery: vi.fn((schema: string, query: string) => query.replace(/\?\?/g, `\`${schema}\``))
 }));
 
 vi.mock('@/config/utils', async importOriginal => {
@@ -847,7 +848,7 @@ describe('sqlpacketload fixed-data upload modes', () => {
     expect(body.error).toContain('1012');
     expect(body.error).toContain('stems and downstream measurements');
     expect(body.error).toContain('Use Revisions Upload instead');
-    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM forestgeo_testing.stems');
+    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM `forestgeo_testing`.stems');
     const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
       String(call[0]).includes('DELETE FROM forestgeo_testing.quadrats')
     );
@@ -874,7 +875,7 @@ describe('sqlpacketload fixed-data upload modes', () => {
     );
 
     expect(res?.status).toBe(200);
-    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM forestgeo_testing.stems');
+    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM `forestgeo_testing`.stems');
   });
 
   it('allows a revisions upload to add a new quadrat to a real layout', async () => {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -828,7 +828,10 @@ describe('sqlpacketload fixed-data upload modes', () => {
   });
 
   it('refuses quadrat clean re-upload when active quadrats are already referenced by stems', async () => {
-    mockConnectionManager.executeQuery.mockResolvedValueOnce([{ QuadratName: '1011' }, { QuadratName: '1012' }]);
+    mockConnectionManager.executeQuery.mockResolvedValueOnce([
+      { QuadratID: 11, QuadratName: '1011' },
+      { QuadratID: 12, QuadratName: '1012' }
+    ]);
 
     const res = await POST(
       makeFixedDataRequest(
@@ -847,7 +850,39 @@ describe('sqlpacketload fixed-data upload modes', () => {
     expect(body.error).toContain('1012');
     expect(body.error).toContain('stems and downstream measurements');
     expect(body.error).toContain('Use Revisions Upload instead');
-    expect(String(mockConnectionManager.executeQuery.mock.calls[0]?.[0])).toContain('FROM `forestgeo_testing`.stems');
+    const guardSQL = String(mockConnectionManager.executeQuery.mock.calls[0]?.[0]);
+    expect(guardSQL).toContain('FROM `forestgeo_testing`.stems');
+    // Soft-deleted stems must not block the wipe; only live stems count.
+    expect(guardSQL).toContain('s.IsActive = 1');
+    // NULL-named quadrats still cascade stems away, so the guard must not
+    // exclude them at the SQL level.
+    expect(guardSQL).not.toContain('QuadratName IS NOT NULL');
+    const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
+      String(call[0]).includes('DELETE FROM `forestgeo_testing`.quadrats')
+    );
+    expect(deleteCalls.length).toBe(0);
+  });
+
+  it('refuses quadrat clean re-upload even when the blocking quadrat has a whitespace-only name', async () => {
+    // Regression: the guard previously trimmed and filtered out blank names
+    // before deciding whether to refuse, so a stem-referenced quadrat named
+    // ' ' slipped past the check and the DELETE cascade destroyed its stems.
+    mockConnectionManager.executeQuery.mockResolvedValueOnce([{ QuadratID: 42, QuadratName: '   ' }]);
+
+    const res = await POST(
+      makeFixedDataRequest(
+        'quadrats',
+        {
+          'row-1': { quadrat: '1011', startx: 0, starty: 0, dimx: 20, dimy: 20 }
+        },
+        { uploadMode: 'clean_reupload' }
+      )
+    );
+
+    expect(res?.status).toBe(503);
+    const body = await res?.json();
+    expect(body.error).toContain('Clean re-upload refused');
+    expect(body.error).toContain('(unnamed QuadratID 42)');
     const deleteCalls = mockConnectionManager.executeQuery.mock.calls.filter((call: any[]) =>
       String(call[0]).includes('DELETE FROM `forestgeo_testing`.quadrats')
     );

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -221,26 +221,35 @@ async function upsertQuadratRows(
     // safeFormatQuery fills BOTH ?? with the schema; mysql2 format() with
     // [schema, schema] would put the second schema into `q.PlotID = ?` and
     // leave the second ?? to be misfilled by plotID at execute time.
+    // Only stems with IsActive = 1 block the wipe: soft-deleted stems were
+    // already discarded by the user, so cascade-removing their tombstone rows
+    // is part of the intended reset, not a loss of live census data.
     const blockingQuadratSQL = safeFormatQuery(
       schema,
-      `SELECT DISTINCT q.QuadratName
+      `SELECT q.QuadratID, q.QuadratName
        FROM ??.quadrats q
        WHERE q.PlotID = ?
          AND q.IsActive = 1
-         AND q.QuadratName IS NOT NULL
          AND EXISTS (
            SELECT 1
            FROM ??.stems s
            WHERE s.QuadratID = q.QuadratID
+             AND s.IsActive = 1
          )
        ORDER BY q.QuadratName`
     );
     const blockingQuadratRows = await connectionManager.executeQuery(blockingQuadratSQL, [plotID], transactionID);
-    const blockingQuadratNames = Array.isArray(blockingQuadratRows)
-      ? blockingQuadratRows.map((row: any) => String(row.QuadratName ?? '').trim()).filter(Boolean)
-      : [];
+    const blockingQuadrats = Array.isArray(blockingQuadratRows) ? blockingQuadratRows : [];
 
-    if (blockingQuadratNames.length > 0) {
+    // The refusal must key off the presence of blocking rows, not the name list:
+    // a quadrat whose name is NULL or whitespace-only still cascades its stems
+    // away on DELETE, so it must block even though it has no displayable name.
+    const blockingQuadratNames = blockingQuadrats.map((row: any) => {
+      const quadratName = String(row.QuadratName ?? '').trim();
+      return quadratName || `(unnamed QuadratID ${row.QuadratID})`;
+    });
+
+    if (blockingQuadrats.length > 0) {
       throw new Error(
         `Clean re-upload refused: active quadrat rows in plot ${plotID} are already referenced ` +
           `by stems for the following QuadratName value(s): ${formatBlockedCleanReuploadValues(blockingQuadratNames)}. ` +

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -249,7 +249,7 @@ async function upsertQuadratRows(
       );
     }
 
-    const deleteSQL = format(`DELETE FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`, [schema]);
+    const deleteSQL = safeFormatQuery(schema, `DELETE FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`);
     await connectionManager.executeQuery(deleteSQL, [plotID], transactionID);
   }
 
@@ -257,7 +257,7 @@ async function upsertQuadratRows(
     // A Revisions upload updates by QuadratName and appends every non-matching row.
     // Refuse only a large, replacement-like file against the known generated Q#####
     // placeholder grid. Other non-overlapping files are valid Revisions additions.
-    const existingNamesSQL = format(`SELECT QuadratName FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1 AND QuadratName IS NOT NULL`, [schema]);
+    const existingNamesSQL = safeFormatQuery(schema, `SELECT QuadratName FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1 AND QuadratName IS NOT NULL`);
     const existingNameRows = await connectionManager.executeQuery(existingNamesSQL, [plotID], transactionID);
     const existingActiveNames = Array.isArray(existingNameRows)
       ? existingNameRows.map(existing => String((existing as { QuadratName?: unknown }).QuadratName ?? ''))
@@ -286,15 +286,18 @@ async function upsertQuadratRows(
     };
 
     if (uploadMode === UploadMode.REVISIONS) {
-      const existingSQL = format(`SELECT QuadratID FROM ??.quadrats WHERE PlotID = ? AND LOWER(QuadratName) = LOWER(?) AND IsActive = 1 LIMIT 1`, [schema]);
+      const existingSQL = safeFormatQuery(
+        schema,
+        `SELECT QuadratID FROM ??.quadrats WHERE PlotID = ? AND LOWER(QuadratName) = LOWER(?) AND IsActive = 1 LIMIT 1`
+      );
       const existingRows = await connectionManager.executeQuery(existingSQL, [plotID, quadratName], transactionID);
 
       if (existingRows.length > 0) {
-        const updateSQL = format(
+        const updateSQL = safeFormatQuery(
+          schema,
           `UPDATE ??.quadrats
            SET QuadratName = ?, StartX = ?, StartY = ?, DimensionX = ?, DimensionY = ?, Area = ?, QuadratShape = ?, DeletedAt = NULL
-           WHERE QuadratID = ?`,
-          [schema]
+           WHERE QuadratID = ?`
         );
         await connectionManager.executeQuery(
           updateSQL,
@@ -306,11 +309,11 @@ async function upsertQuadratRows(
       }
     }
 
-    const insertSQL = format(
+    const insertSQL = safeFormatQuery(
+      schema,
       `INSERT INTO ??.quadrats
        (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area, QuadratShape, IsActive, DeletedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, NULL)`,
-      [schema]
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, NULL)`
     );
     await connectionManager.executeQuery(
       insertSQL,

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -11,7 +11,7 @@ import { getCookie } from '@/app/actions/cookiemanager';
 import ailogger from '@/ailogger';
 import { auth } from '@/auth';
 import { format } from 'mysql2/promise';
-import { isValidSchema } from '@/lib/db/sqlsecurity';
+import { isValidSchema, safeFormatQuery } from '@/lib/db/sqlsecurity';
 import crypto from 'crypto';
 import { insertIngestionFailureRows } from '@/config/measurementerrors';
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState as TrackedUploadSessionState } from '@/config/uploadsessiontracker';
@@ -218,7 +218,11 @@ async function upsertQuadratRows(
     // any downstream measurements, even if the same QuadratName appears again in
     // the upload. Only allow this path when the plot has no stems attached to any
     // active quadrat rows yet.
-    const blockingQuadratSQL = format(
+    // safeFormatQuery fills BOTH ?? with the schema; mysql2 format() with
+    // [schema, schema] would put the second schema into `q.PlotID = ?` and
+    // leave the second ?? to be misfilled by plotID at execute time.
+    const blockingQuadratSQL = safeFormatQuery(
+      schema,
       `SELECT DISTINCT q.QuadratName
        FROM ??.quadrats q
        WHERE q.PlotID = ?
@@ -229,8 +233,7 @@ async function upsertQuadratRows(
            FROM ??.stems s
            WHERE s.QuadratID = q.QuadratID
          )
-       ORDER BY q.QuadratName`,
-      [schema, schema]
+       ORDER BY q.QuadratName`
     );
     const blockingQuadratRows = await connectionManager.executeQuery(blockingQuadratSQL, [plotID], transactionID);
     const blockingQuadratNames = Array.isArray(blockingQuadratRows)

--- a/frontend/lib/ingestion/temporary-measurements.test.ts
+++ b/frontend/lib/ingestion/temporary-measurements.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { isUnsignedIntFieldInvalid, MYSQL_UNSIGNED_INT_MAX, parseUnsignedIntField } from './temporary-measurements';
+import { describe, expect, it, vi } from 'vitest';
+import { findDroppedMeasurementCandidates, isUnsignedIntFieldInvalid, MYSQL_UNSIGNED_INT_MAX, parseUnsignedIntField } from './temporary-measurements';
+import type ConnectionManager from '@/lib/db/connectionmanager';
+import type { FileRow } from '@/config/macros/formdetails';
 
 describe('parseUnsignedIntField', () => {
   it('parses positive integers within the MySQL unsigned range', () => {
@@ -23,6 +25,52 @@ describe('parseUnsignedIntField', () => {
     expect(parseUnsignedIntField(-1)).toBeNull();
     expect(parseUnsignedIntField(12.3)).toBeNull();
     expect(parseUnsignedIntField(MYSQL_UNSIGNED_INT_MAX + 1)).toBeNull();
+  });
+});
+
+describe('findDroppedMeasurementCandidates placeholder alignment', () => {
+  const TEST_SCHEMA = 'forestgeo_testing';
+  const TEST_FILE_NAME = 'SERC_census1_2025.csv';
+  const TEST_BATCH_ID = 'batch-7';
+  const TEST_PLOT_ID = 22;
+  const TEST_CENSUS_ID = 32;
+  const TEST_TRANSACTION_ID = 'tx-test';
+
+  it('fills every ?? with the backticked schema and keeps value params aligned to the remaining ? slots', async () => {
+    const executeQuery = vi.fn().mockResolvedValue([]);
+    const connectionManager = { executeQuery } as unknown as ConnectionManager;
+
+    await findDroppedMeasurementCandidates(
+      connectionManager,
+      TEST_SCHEMA,
+      TEST_FILE_NAME,
+      TEST_BATCH_ID,
+      TEST_PLOT_ID,
+      TEST_CENSUS_ID,
+      [{ tag: '100001', stemtag: '1', spcode: 'FAGR', quadrat: '1011', date: '2010-03-17' }] as FileRow[],
+      TEST_TRANSACTION_ID
+    );
+
+    const droppedRowCall = executeQuery.mock.calls.find(call => String(call[0]).includes('MIN(dup.BatchID)'));
+    expect(droppedRowCall, 'dropped-row audit query was never executed').toBeDefined();
+    const [sql, params] = droppedRowCall!;
+
+    // Regression guard for the mysql2 format() misfill this query shipped with:
+    // format(sql, [schema, schema]) fills placeholders strictly in order, so the
+    // second schema landed in the `tm.FileID = ?` value slot and the second ??
+    // was later misfilled by a value param and treated as a database name.
+    // safeFormatQuery must consume EVERY ?? so executeQuery sees only value slots.
+    expect(sql).not.toContain('??');
+    expect(String(sql).match(/`forestgeo_testing`\.temporarymeasurements/g)).toHaveLength(2);
+
+    expect(String(sql).match(/\?/g)).toHaveLength(params.length);
+    expect(params).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_FILE_NAME, TEST_PLOT_ID, TEST_CENSUS_ID]);
+    expect(params).not.toContain(TEST_SCHEMA);
+
+    const slotOrder = ['tm.FileID = ?', 'tm.BatchID = ?', 'dup.FileID = ?', 'dup.PlotID = ?', 'dup.CensusID = ?'];
+    const slotPositions = slotOrder.map(slot => String(sql).indexOf(slot));
+    slotPositions.forEach((position, index) => expect(position, `missing value slot ${slotOrder[index]}`).toBeGreaterThan(-1));
+    expect(slotPositions, 'value slots appear in a different order than the params array').toEqual([...slotPositions].sort((a, b) => a - b));
   });
 });
 

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -1,5 +1,6 @@
 import { format } from 'mysql2/promise';
 import moment from 'moment/moment';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
 import { FileRow, SourceFormat } from '@/config/macros/formdetails';
@@ -382,7 +383,14 @@ export async function findDroppedMeasurementCandidates(
       );
     }
 
-    const droppedRowsSQL = format(
+    // safeFormatQuery substitutes EVERY ?? with the validated schema, leaving
+    // the value `?` placeholders for executeQuery. Do NOT use mysql2 format()
+    // with [schema, schema] here: format fills placeholders strictly in order,
+    // so the second array value lands in `tm.FileID = ?` and the second ??
+    // never gets the schema (it would be filled by a value param at execute
+    // time and treated as a database name).
+    const droppedRowsSQL = safeFormatQuery(
+      schema,
       `SELECT drc.RowOrdinal as rowOrdinal,
               MIN(dup.BatchID) as existingBatch
        FROM ${tempTable} drc
@@ -403,8 +411,7 @@ export async function findDroppedMeasurementCandidates(
         AND dup.QuadratName <=> drc.QuadratName
        WHERE tm.id IS NULL
        GROUP BY drc.RowOrdinal
-       ORDER BY drc.RowOrdinal`,
-      [schema, schema]
+       ORDER BY drc.RowOrdinal`
     );
 
     const results = await connectionManager.executeQuery(droppedRowsSQL, [fileName, batchID, fileName, plotID, censusID], transactionID);


### PR DESCRIPTION
Two concerns, both small and verified:

**mysql2 `format()` placeholder misfill (live production bug).** `format(sql, [schema, schema])` on SQL with a value `?` between the two `??`s fills placeholders in strict order, so the second schema lands in a value slot and everything after misaligns. Two live sites: `findDroppedMeasurementCandidates` (`lib/ingestion/temporary-measurements.ts`) — dropped-measurement detection for `sqlpacketload` and the ArcGIS commit — and the CLEAN_REUPLOAD quadrat dependency guard in `sqlpacketload`, whose `q.PlotID = ?` received the schema name, disabling the guard. Both now use `safeFormatQuery`, which substitutes every `??` with the validated schema and leaves value placeholders for `executeQuery`. Originally found and fixed on `codex/async-upload-processing` (`4ecef8da`); adapted to the post-reorg import paths, with the route test's sqlsecurity mock extended to mirror the real `safeFormatQuery`.

**Task 10A/10C review follow-ups** (from `feat/task10a-precision-contract`, post-#359):
- contract #8 un-nested from the blocked section; resolved-vs-blocked split
- runbook note recording the 2026-07-21 AUTH_SECRET replay check (dev/prod already distinct) + the braces gotcha
- `connRelease` assertion on the blocking test + contract-#7 dedup/viewfulltable notes

**Quadrat clean-reupload guard hardening** (from the branch code review): the guard's refusal now keys off the presence of blocking rows rather than the post-trim name list, so NULL- or whitespace-named quadrats with live stems still block the wipe (rendered as `(unnamed QuadratID N)` in the error), and the stems `EXISTS` predicate now requires `s.IsActive = 1` so soft-deleted stems no longer block a clean re-upload. Both paths only became reachable once the misfill fix above made the guard query actually execute.
