### PR TITLE
Simplify quadrat upload boundary and acknowledgment provenance

### DIFF
--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -1214,14 +1214,24 @@ describe('sqlpacketload fixed-data upload modes', () => {
     expect(res?.status).toBe(200);
     await expect(res?.json()).resolves.toMatchObject({ insertedCount: 2 });
 
-    const changelogInsertCall = mockConnectionManager.executeQuery.mock.calls.find(
-      (call: any[]) => String(call[0]).includes('unifiedchangelog') && String(call[0]).includes('INSERT INTO')
+    const fileUploadInsertCall = mockConnectionManager.executeQuery.mock.calls.find(
+      (call: any[]) => String(call[0]).includes('unifiedchangelog') && call[1]?.[0] === 'file_upload'
     );
-    expect(changelogInsertCall, 'the file_upload changelog entry must have been written').toBeDefined();
-    const storedMetadata = JSON.parse(changelogInsertCall![1][3]);
-    expect(storedMetadata.overlapAcknowledgment.statement).toBe(QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT);
-    expect(storedMetadata.overlapAcknowledgment.summaries[0].pairs.some((pair: { message: string }) => pair.message.includes('overlaps'))).toBe(true);
-    expect(storedMetadata.overlapAcknowledgment.acknowledgedBy).toBe('user-1');
+    expect(fileUploadInsertCall, 'the file_upload changelog entry must have been written').toBeDefined();
+    expect(JSON.parse(fileUploadInsertCall![1][3])).not.toHaveProperty('overlapAcknowledgment');
+
+    const acknowledgmentInsertCall = mockConnectionManager.executeQuery.mock.calls.find(
+      (call: any[]) => String(call[0]).includes('unifiedchangelog') && call[1]?.[0] === 'quadrat_overlap_acknowledgment'
+    );
+    expect(acknowledgmentInsertCall, 'the immutable acknowledgment event must have been written').toBeDefined();
+    expect(String(acknowledgmentInsertCall![0])).toContain('WHERE NOT EXISTS');
+    expect(acknowledgmentInsertCall![1][1]).toMatch(/^[a-f0-9]{40}$/);
+    expect(acknowledgmentInsertCall![1][1]).toBe(acknowledgmentInsertCall![1][6]);
+    const storedEvent = JSON.parse(acknowledgmentInsertCall![1][2]);
+    expect(storedEvent.statement).toBe(QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT);
+    expect(storedEvent.summaries[0].pairs.some((pair: { message: string }) => pair.message.includes('overlaps'))).toBe(true);
+    expect(storedEvent.acknowledgedBy).toBe('user-1');
+    expect(storedEvent.uploadSessionId).toBe(TEST_SESSION_ID);
   });
 
   it('does not treat a coerced false value as an overlap acknowledgment', async () => {
@@ -1287,7 +1297,8 @@ describe('sqlpacketload fixed-data upload modes', () => {
       .mockResolvedValueOnce({ insertId: 1 })
       .mockResolvedValueOnce({ insertId: 2 })
       .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error('changelog unavailable'));
+      .mockResolvedValueOnce({ insertId: 3 })
+      .mockRejectedValueOnce(new Error('acknowledgment changelog unavailable'));
 
     const res = await POST(
       makeFixedDataRequest(
@@ -1389,8 +1400,6 @@ describe('sqlpacketload fixed-data upload modes', () => {
   it('rejects a quadrat upload whose rows are ALL blank padding before deleting anything', async () => {
     // Falling through with zero usable rows would validate an empty layout and then, in
     // CLEAN_REUPLOAD, wipe the plot's quadrats without inserting anything.
-    mockConnectionManager.executeQuery.mockResolvedValueOnce([{ DimensionX: 500, DimensionY: 500 }]);
-
     const res = await POST(
       makeFixedDataRequest('quadrats', { 'row-1': { quadrat: '', startx: '', starty: '', dimx: '', dimy: '' } }, { uploadMode: 'clean_reupload' })
     );
@@ -1399,16 +1408,12 @@ describe('sqlpacketload fixed-data upload modes', () => {
     const body = await res?.json();
     expect(body.code).toBe('INVALID_QUADRAT_GEOMETRY');
     expect(body.error).toContain('contains no usable rows (1 blank row(s) skipped)');
-    expect(mockConnectionManager.executeQuery).toHaveBeenCalledTimes(1);
+    expect(mockConnectionManager.executeQuery).not.toHaveBeenCalled();
   });
 
   it('reports every unconvertible row in a rejected quadrat upload, not just the first', async () => {
     // Two rows are bad for two DIFFERENT reasons (blank name vs. non-numeric coordinate) and
     // one row is entirely valid. A fail-fast implementation would only ever mention row 1.
-    mockConnectionManager.executeQuery
-      // authoritative plot bounds lookup
-      .mockResolvedValueOnce([{ DimensionX: 500, DimensionY: 500 }]);
-
     const res = await POST(
       makeFixedDataRequest(
         'quadrats',
@@ -1430,7 +1435,7 @@ describe('sqlpacketload fixed-data upload modes', () => {
     // The valid third row must not be reported.
     expect(body.error).not.toContain('GOOD03');
     // Nothing was ever written: the failure happens before the stem-safety check or delete.
-    expect(mockConnectionManager.executeQuery).toHaveBeenCalledTimes(1);
+    expect(mockConnectionManager.executeQuery).not.toHaveBeenCalled();
     expect(mockConnectionManager.rollbackTransaction).toHaveBeenCalledWith('tx-fixed');
   });
 

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -16,24 +16,15 @@ import crypto from 'crypto';
 import { insertIngestionFailureRows } from '@/config/measurementerrors';
 import { requireUploadSessionOwnership, UploadSessionOwnershipError, UploadSessionState as TrackedUploadSessionState } from '@/config/uploadsessiontracker';
 import { normalizeUploadMode, UploadMode } from '@/config/uploadmodes';
-import { buildDivergentQuadratUploadError, quadratRevisionAppendsDivergentSet } from '@/lib/ingestion/quadrat-upload-guards';
+import { QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT, type QuadratOverlapSummary } from '@/lib/provisioning/quadrat-collection-validation';
+import { DEFAULT_REFERENCE_CORNER } from '@/lib/provisioning/coordinate-reference-corner';
 import {
-  acknowledgmentCoversLayout,
-  QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
-  summarizeQuadratOverlaps,
-  toQuadratGeometry,
-  validateQuadratCollectionDetailed,
-  type QuadratCollectionIssue,
-  type QuadratOverlapSummary
-} from '@/lib/provisioning/quadrat-collection-validation';
-import {
-  DEFAULT_REFERENCE_CORNER,
-  isQuadratReferenceCorner,
-  normalizeToSouthwest,
-  type QuadratReferenceCorner
-} from '@/lib/provisioning/coordinate-reference-corner';
-import type { QuadratCsvRow } from '@/lib/provisioning/types';
-import { MAX_GENERATED_QUADRATS } from '@/lib/provisioning/grid-generator';
+  parseQuadratReferenceCorner,
+  QuadratGeometryValidationError,
+  QuadratOverlapAcknowledgmentRequiredError,
+  writeQuadratUpload
+} from '@/lib/ingestion/quadrat-write-boundary';
+import { QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE } from '@/lib/ingestion/quadrat-overlap-contract';
 import { FamilyResult, GenusResult } from '@/lib/db/definitions/taxonomies';
 import { RoleResult } from '@/lib/db/definitions/personnel';
 import { requireSession } from '@/lib/auth-helpers';
@@ -89,19 +80,6 @@ function toNullableNumber(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-/**
- * `FileRow` is documented as `Record<string, string | null>`, but the request body is raw
- * `JSON.parse` output that TypeScript cannot actually enforce -- a non-browser caller may send
- * a JSON number instead of a string (e.g. `startx: 0`). Stringify defensively so a well-formed
- * numeric value is parsed correctly by `toQuadratGeometry` instead of throwing a raw TypeError
- * that would surface as an infrastructure failure rather than the intended geometry validation.
- */
-function coerceGeometryField(value: unknown): string | null | undefined {
-  if (value === undefined) return undefined;
-  if (value === null) return null;
-  return String(value);
-}
-
 function toPositiveInteger(value: unknown): number | null {
   if (value === undefined || value === null || value === '') return null;
   const parsed = Number(value);
@@ -144,6 +122,55 @@ function authenticatedSessionIdentity(sessionUser: unknown): string {
   return 'authenticated-user';
 }
 
+async function insertQuadratOverlapAcknowledgmentEvent(
+  connectionManager: ConnectionManager,
+  schema: string,
+  fileName: string,
+  uploadMode: UploadMode,
+  uploadSessionId: string | null,
+  plotID: number | undefined,
+  censusID: number | undefined,
+  sessionUser: unknown,
+  summaries: QuadratOverlapSummary[],
+  transactionID: string
+): Promise<void> {
+  const changedBy = authenticatedSessionIdentity(sessionUser);
+  const layoutSignatures = summaries.map(summary => summary.layoutSignature).sort();
+  const recordID = crypto
+    .createHash('sha256')
+    .update([schema, plotID ?? '', censusID ?? '', fileName, uploadSessionId ?? '', ...layoutSignatures].join('#'))
+    .digest('hex')
+    .slice(0, 40);
+  const eventState = JSON.stringify({
+    statement: QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
+    acknowledgedBy: changedBy,
+    fileName,
+    uploadMode,
+    uploadSessionId,
+    summaries
+  });
+  // Keep acknowledgment provenance immutable and avoid the file_upload JSON merge entirely.
+  // The deterministic RecordID makes a retry of the same upload event idempotent.
+  const insertSQL = safeFormatQuery(
+    schema,
+    `INSERT INTO ??.unifiedchangelog
+       (TableName, RecordID, Operation, NewRowState, ChangeTimestamp, ChangedBy, PlotID, CensusID)
+     SELECT ?, ?, 'INSERT', ?, NOW(), ?, ?, ?
+     WHERE NOT EXISTS (
+       SELECT 1
+       FROM ??.unifiedchangelog
+       WHERE TableName = 'quadrat_overlap_acknowledgment'
+         AND RecordID = ?
+         AND Operation = 'INSERT'
+     )`
+  );
+  await connectionManager.executeQuery(
+    insertSQL,
+    ['quadrat_overlap_acknowledgment', recordID, eventState, changedBy, plotID, censusID, recordID],
+    transactionID
+  );
+}
+
 function normalizeRequiredString(value: unknown): string {
   return String(value ?? '').trim();
 }
@@ -184,53 +211,8 @@ function formatBlockedCleanReuploadValues(values: string[], maxValues: number = 
   return truncateAndJoin(uniqueValues, ', ', maxValues);
 }
 
-/**
- * Thrown when a quadrat upload's declared geometry is unusable (missing/blank/non-numeric
- * coordinates, an unsupported reference corner, or a layout that is out of the plot's bounds).
- * The route treats this as a client error (400), never as a
- * retryable infrastructure failure -- see the fixed-data catch block.
- */
-class QuadratGeometryValidationError extends Error {}
-
-/**
- * Overlapping quadrat footprints are field reality (surveyed widths can exceed the grid
- * pitch), not necessarily data errors — so unlike QuadratGeometryValidationError they are
- * not an outright refusal. The upload proceeds only when the request carries an explicit
- * acknowledgment that the overlaps reflect field measurements; without it, this error tells
- * the uploader exactly which pairs overlap and how to proceed.
- */
-class QuadratOverlapAcknowledgmentRequiredError extends Error {
-  constructor(
-    message: string,
-    readonly overlapSummary: QuadratOverlapSummary
-  ) {
-    super(message);
-    this.name = 'QuadratOverlapAcknowledgmentRequiredError';
-  }
-}
-const QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE = 'QUADRAT_OVERLAPS_REQUIRE_ACKNOWLEDGMENT';
-
-/** Stored quadrat rows are always canonical south-west, regardless of what the upload declared. */
-const CANONICAL_SOUTHWEST_CORNER: QuadratReferenceCorner = 'SW';
-
-function parseReferenceCorner(value: unknown): QuadratReferenceCorner {
-  if (value === undefined || value === null) return DEFAULT_REFERENCE_CORNER;
-  if (!isQuadratReferenceCorner(value)) {
-    throw new QuadratGeometryValidationError('coordinateReferenceCorner must be SW, SE, NW, or NE');
-  }
-  return value;
-}
-
 function isSupportedUploadMode(value: unknown): value is UploadMode {
   return value === UploadMode.CLEAN_REUPLOAD || value === UploadMode.REVISIONS;
-}
-
-function formatQuadratGeometryMessages(messages: string[]): string {
-  return `Quadrat geometry validation failed: ${truncateAndJoin(messages, ' ')}`;
-}
-
-function formatQuadratGeometryIssues(issues: QuadratCollectionIssue[]): string {
-  return formatQuadratGeometryMessages(issues.map(issue => issue.message));
 }
 
 async function rollbackPreservingOriginalError(connectionManager: ConnectionManager, transactionID: string, context: Record<string, unknown>): Promise<void> {
@@ -305,380 +287,6 @@ async function upsertAttributeRows(
   }
 
   return { insertedCount, updatedCount, skippedCount };
-}
-
-async function upsertQuadratRows(
-  connectionManager: ConnectionManager,
-  schema: string,
-  plotID: number | undefined,
-  rows: FileRow[],
-  uploadMode: UploadMode,
-  referenceCorner: QuadratReferenceCorner,
-  overlapAcknowledgment: unknown,
-  transactionID: string
-): Promise<FixedDataProcessingResult> {
-  if (!plotID) {
-    throw new Error('PlotID is required for quadrat uploads');
-  }
-  if (rows.length === 0) {
-    throw new QuadratGeometryValidationError('Quadrat upload must contain at least one row.');
-  }
-  if (rows.length > MAX_GENERATED_QUADRATS) {
-    throw new QuadratGeometryValidationError(`Quadrat upload contains ${rows.length} rows; maximum allowed per request is ${MAX_GENERATED_QUADRATS}.`);
-  }
-
-  let insertedCount = 0;
-  let updatedCount = 0;
-  // Only entirely-empty rows (no name AND no geometry values -- e.g. trailing padding lines
-  // in a hand-edited CSV) are skipped, and they are counted so the response accounts for
-  // every input row. A row carrying ANY data that cannot be interpreted throws instead of
-  // being silently dropped or inserted with raw, unparsed values.
-  let skippedCount = 0;
-
-  // Trust boundary: authoritative plot bounds come from the database row selected by
-  // plotID. Client-supplied plot dimensions in the request body are never consulted here,
-  // so they cannot widen what a quadrat is allowed to occupy.
-  const plotBoundsSQL = safeFormatQuery(schema, `SELECT DimensionX, DimensionY FROM ??.plots WHERE PlotID = ? LIMIT 1`);
-  const plotBoundsResult = await connectionManager.executeQuery(plotBoundsSQL, [plotID], transactionID);
-  const plotBoundsRow = Array.isArray(plotBoundsResult) ? plotBoundsResult[0] : undefined;
-  const plotDimensionX = toNullableNumber(plotBoundsRow?.DimensionX);
-  const plotDimensionY = toNullableNumber(plotBoundsRow?.DimensionY);
-
-  // Plots recorded without usable dimensions (nullable columns, and rows written before this
-  // boundary existed) must not lock their sites out of quadrat management: degrade to bounds-less
-  // validation instead of rejecting. Overlap, duplicate-name, and non-positive-dimension checks
-  // still run in full; only the plot-edge checks are skipped, and the gap is logged.
-  const plotBoundsUsable = !!plotBoundsRow && plotDimensionX !== null && plotDimensionY !== null && plotDimensionX > 0 && plotDimensionY > 0;
-  const plotBounds = plotBoundsUsable ? { dimensionX: plotDimensionX, dimensionY: plotDimensionY } : null;
-  if (!plotBounds) {
-    ailogger.warn(
-      `Plot ${plotID} has no valid DimensionX/DimensionY on record; quadrat plot-bounds checks are skipped for this upload. ` +
-        `Overlap and duplicate-name validation still applies. Record the plot dimensions to restore full validation.`
-    );
-  }
-
-  // Convert every incoming row to canonical geometry up front. A row that cannot be
-  // interpreted is a hard error: it is never filtered out and never inserted using its
-  // raw, unparsed values -- that is how rows go missing without anyone noticing.
-  //
-  // Every row is checked, not just the first bad one: a file with a systemic problem
-  // (wrong delimiter, a shifted column mapping, a whole blank column) can have hundreds
-  // of unusable rows, and reporting only row 1 forces a guess-and-check loop where the
-  // user re-uploads once per bad row. Collect every failure and throw once, capped by
-  // truncateAndJoin the same way the geometry-issue and blocked-value messages already are.
-  const rowConversionFailures: string[] = [];
-  const incomingGeometry: QuadratCsvRow[] = [];
-  rows.forEach((row, index) => {
-    const quadratName = normalizeRequiredString(row.quadrat);
-    if (!quadratName) {
-      const hasGeometryValues = [row.startx, row.starty, row.dimx, row.dimy].some(value => normalizeRequiredString(value) !== '');
-      if (!hasGeometryValues) {
-        skippedCount += 1;
-        return;
-      }
-      rowConversionFailures.push(`Quadrat upload row ${index + 1} has a missing or blank QuadratName.`);
-      return;
-    }
-
-    const geometry = toQuadratGeometry({
-      quadrat: quadratName,
-      startx: coerceGeometryField(row.startx),
-      starty: coerceGeometryField(row.starty),
-      dimx: coerceGeometryField(row.dimx),
-      dimy: coerceGeometryField(row.dimy)
-    });
-    if (!geometry) {
-      rowConversionFailures.push(
-        `Quadrat upload row ${index + 1} (QuadratName "${quadratName}") has missing, blank, or non-numeric ` +
-          `geometry (startx/starty/dimx/dimy). Fix the file and re-upload.`
-      );
-      return;
-    }
-    incomingGeometry.push(geometry);
-  });
-
-  if (rowConversionFailures.length > 0) {
-    throw new QuadratGeometryValidationError(`Quadrat upload has unusable rows: ${truncateAndJoin(rowConversionFailures, ' ')}`);
-  }
-  // A request that was all padding rows must not fall through: in CLEAN_REUPLOAD it would
-  // validate an empty layout and then wipe the plot's quadrats without inserting anything.
-  if (incomingGeometry.length === 0) {
-    throw new QuadratGeometryValidationError(`Quadrat upload contains no usable rows (${skippedCount} blank row(s) skipped).`);
-  }
-
-  const normalizedIncoming = incomingGeometry.map(row => normalizeToSouthwest(row, referenceCorner));
-
-  // Overlap policy: overlapping footprints can be genuine field measurements, so 'overlap'
-  // issues never reject outright — they require the request's explicit acknowledgment, and
-  // acknowledged pairs are returned so the caller can record them for provenance. Every
-  // other issue kind (missing/bad geometry, duplicate names, out of bounds) stays fatal.
-  const acknowledgedOverlapSummaries: QuadratOverlapSummary[] = [];
-  const requireOverlapAcknowledgment = (overlapSummary: QuadratOverlapSummary | null) => {
-    if (!overlapSummary) return;
-    if (!acknowledgmentCoversLayout(overlapAcknowledgment, overlapSummary.layoutSignature)) {
-      const pairMessages = overlapSummary.pairs.map(pair => pair.message);
-      const truncationNotice = overlapSummary.truncated
-        ? ` At least ${overlapSummary.minimumPairCount} pairs overlap; the response includes a ${overlapSummary.reportedPairCount}-pair sample.`
-        : '';
-      throw new QuadratOverlapAcknowledgmentRequiredError(
-        `Quadrat footprints overlap: ${truncateAndJoin(pairMessages, ' ')}${truncationNotice} ` +
-          `If these overlaps reflect field measurements, review and confirm the overlap acknowledgment, then re-submit.`,
-        overlapSummary
-      );
-    }
-    acknowledgedOverlapSummaries.push(overlapSummary);
-  };
-
-  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
-    // Validate the incoming layout BEFORE the stem-safety check and before deleting anything.
-    // Rows are already normalized to canonical south-west above, so pass CANONICAL_SOUTHWEST_CORNER
-    // here (matching the REVISIONS branch below) rather than re-declaring referenceCorner and
-    // making validateQuadratCollection normalize the same rows a second time internally.
-    const cleanValidation = validateQuadratCollectionDetailed(normalizedIncoming, plotBounds, CANONICAL_SOUTHWEST_CORNER);
-    const cleanReuploadIssues = cleanValidation.issues;
-    const cleanFatalIssues = cleanReuploadIssues.filter(issue => issue.kind !== 'overlap');
-    if (cleanFatalIssues.length > 0) {
-      throw new QuadratGeometryValidationError(formatQuadratGeometryIssues(cleanFatalIssues));
-    }
-    requireOverlapAcknowledgment(cleanValidation.overlapSummary);
-
-    // CLEAN_REUPLOAD deletes every active quadrat in the plot before re-inserting
-    // the upload contents. Because stems references quadrats via ON DELETE CASCADE,
-    // removing a quadrat that is already in use would also destroy its stems and
-    // any downstream measurements, even if the same QuadratName appears again in
-    // the upload. Only allow this path when the plot has no stems attached to any
-    // active quadrat rows yet.
-    // safeFormatQuery fills BOTH ?? with the schema; mysql2 format() with
-    // [schema, schema] would put the second schema into `q.PlotID = ?` and
-    // leave the second ?? to be misfilled by plotID at execute time.
-    // Only stems with IsActive = 1 block the wipe: soft-deleted stems were
-    // already discarded by the user, so cascade-removing their tombstone rows
-    // is part of the intended reset, not a loss of live census data.
-    const blockingQuadratSQL = safeFormatQuery(
-      schema,
-      `SELECT q.QuadratID, q.QuadratName
-       FROM ??.quadrats q
-       WHERE q.PlotID = ?
-         AND q.IsActive = 1
-         AND EXISTS (
-           SELECT 1
-           FROM ??.stems s
-           WHERE s.QuadratID = q.QuadratID
-             AND s.IsActive = 1
-         )
-       ORDER BY q.QuadratName`
-    );
-    const blockingQuadratRows = await connectionManager.executeQuery(blockingQuadratSQL, [plotID], transactionID);
-    const blockingQuadrats = Array.isArray(blockingQuadratRows) ? blockingQuadratRows : [];
-
-    // The refusal must key off the presence of blocking rows, not the name list:
-    // a quadrat whose name is NULL or whitespace-only still cascades its stems
-    // away on DELETE, so it must block even though it has no displayable name.
-    const blockingQuadratNames = blockingQuadrats.map((row: any) => {
-      const quadratName = String(row.QuadratName ?? '').trim();
-      return quadratName || `(unnamed QuadratID ${row.QuadratID})`;
-    });
-
-    if (blockingQuadrats.length > 0) {
-      throw new Error(
-        `Clean re-upload refused: active quadrat rows in plot ${plotID} are already referenced ` +
-          `by stems for the following QuadratName value(s): ${formatBlockedCleanReuploadValues(blockingQuadratNames)}. ` +
-          `Deleting quadrats would cascade-delete stems and downstream measurements even if the same names appear in the upload. ` +
-          `Use Revisions Upload instead.`
-      );
-    }
-
-    const deleteSQL = safeFormatQuery(schema, `DELETE FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`);
-    await connectionManager.executeQuery(deleteSQL, [plotID], transactionID);
-  }
-
-  if (uploadMode === UploadMode.REVISIONS) {
-    // A Revisions upload updates by QuadratName and appends every non-matching row, so the
-    // set that must be geometrically valid is the PROSPECTIVE FINAL LAYOUT: every existing
-    // active quadrat NOT named by this upload, plus every incoming row exactly as declared
-    // (duplicates included, so a duplicate incoming name still surfaces as a validation
-    // issue instead of being silently deduplicated before this check runs). NULL-named
-    // rows are deliberately included: an unnamed quadrat still occupies plot area, so it
-    // must participate in the overlap check even though no upload row can ever replace it.
-    const existingQuadratsSQL = safeFormatQuery(
-      schema,
-      `SELECT QuadratID, QuadratName, StartX, StartY, DimensionX, DimensionY FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`
-    );
-    const existingQuadratRows = await connectionManager.executeQuery(existingQuadratsSQL, [plotID], transactionID);
-    const existingQuadratList: any[] = Array.isArray(existingQuadratRows) ? existingQuadratRows : [];
-
-    // Divergent-placeholder guard runs FIRST: it needs only names, and its guidance message
-    // ("this plot still holds the provisioning placeholder grid, here is how to proceed") is
-    // strictly more actionable than the raw pairwise-overlap errors the geometry check would
-    // produce for the same replacement-grid upload. Running it after geometry validation made
-    // it unreachable in exactly its primary scenario, since a replacement grid always overlaps
-    // the placeholder grid it replaces.
-    const existingActiveNames = existingQuadratList.map(row => String(row.QuadratName ?? ''));
-    const incomingNames = rows.map(row => normalizeRequiredString(row.quadrat)).filter(Boolean);
-    if (quadratRevisionAppendsDivergentSet(existingActiveNames, incomingNames)) {
-      throw new Error(buildDivergentQuadratUploadError(plotID, existingActiveNames, incomingNames.length));
-    }
-
-    const incomingNamesLower = new Set(normalizedIncoming.map(row => row.quadratName.toLowerCase()));
-
-    // Build the carry-over set. Rows named by the upload are being replaced, so their stored
-    // geometry is irrelevant (and must not be parsed: rejecting a revision because the very
-    // row it repairs has malformed stored geometry would make that row permanently unfixable).
-    // A carry-over row whose stored geometry cannot be parsed -- legacy rows written before
-    // this boundary enforced geometry -- cannot participate in geometry math, so it is
-    // excluded from the prospective layout with a logged warning rather than rejecting the
-    // upload outright, which would lock the plot out of quadrat revisions entirely.
-    const carryOverExisting: QuadratCsvRow[] = [];
-    const unvalidatableExistingNames: string[] = [];
-    for (const existingRow of existingQuadratList) {
-      const storedName = String(existingRow.QuadratName ?? '').trim();
-      if (storedName && incomingNamesLower.has(storedName.toLowerCase())) continue;
-
-      // Unnamed rows get a synthetic display name: it keeps them visible in issue messages
-      // and cannot collide with incoming names, which are non-blank by this point.
-      const displayName = storedName || `(unnamed QuadratID ${existingRow.QuadratID})`;
-      // Stored rows are always canonical south-west, so toQuadratGeometry here is a pure
-      // parse -- not a re-declaration of the reference corner. coerceGeometryField is reused
-      // rather than a second near-identical coercer: it maps undefined to undefined and
-      // everything else through String(), which toQuadratGeometry treats the same as null.
-      const geometry = toQuadratGeometry({
-        quadrat: displayName,
-        startx: coerceGeometryField(existingRow.StartX),
-        starty: coerceGeometryField(existingRow.StartY),
-        dimx: coerceGeometryField(existingRow.DimensionX),
-        dimy: coerceGeometryField(existingRow.DimensionY)
-      });
-      if (!geometry) {
-        unvalidatableExistingNames.push(displayName);
-        continue;
-      }
-      carryOverExisting.push(geometry);
-    }
-    if (unvalidatableExistingNames.length > 0) {
-      ailogger.warn(
-        `Plot ${plotID} has ${unvalidatableExistingNames.length} existing active quadrat(s) with malformed stored geometry; ` +
-          `they were excluded from revision geometry validation: ${truncateAndJoin(unvalidatableExistingNames, ', ')}. ` +
-          `Re-upload those quadrats with valid geometry to restore full validation.`
-      );
-    }
-
-    const prospectiveLayout = [...carryOverExisting, ...normalizedIncoming];
-    if (prospectiveLayout.length > MAX_GENERATED_QUADRATS) {
-      throw new QuadratGeometryValidationError(
-        `Prospective quadrat layout contains ${prospectiveLayout.length} rows; maximum allowed per plot is ${MAX_GENERATED_QUADRATS}.`
-      );
-    }
-
-    // Reject only defects this upload INTRODUCES. Issues confined to carry-over rows are
-    // pre-existing database state the uploader neither caused nor can repair in this file
-    // (repairing them is itself a Revisions upload, which would re-run this same check --
-    // blocking on them would deadlock the plot). Issue rowIndexes map into prospectiveLayout,
-    // so everything at or past carryOverExisting.length was introduced by an incoming row;
-    // an incoming row overlapping a carry-over row still blocks via the incoming row's entry.
-    const incomingStartIndex = carryOverExisting.length;
-    const revisionIssues = validateQuadratCollectionDetailed(prospectiveLayout, plotBounds, CANONICAL_SOUTHWEST_CORNER).issues;
-    const preExistingIssues = revisionIssues.filter(issue => issue.rowIndex < incomingStartIndex);
-    const introducedIssues = revisionIssues.filter(issue => issue.rowIndex >= incomingStartIndex);
-    if (preExistingIssues.length > 0) {
-      ailogger.warn(
-        `Plot ${plotID} has pre-existing quadrat layout defects not caused by this upload: ` +
-          `${truncateAndJoin(
-            preExistingIssues.map(issue => issue.message),
-            ' '
-          )}`
-      );
-    }
-
-    // Supplemental cap-proof overlap sweep. validateQuadratCollection caps how many overlapping
-    // pairs it reports, and on a plot whose existing layout is saturated with overlaps (a real
-    // production case: every quadrat stacked at the same coordinates) pre-existing pairs can
-    // exhaust that cap and mask a NEW overlap this upload introduces. Only incoming-involving
-    // pairs are reportable here, so pre-existing pairs cannot crowd them out. Rows are already
-    // canonical south-west; non-positive-dimension rows are excluded from the sweep the same
-    // way the shared validator excludes them (they surface via their own dimension issue).
-    const incomingRowSet = new Set<QuadratCsvRow>(normalizedIncoming);
-    const sweepableLayout = prospectiveLayout.filter(row => row.dimensionX > 0 && row.dimensionY > 0);
-    const introducedOverlapSummary = summarizeQuadratOverlaps(sweepableLayout, (a, b) => incomingRowSet.has(a) || incomingRowSet.has(b));
-
-    const fatalIntroducedMessages = new Set<string>(introducedIssues.filter(issue => issue.kind !== 'overlap').map(issue => issue.message));
-    if (fatalIntroducedMessages.size > 0) {
-      throw new QuadratGeometryValidationError(formatQuadratGeometryMessages([...fatalIntroducedMessages]));
-    }
-
-    requireOverlapAcknowledgment(introducedOverlapSummary);
-  }
-
-  // Every incoming row was validated above (unique, in-bounds, with any overlaps explicitly
-  // acknowledged for this exact layout), so this
-  // lookup is guaranteed to hit for every row processed below.
-  const canonicalByName = new Map<string, QuadratCsvRow>();
-  for (const row of normalizedIncoming) {
-    canonicalByName.set(row.quadratName.toLowerCase(), row);
-  }
-
-  for (const row of rows) {
-    const quadratName = normalizeRequiredString(row.quadrat);
-    // Blank name here means an entirely-blank padding row: it was counted in skippedCount
-    // above (a blank name WITH data present already threw during row conversion).
-    if (!quadratName) continue;
-    const canonical = canonicalByName.get(quadratName.toLowerCase());
-    if (!canonical) {
-      throw new QuadratGeometryValidationError(`Internal error: no canonical geometry resolved for quadrat "${quadratName}".`);
-    }
-
-    const payload = {
-      StartX: canonical.startX,
-      StartY: canonical.startY,
-      DimensionX: canonical.dimensionX,
-      DimensionY: canonical.dimensionY,
-      Area: row.area,
-      QuadratShape: normalizeOptionalString(row.quadratshape)
-    };
-
-    if (uploadMode === UploadMode.REVISIONS) {
-      const existingSQL = safeFormatQuery(
-        schema,
-        `SELECT QuadratID FROM ??.quadrats WHERE PlotID = ? AND LOWER(QuadratName) = LOWER(?) AND IsActive = 1 LIMIT 1`
-      );
-      const existingRows = await connectionManager.executeQuery(existingSQL, [plotID, quadratName], transactionID);
-
-      if (existingRows.length > 0) {
-        const updateSQL = safeFormatQuery(
-          schema,
-          `UPDATE ??.quadrats
-           SET QuadratName = ?, StartX = ?, StartY = ?, DimensionX = ?, DimensionY = ?, Area = ?, QuadratShape = ?, DeletedAt = NULL
-           WHERE QuadratID = ?`
-        );
-        await connectionManager.executeQuery(
-          updateSQL,
-          [quadratName, payload.StartX, payload.StartY, payload.DimensionX, payload.DimensionY, payload.Area, payload.QuadratShape, existingRows[0].QuadratID],
-          transactionID
-        );
-        updatedCount += 1;
-        continue;
-      }
-    }
-
-    const insertSQL = safeFormatQuery(
-      schema,
-      `INSERT INTO ??.quadrats
-       (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area, QuadratShape, IsActive, DeletedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, NULL)`
-    );
-    await connectionManager.executeQuery(
-      insertSQL,
-      [plotID, quadratName, payload.StartX, payload.StartY, payload.DimensionX, payload.DimensionY, payload.Area, payload.QuadratShape],
-      transactionID
-    );
-    insertedCount += 1;
-  }
-
-  return {
-    insertedCount,
-    updatedCount,
-    skippedCount,
-    ...(acknowledgedOverlapSummaries.length > 0 ? { acknowledgedOverlapSummaries } : {})
-  };
 }
 
 async function upsertSpeciesRows(
@@ -1160,11 +768,11 @@ export async function POST(request: NextRequest) {
   const connectionManager = ConnectionManager.getInstance();
   const maxRetries = 3;
   let retryCount = 0;
+  const sessionId = request.headers.get('x-upload-session-id');
   if (formType === 'measurements') {
     let chunkRows = Object.values(fileRowSet ?? {});
     let mappingDiagnostics: { invalidDateValues: string[]; extraColumnRows: number; ignoredColumnCount: number } | null = null;
     const batchID = body.batchID || generateShortBatchID();
-    const sessionId = request.headers.get('x-upload-session-id');
     let scopeValidation: Awaited<ReturnType<typeof validateMeasurementUploadScope>>;
     try {
       scopeValidation = await validateMeasurementUploadScope(connectionManager, schema, fileName, batchID, plot, census);
@@ -1610,9 +1218,9 @@ export async function POST(request: NextRequest) {
         transactionID = await connectionManager.beginTransaction();
 
         if (formType === 'quadrats') {
-          const referenceCorner = parseReferenceCorner(body.coordinateReferenceCorner);
+          const referenceCorner = parseQuadratReferenceCorner(body.coordinateReferenceCorner);
           const overlapAcknowledgment: unknown = body.quadratOverlapAcknowledgment;
-          fixedDataProcessingResult = await upsertQuadratRows(
+          fixedDataProcessingResult = await writeQuadratUpload(
             connectionManager,
             schema,
             plot?.plotID,
@@ -1661,16 +1269,6 @@ export async function POST(request: NextRequest) {
         try {
           const batchRowCount = Object.keys(fileRowSet).length;
           const censusID = census?.dateRanges?.[0]?.censusID;
-          // Provenance for acknowledged quadrat overlaps: the fixed statement, authoritative
-          // session identity, complete layout signature, and either an exhaustive pair list or
-          // an explicitly truncated sample. This record is part of the quadrat transaction.
-          const overlapAcknowledgmentRecord = fixedDataProcessingResult.acknowledgedOverlapSummaries?.length
-            ? {
-                statement: QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
-                acknowledgedBy: authenticatedSessionIdentity(session?.user),
-                summaries: fixedDataProcessingResult.acknowledgedOverlapSummaries
-              }
-            : null;
 
           // Check if we've already logged this file upload - use format() for schema
           const existingEntrySQL = format(
@@ -1691,8 +1289,7 @@ export async function POST(request: NextRequest) {
               insertedCount: fixedDataProcessingResult.insertedCount,
               updatedCount: fixedDataProcessingResult.updatedCount,
               skippedCount: fixedDataProcessingResult.skippedCount,
-              batchCount: 1,
-              ...(overlapAcknowledgmentRecord ? { overlapAcknowledgment: overlapAcknowledgmentRecord } : {})
+              batchCount: 1
             });
             const insertChangelogSQL = format(
               `INSERT INTO ??.unifiedchangelog
@@ -1715,25 +1312,27 @@ export async function POST(request: NextRequest) {
             metadata.uploadMode = metadata.uploadMode || uploadMode;
             metadata.lastChunkMode = uploadMode;
             metadata.rowCount = (metadata.rowCount || 0) + batchRowCount;
-            if (overlapAcknowledgmentRecord) {
-              const existingSummaries = Array.isArray(metadata.overlapAcknowledgment?.summaries) ? metadata.overlapAcknowledgment.summaries : [];
-              const summariesBySignature = new Map<string, QuadratOverlapSummary>();
-              for (const summary of [...existingSummaries, ...overlapAcknowledgmentRecord.summaries]) {
-                if (summary && typeof summary.layoutSignature === 'string') {
-                  summariesBySignature.set(summary.layoutSignature, summary);
-                }
-              }
-              metadata.overlapAcknowledgment = {
-                ...overlapAcknowledgmentRecord,
-                summaries: [...summariesBySignature.values()]
-              };
-            }
             metadata.insertedCount = (metadata.insertedCount || 0) + fixedDataProcessingResult.insertedCount;
             metadata.updatedCount = (metadata.updatedCount || 0) + fixedDataProcessingResult.updatedCount;
             metadata.skippedCount = (metadata.skippedCount || 0) + fixedDataProcessingResult.skippedCount;
             metadata.batchCount = (metadata.batchCount || 1) + 1;
             const updateChangelogSQL = format(`UPDATE ??.unifiedchangelog SET NewRowState = ?, ChangeTimestamp = NOW() WHERE ChangeID = ?`, [schema]);
             await connectionManager.executeQuery(updateChangelogSQL, [JSON.stringify(metadata), existingEntry[0].ChangeID], transactionID);
+          }
+
+          if (fixedDataProcessingResult.acknowledgedOverlapSummaries?.length) {
+            await insertQuadratOverlapAcknowledgmentEvent(
+              connectionManager,
+              schema,
+              fileName,
+              uploadMode,
+              sessionId,
+              plot?.plotID,
+              censusID,
+              session?.user,
+              fixedDataProcessingResult.acknowledgedOverlapSummaries,
+              transactionID
+            );
           }
         } catch (logError: any) {
           ailogger.error('Failed to log file upload to changelog', logError);

--- a/frontend/components/provisioning/QuadratPlanner.tsx
+++ b/frontend/components/provisioning/QuadratPlanner.tsx
@@ -10,8 +10,7 @@ import {
   acknowledgmentCoversLayout,
   buildQuadratOverlapAcknowledgment,
   QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
-  validateQuadratCollectionDetailed,
-  type QuadratIssueKind
+  validateQuadratCollectionDetailed
 } from '@/lib/provisioning/quadrat-collection-validation';
 import ReferenceCornerSelect from './ReferenceCornerSelect';
 
@@ -24,7 +23,6 @@ const NAMING_PATTERN_ROW_COL = 'row-col' as const;
 interface CsvValidationIssue {
   quadratName: string;
   message: string;
-  kind: QuadratIssueKind;
 }
 
 export interface QuadratPlannerProps {
@@ -191,13 +189,14 @@ export default function QuadratPlanner({ value, onChange, plot, showErrors = fal
     if (value.mode !== 'csv' || !normalizedRows) return null;
     return validateQuadratCollectionDetailed(normalizedRows, plot, 'SW');
   }, [value.mode, normalizedRows, plot]);
-  const csvValidationIssues = useMemo<CsvValidationIssue[]>(
-    () => csvValidation?.issues.map(issue => ({ quadratName: issue.quadratName, message: issue.message, kind: issue.kind })) ?? [],
+  const csvBlockingIssues = useMemo<CsvValidationIssue[]>(
+    () => csvValidation?.fatalIssues.map(issue => ({ quadratName: issue.quadratName, message: issue.message })) ?? [],
     [csvValidation]
   );
-
-  const csvBlockingIssues = useMemo(() => csvValidationIssues.filter(issue => issue.kind !== 'overlap'), [csvValidationIssues]);
-  const csvOverlapIssues = useMemo(() => csvValidationIssues.filter(issue => issue.kind === 'overlap'), [csvValidationIssues]);
+  const csvOverlapIssues = useMemo<CsvValidationIssue[]>(
+    () => csvValidation?.overlapSummary?.pairs.map(pair => ({ quadratName: '(layout)', message: pair.message })) ?? [],
+    [csvValidation]
+  );
   const overlapAcknowledged =
     value.mode === 'csv' &&
     csvValidation?.overlapSummary !== null &&

--- a/frontend/components/uploadsystem/segments/uploadfiresql.tsx
+++ b/frontend/components/uploadsystem/segments/uploadfiresql.tsx
@@ -43,6 +43,7 @@ import { transformMeasurementValue, validateMeasurementRow } from '@/lib/column-
 import { UploadMode } from '@/config/uploadmodes';
 import { evaluateUploadReconciliation, type UploadReconciliationVerdict } from '@/lib/ingestion/reconciliation';
 import type { QuadratOverlapSummary } from '@/lib/provisioning/quadrat-collection-validation';
+import { parseQuadratOverlapSummaries } from '@/lib/ingestion/quadrat-overlap-contract';
 
 const CSV_MAPPING_REJECTION_SENTENCE: Record<CsvMappingRejectionCode, string> = {
   stale: 'the saved column mapping was built from different headers',
@@ -56,8 +57,6 @@ class UploadReconciliationError extends Error {
   }
 }
 
-const QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE = 'QUADRAT_OVERLAPS_REQUIRE_ACKNOWLEDGMENT';
-
 class QuadratOverlapAcknowledgmentRequiredClientError extends Error {
   constructor(
     message: string,
@@ -66,24 +65,6 @@ class QuadratOverlapAcknowledgmentRequiredClientError extends Error {
     super(message);
     this.name = 'QuadratOverlapAcknowledgmentRequiredClientError';
   }
-}
-
-function parseQuadratOverlapSummaries(payload: unknown): QuadratOverlapSummary[] | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const record = payload as Record<string, unknown>;
-  if (record.code !== QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE || !Array.isArray(record.overlapSummaries)) return null;
-  const summaries = record.overlapSummaries.filter((summary): summary is QuadratOverlapSummary => {
-    if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return false;
-    const candidate = summary as Record<string, unknown>;
-    return (
-      typeof candidate.layoutSignature === 'string' &&
-      typeof candidate.reportedPairCount === 'number' &&
-      typeof candidate.minimumPairCount === 'number' &&
-      typeof candidate.truncated === 'boolean' &&
-      Array.isArray(candidate.pairs)
-    );
-  });
-  return summaries.length > 0 ? summaries : null;
 }
 
 function createAbortError(message: string): Error {
@@ -204,11 +185,6 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
   const uploadRunningRef = useRef<boolean>(false);
   const batchProcessingStartedRef = useRef<boolean>(false);
   const lastPreparedUploadAttemptRef = useRef<string>('');
-  // A clean quadrat upload may span many Papa Parse chunks (and even several selected files).
-  // Only the first successfully committed chunk may perform the destructive reset; every
-  // subsequent chunk must append through revisions mode or it would delete the prior chunks.
-  const quadratCleanResetCommittedRef = useRef<boolean>(false);
-
   // Transaction-aware queue for managing concurrent operations
   const queue = useMemo(() => createTransactionAwareQueue(connectionLimit), [connectionLimit]);
 
@@ -583,8 +559,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
       fileData: FileCollectionRowSet | null,
       fileName: string,
       batchID?: string,
-      rawPayload?: { rawRows: FileRow[]; csvHeaders: string[]; mapping: ColumnMapping | null; delimiter: string },
-      effectiveUploadMode: UploadMode | undefined = uploadMode
+      rawPayload?: { rawRows: FileRow[]; csvHeaders: string[]; mapping: ColumnMapping | null; delimiter: string }
     ) => {
       if (!isMountedRef.current) {
         throw createAbortError(`Upload cancelled before starting ${fileName}`);
@@ -621,7 +596,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
                       coordinateReferenceCorner,
                       quadratOverlapAcknowledgment: uploadForm === FormType.quadrats ? quadratOverlapAcknowledgment : undefined,
                       sourceFormat: sourceFormat ?? SourceFormat.csv,
-                      uploadMode: effectiveUploadMode,
+                      uploadMode,
                       fileName,
                       plot: currentPlot,
                       census: currentCensus,
@@ -638,7 +613,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
                       coordinateReferenceCorner,
                       quadratOverlapAcknowledgment: uploadForm === FormType.quadrats ? quadratOverlapAcknowledgment : undefined,
                       sourceFormat: sourceFormat ?? SourceFormat.csv,
-                      uploadMode: effectiveUploadMode,
+                      uploadMode,
                       fileName,
                       plot: currentPlot,
                       census: currentCensus,
@@ -1130,25 +1105,13 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
                   }
 
                   try {
-                    const requestedUploadMode = uploadMode ?? UploadMode.CLEAN_REUPLOAD;
-                    const chunkUploadMode =
-                      uploadForm === FormType.quadrats && requestedUploadMode === UploadMode.CLEAN_REUPLOAD && quadratCleanResetCommittedRef.current
-                        ? UploadMode.REVISIONS
-                        : requestedUploadMode;
-
                     if (serverResolves) {
-                      const data = await uploadToSql(
-                        null,
-                        file.name,
-                        fileBatchID,
-                        {
-                          rawRows: rawChunkRows,
-                          csvHeaders: serverCsvHeaders,
-                          mapping: columnMappings?.[file.name] ?? null,
-                          delimiter
-                        },
-                        chunkUploadMode
-                      );
+                      const data = await uploadToSql(null, file.name, fileBatchID, {
+                        rawRows: rawChunkRows,
+                        csvHeaders: serverCsvHeaders,
+                        mapping: columnMappings?.[file.name] ?? null,
+                        delimiter
+                      });
                       if (data?.failingRows?.length) {
                         serverFailingRowsCount += data.failingRows.length;
                         await pushErrorRowsToFailedMeasurements(data.failingRows, file.name);
@@ -1159,11 +1122,7 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
                         setMappingWarnings(prev => (prev.includes(warning) ? prev : [...prev, warning]));
                       }
                     } else {
-                      await uploadToSql(fileCollectionRowSet, file.name, fileBatchID, undefined, chunkUploadMode);
-                    }
-
-                    if (uploadForm === FormType.quadrats && chunkUploadMode === UploadMode.CLEAN_REUPLOAD) {
-                      quadratCleanResetCommittedRef.current = true;
+                      await uploadToSql(fileCollectionRowSet, file.name, fileBatchID);
                     }
                   } catch (error: unknown) {
                     const errorObj = error instanceof Error ? error : new Error(String(error));
@@ -1403,8 +1362,6 @@ const UploadFireSQL: React.FC<UploadFireProps> = ({
         expectedTemporaryRowCounts.current.clear();
         persistedRejectedRowCounts.current.clear();
         serverAccountedRejectedRowCounts.current.clear();
-        quadratCleanResetCommittedRef.current = false;
-
         if (fatalUploadErrorRef.current) {
           throw fatalUploadErrorRef.current;
         }

--- a/frontend/components/uploadsystem/segments/uploadparsefiles.quadrats.test.tsx
+++ b/frontend/components/uploadsystem/segments/uploadparsefiles.quadrats.test.tsx
@@ -12,6 +12,7 @@ import { FormType, SourceFormat } from '@/config/macros/formdetails';
 import { UploadMode } from '@/config/uploadmodes';
 import { FileWithStream, type UploadParseFilesProps } from '@/config/macros/uploadsystemmacros';
 import { DEFAULT_REFERENCE_CORNER } from '@/lib/provisioning/coordinate-reference-corner';
+import { MAX_GENERATED_QUADRATS } from '@/lib/provisioning/grid-generator';
 import type { QuadratOverlapAcknowledgment, QuadratReferenceCorner } from '@/lib/provisioning/types';
 import UploadParseFiles, { parseQuadratFileRows } from './uploadparsefiles';
 
@@ -59,7 +60,9 @@ vi.mock('@/components/uploadsystemhelpers/filelistenhanced', async () => {
 });
 
 vi.mock('@/components/uploadsystemhelpers/dropzonecompact', () => ({
-  DropzoneCompact: () => null
+  DropzoneCompact: ({ allowMultipleFiles }: { allowMultipleFiles?: boolean }) => (
+    <div data-testid="dropzone-file-mode">{allowMultipleFiles === false ? 'single' : 'multiple'}</div>
+  )
 }));
 
 const QUADRAT_HEADER_ROW = 'quadrat,startx,starty,dimx,dimy,area,quadratshape';
@@ -233,15 +236,9 @@ describe('quadrat geometry preflight — overlap acknowledgment', () => {
     expect(screen.queryByRole('checkbox', { name: /acknowledge quadrat overlaps/i })).toBeNull();
   });
 
-  it('detects overlaps spanning separate files before upload begins', async () => {
-    const first = buildQuadratFile('quadrats-a.csv', 'A,10,10,20,20,400,square');
-    const second = buildQuadratFile('quadrats-b.csv', 'B,20,20,20,20,400,square');
-
-    render(<Harness uploadForm={FormType.quadrats} acceptedFiles={[first, second]} selectedDelimiters={{ 'quadrats-a.csv': ',', 'quadrats-b.csv': ',' }} />);
-
-    await waitFor(() => expect(screen.getByText(/overlapping quadrat footprints detected/i)).toBeInTheDocument());
-    expect(screen.getByText(/Quadrat "A" overlaps quadrat "B"/i)).toBeInTheDocument();
-    expect(continueButton()).toBeDisabled();
+  it('configures the quadrat dropzone for exactly one file', () => {
+    render(<Harness uploadForm={FormType.quadrats} />);
+    expect(screen.getByTestId('dropzone-file-mode')).toHaveTextContent('single');
   });
 
   it('surfaces a server-discovered existing-layout overlap and allows an explicit retry acknowledgment', async () => {
@@ -313,7 +310,7 @@ describe('quadrat geometry preflight — scalar issues (blank/missing coordinate
 });
 
 describe('quadrat geometry preflight — plot dimensions unavailable', () => {
-  it('warns that geometry could not be validated and blocks Continue when the plot has no dimensions on record', async () => {
+  it('warns that bounds could not be validated but allows Continue when the plot has no dimensions on record', async () => {
     mockPlotContext.current = { plotID: 1, plotName: 'Test Plot', dimensionX: undefined, dimensionY: undefined };
 
     const fileName = 'quadrats-no-plot-dims.csv';
@@ -334,7 +331,7 @@ describe('quadrat geometry preflight — plot dimensions unavailable', () => {
     // must not also fire for this otherwise-clean row.
     expect(screen.queryByText(/quadrat geometry problem/i)).toBeNull();
 
-    expect(continueButton()).toBeDisabled();
+    expect(continueButton()).not.toBeDisabled();
   });
 
   it('treats NULL plot dimensions like missing ones instead of flagging every row as out of bounds', async () => {
@@ -360,6 +357,7 @@ describe('quadrat geometry preflight — plot dimensions unavailable', () => {
     });
     expect(screen.queryByText(/extends past plot/i)).toBeNull();
     expect(screen.queryByText(/quadrat geometry problem/i)).toBeNull();
+    expect(continueButton()).not.toBeDisabled();
   });
 
   it('still reports an overlap between rows when plot dimensions are unavailable', async () => {
@@ -375,9 +373,41 @@ describe('quadrat geometry preflight — plot dimensions unavailable', () => {
     });
 
     await waitFor(() => {
-      // Both directions of the pair are reported (Q0001 vs Q0002 and Q0002 vs Q0001).
       expect(screen.getAllByText(/overlaps quadrat/i).length).toBeGreaterThan(0);
     });
+    expect(continueButton()).toBeDisabled();
+  });
+});
+
+describe('quadrat geometry preflight — usable-row parity', () => {
+  it('ignores delimiter-only padding rows when a usable quadrat row is present', async () => {
+    const fileName = 'quadrats-with-padding.csv';
+    const file = buildQuadratFile(fileName, ',,,,,,\nQ0001,10,10,10,10,100,square');
+
+    render(<Harness acceptedFiles={[file]} selectedDelimiters={{ [fileName]: ',' }} />);
+
+    await waitFor(() => expect(continueButton()).not.toBeDisabled());
+    expect(screen.queryByText(/quadrat geometry problem/i)).toBeNull();
+  });
+
+  it('blocks a file containing only delimiter padding rows', async () => {
+    const fileName = 'quadrats-only-padding.csv';
+    const file = buildQuadratFile(fileName, ',,,,,,');
+
+    render(<Harness acceptedFiles={[file]} selectedDelimiters={{ [fileName]: ',' }} />);
+
+    await waitFor(() => expect(screen.getByText(/contains no usable quadrat rows/i)).toBeInTheDocument());
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it('blocks more than the maximum number of usable quadrat rows', async () => {
+    const fileName = 'quadrats-too-many.csv';
+    const dataRows = Array.from({ length: MAX_GENERATED_QUADRATS + 1 }, (_, index) => `Q${index},${index},0,1,1,1,square`).join('\n');
+    const file = buildQuadratFile(fileName, dataRows);
+
+    render(<Harness acceptedFiles={[file]} selectedDelimiters={{ [fileName]: ',' }} />);
+
+    await waitFor(() => expect(screen.getByText(new RegExp(`maximum is ${MAX_GENERATED_QUADRATS}`, 'i'))).toBeInTheDocument(), { timeout: 10_000 });
     expect(continueButton()).toBeDisabled();
   });
 });

--- a/frontend/components/uploadsystem/segments/uploadparsefiles.tsx
+++ b/frontend/components/uploadsystem/segments/uploadparsefiles.tsx
@@ -41,6 +41,7 @@ import { validateQuadratsRow } from '@/lib/db/definitions/zones';
 import {
   acknowledgmentCoversLayout,
   buildQuadratOverlapAcknowledgment,
+  isBlankQuadratPaddingRow,
   QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
   toQuadratGeometry,
   validateQuadratCollectionDetailed,
@@ -48,6 +49,7 @@ import {
 } from '@/lib/provisioning/quadrat-collection-validation';
 import type { QuadratCsvRow } from '@/lib/provisioning/types';
 import ReferenceCornerSelect from '@/components/provisioning/ReferenceCornerSelect';
+import { MAX_GENERATED_QUADRATS } from '@/lib/provisioning/grid-generator';
 
 export interface FileValidationStatus {
   fileName: string;
@@ -184,10 +186,8 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
   const [quadratOverlapWarningsByFile, setQuadratOverlapWarningsByFile] = useState<Record<string, QuadratPreflightIssue[]>>({});
   const [localQuadratOverlapSummaries, setLocalQuadratOverlapSummaries] = useState<QuadratOverlapSummary[]>([]);
   const [quadratPreflightRunning, setQuadratPreflightRunning] = useState<boolean>(false);
-  // True when at least one file had rows that parsed as geometry but the plot's DimensionX/DimensionY
-  // are unset, so bounds/overlap/duplicate-name checks (validateQuadratCollection) could not run at
-  // all. This is "we could not check", never conflated with quadratPreflightIssuesByFile's "your file
-  // is wrong" — the two are rendered as separate alerts and both independently block Continue.
+  // True when the file parsed as geometry but the plot's DimensionX/DimensionY are unset. This is
+  // an advisory warning: overlap and duplicate-name checks still run without plot bounds.
   const [quadratPlotDimensionsUnvalidated, setQuadratPlotDimensionsUnvalidated] = useState<boolean>(false);
 
   // Advisory preflight only (Task 11 owns server-side enforcement): parses every accepted quadrat
@@ -213,17 +213,17 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
       const nextOverlapWarningsByFile: Record<string, QuadratPreflightIssue[]> = {};
       const nextOverlapSummaries: QuadratOverlapSummary[] = [];
       let dimensionsUnvalidated = false;
-      const geometryByFile: Array<{ fileName: string; rows: QuadratCsvRow[]; originalRowIndexes: number[] }> = [];
+      let parsedGeometry: { fileName: string; rows: QuadratCsvRow[]; originalRowIndexes: number[] } | null = null;
 
-      for (const file of acceptedFiles) {
-        let rows: FileRow[];
+      const file = acceptedFiles[0];
+      if (file) {
+        let rows: FileRow[] | null = null;
         try {
           rows = await parseQuadratFileRows(file, selectedDelimiters[file.name], abortController.signal);
         } catch (parseError: unknown) {
           if (parseError instanceof Error && parseError.name === 'AbortError') return;
           const message = parseError instanceof Error ? parseError.message : String(parseError);
           nextIssuesByFile[file.name] = [{ rowIndex: -1, quadratName: '(file)', message: `Could not parse ${file.name}: ${message}` }];
-          continue;
         }
 
         const fileIssues: QuadratPreflightIssue[] = [];
@@ -232,9 +232,10 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
           const geometryRows: QuadratCsvRow[] = [];
           const originalRowIndexes: number[] = [];
 
-          rows.forEach((row, rowIndex) => {
+          rows?.forEach((row, rowIndex) => {
             const geometry = toQuadratGeometry(row);
             if (!geometry) {
+              if (isBlankQuadratPaddingRow(row)) return;
               // A null conversion is a blocking scalar issue, not a row to silently drop — reuse the
               // real per-row validator so this preflight's reasons agree with what the row actually fails.
               const scalarErrors = validateQuadratsRow(row);
@@ -247,8 +248,16 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
             geometryRows.push(geometry);
           });
 
-          if (geometryRows.length > 0) {
-            geometryByFile.push({ fileName: file.name, rows: geometryRows, originalRowIndexes });
+          if (geometryRows.length > MAX_GENERATED_QUADRATS) {
+            fileIssues.push({
+              rowIndex: -1,
+              quadratName: '(file)',
+              message: `${file.name} contains ${geometryRows.length} usable quadrat rows; the maximum is ${MAX_GENERATED_QUADRATS}.`
+            });
+          } else if (geometryRows.length > 0) {
+            parsedGeometry = { fileName: file.name, rows: geometryRows, originalRowIndexes };
+          } else if (rows && rows.length > 0 && fileIssues.length === 0) {
+            fileIssues.push({ rowIndex: -1, quadratName: '(file)', message: `${file.name} contains no usable quadrat rows.` });
           }
         } catch (geometryError: unknown) {
           const message = geometryError instanceof Error ? geometryError.message : String(geometryError);
@@ -259,48 +268,35 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
           });
         }
 
-        if (fileIssues.length > 0) {
+        if (fileIssues.length > 0 && !nextIssuesByFile[file.name]) {
           nextIssuesByFile[file.name] = fileIssues.sort((a, b) => a.rowIndex - b.rowIndex);
         }
       }
 
       const plotBoundsUsable = typeof plotDimensionX === 'number' && plotDimensionX > 0 && typeof plotDimensionY === 'number' && plotDimensionY > 0;
-      if (geometryByFile.length > 0 && !plotBoundsUsable) {
+      if (parsedGeometry && !plotBoundsUsable) {
         dimensionsUnvalidated = true;
       }
 
-      const combinedRows = geometryByFile.flatMap(entry => entry.rows);
-      const combinedSources = geometryByFile.flatMap(entry =>
-        entry.rows.map((_, index) => ({ fileName: entry.fileName, rowIndex: entry.originalRowIndexes[index] ?? index }))
-      );
-      if (combinedRows.length > 0) {
-        // Validate the whole selected layout, not each file in isolation. This catches duplicate
-        // names and overlaps spanning separate files before the first file can commit.
-        const combinedValidation = validateQuadratCollectionDetailed(
-          combinedRows,
+      if (parsedGeometry) {
+        const validation = validateQuadratCollectionDetailed(
+          parsedGeometry.rows,
           plotBoundsUsable ? { dimensionX: plotDimensionX, dimensionY: plotDimensionY } : null,
           coordinateReferenceCorner
         );
-        combinedValidation.issues.forEach(issue => {
-          const source = combinedSources[issue.rowIndex] ?? { fileName: '(selection)', rowIndex: issue.rowIndex };
-          const target = issue.kind === 'overlap' ? nextOverlapWarningsByFile : nextIssuesByFile;
-          const list = target[source.fileName] ?? [];
-          list.push({ rowIndex: source.rowIndex, quadratName: issue.quadratName, message: issue.message });
-          target[source.fileName] = list;
+        validation.fatalIssues.forEach(issue => {
+          const sourceRowIndex = parsedGeometry?.originalRowIndexes[issue.rowIndex] ?? issue.rowIndex;
+          const list = nextIssuesByFile[parsedGeometry.fileName] ?? [];
+          list.push({ rowIndex: sourceRowIndex, quadratName: issue.quadratName, message: issue.message });
+          nextIssuesByFile[parsedGeometry.fileName] = list;
         });
-
-        // The server processes quadrat files sequentially. Record every cumulative-prefix
-        // signature containing overlaps so a confirmation can cover each exact layout the server
-        // will validate, while still invalidating automatically if any file or ordering changes.
-        const prefixRows: QuadratCsvRow[] = [];
-        for (const entry of geometryByFile) {
-          prefixRows.push(...entry.rows);
-          const prefixValidation = validateQuadratCollectionDetailed(
-            prefixRows,
-            plotBoundsUsable ? { dimensionX: plotDimensionX, dimensionY: plotDimensionY } : null,
-            coordinateReferenceCorner
-          );
-          if (prefixValidation.overlapSummary) nextOverlapSummaries.push(prefixValidation.overlapSummary);
+        if (validation.overlapSummary) {
+          nextOverlapSummaries.push(validation.overlapSummary);
+          nextOverlapWarningsByFile[parsedGeometry.fileName] = validation.overlapSummary.pairs.map(pair => ({
+            rowIndex: -1,
+            quadratName: '(layout)',
+            message: pair.message
+          }));
         }
       }
 
@@ -345,10 +341,20 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
   // sent (and required) server-side, so unchecking cannot be bypassed by skipping the preflight.
   const quadratOverlapsUnacknowledged = quadratPreflightHasOverlapWarnings && !quadratOverlapsAcknowledged;
 
-  const quadratPreflightBlocksContinue =
-    isQuadratsForm && (quadratPreflightRunning || quadratPreflightHasIssues || quadratPlotDimensionsUnvalidated || quadratOverlapsUnacknowledged);
+  const quadratPreflightBlocksContinue = isQuadratsForm && (quadratPreflightRunning || quadratPreflightHasIssues || quadratOverlapsUnacknowledged);
 
   const handleFileChange = async (newFiles: FileWithPath[]) => {
+    if (isQuadratsForm) {
+      const nextFile = newFiles[0];
+      if (!nextFile) return;
+      if (acceptedFiles.length > 0) {
+        setFileToReplace(nextFile);
+      } else {
+        handleAddFile(nextFile);
+      }
+      return;
+    }
+
     for (const file of newFiles) {
       const existingFile = acceptedFiles.find(f => f.name === file.name);
       if (existingFile) {
@@ -564,7 +570,12 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
             }}
           >
             <Stack spacing={3} sx={{ height: '100%' }}>
-              <DropzoneCompact onChange={handleFileChange} hasFiles={acceptedFiles.length > 0} sourceFormat={sourceFormat} />
+              <DropzoneCompact
+                onChange={handleFileChange}
+                hasFiles={acceptedFiles.length > 0}
+                sourceFormat={sourceFormat}
+                allowMultipleFiles={!isQuadratsForm}
+              />
               {isQuadratsForm && (
                 <ReferenceCornerSelect
                   id="upload-quadrat-reference-corner-input"
@@ -602,9 +613,8 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
                     </Alert>
                   )}
 
-                  {/* Quadrat Geometry Preflight — "we could not check" (plot has no dimensions to check
-                      against), distinct from and rendered separately from the "your file is wrong"
-                      alert below. Both independently block Continue. */}
+                  {/* Quadrat Geometry Preflight — bounds could not be checked, but bounds-independent
+                      checks still ran. This is advisory and does not block Continue. */}
                   {isQuadratsForm && quadratPlotDimensionsUnvalidated && (
                     <Alert color="warning" variant="soft" startDecorator={<WarningAmberIcon />} sx={{ textAlign: 'left' }}>
                       <Box>
@@ -613,8 +623,8 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
                         </Typography>
                         <Typography level="body-sm" sx={{ mt: 0.5 }}>
                           This plot has no DimensionX/DimensionY on record, so the plot-bounds checks could not run against it. Overlap, duplicate-name, and
-                          per-row checks (missing or non-numeric coordinates) still completed normally. Continue is disabled until the plot&apos;s dimensions
-                          are set — this preflight cannot confirm your file fits the plot without them.
+                          per-row checks (missing or non-numeric coordinates) still completed normally. You may continue, but record the plot dimensions to
+                          restore full bounds validation.
                         </Typography>
                       </Box>
                     </Alert>

--- a/frontend/components/uploadsystem/uploadparent.quadrat-reference-corner.test.tsx
+++ b/frontend/components/uploadsystem/uploadparent.quadrat-reference-corner.test.tsx
@@ -86,15 +86,18 @@ vi.mock('@/components/uploadsystem/segments/uploadparsefiles', () => ({
   default: ({
     coordinateReferenceCorner,
     setCoordinateReferenceCorner,
+    handleAddFile,
     handleInitialSubmit
   }: {
     coordinateReferenceCorner: QuadratReferenceCorner;
     setCoordinateReferenceCorner: (next: QuadratReferenceCorner) => void;
+    handleAddFile: (file: File) => void;
     handleInitialSubmit: () => Promise<void>;
   }) => (
     <div data-testid="upload-parse-files">
       <div data-testid="corner-in-parse-files">{coordinateReferenceCorner}</div>
       <button onClick={() => setCoordinateReferenceCorner('NE')}>Select North-East</button>
+      <button onClick={() => handleAddFile(new File(['quadrat,startx,starty,dimx,dimy\nQ1,0,0,10,10'], 'quadrats.csv'))}>Select File</button>
       <button onClick={() => handleInitialSubmit()}>Continue Upload</button>
     </div>
   )
@@ -125,6 +128,7 @@ describe('UploadParent — coordinateReferenceCorner survives the UPLOAD_FILES -
     await user.click(screen.getByText('Select North-East'));
     expect(screen.getByTestId('corner-in-parse-files')).toHaveTextContent('NE');
 
+    await user.click(screen.getByText('Select File'));
     await user.click(screen.getByText('Continue Upload'));
 
     await waitFor(() => {

--- a/frontend/components/uploadsystem/uploadparent.tsx
+++ b/frontend/components/uploadsystem/uploadparent.tsx
@@ -320,6 +320,12 @@ function UploadParentInner(props: UploadParentProps) {
   }
 
   async function handleInitialSubmit() {
+    if (uploadState.state.uploadForm === FormType.quadrats && fileManagement.files.length !== 1) {
+      errorHandling.setError(new Error('Quadrat uploads require exactly one file. Remove extra files or select a single complete quadrat file.'));
+      uploadState.setReviewState(ReviewStates.ERRORS);
+      return;
+    }
+
     if (uploadState.state.sourceFormat === SourceFormat.arcgis_xlsx) {
       setArcgisImportSession(null);
       uploadState.setReviewState(ReviewStates.ARCGIS_PREFLIGHT);

--- a/frontend/components/uploadsystemhelpers/dropzonecompact.tsx
+++ b/frontend/components/uploadsystemhelpers/dropzonecompact.tsx
@@ -9,10 +9,12 @@ interface DropzoneCompactProps {
   onChange: (acceptedFiles: FileWithPath[], rejectedFiles: FileRejection[]) => void;
   hasFiles?: boolean;
   sourceFormat?: SourceFormat;
+  allowMultipleFiles?: boolean;
 }
 
-export function DropzoneCompact({ onChange, hasFiles = false, sourceFormat = SourceFormat.csv }: DropzoneCompactProps) {
+export function DropzoneCompact({ onChange, hasFiles = false, sourceFormat = SourceFormat.csv, allowMultipleFiles = true }: DropzoneCompactProps) {
   const isArcgisWorkbook = sourceFormat === SourceFormat.arcgis_xlsx;
+  const acceptsMultipleFiles = allowMultipleFiles && !isArcgisWorkbook;
   const onDrop = useCallback(
     (acceptedFiles: FileWithPath[], rejectedFiles: FileRejection[]) => {
       onChange(acceptedFiles, rejectedFiles);
@@ -32,7 +34,8 @@ export function DropzoneCompact({ onChange, hasFiles = false, sourceFormat = Sou
           'text/csv': ['.csv'],
           'text/plain': ['.txt', '.tsv']
         },
-    multiple: !isArcgisWorkbook
+    multiple: acceptsMultipleFiles,
+    maxFiles: acceptsMultipleFiles ? undefined : 1
   });
 
   const getBorderColor = () => {
@@ -107,7 +110,9 @@ export function DropzoneCompact({ onChange, hasFiles = false, sourceFormat = Sou
                 ? 'Choose a replacement file'
                 : isArcgisWorkbook
                   ? 'Choose one ArcGIS .xlsx workbook or drag it here'
-                  : 'Choose files or drag them here'}
+                  : acceptsMultipleFiles
+                    ? 'Choose files or drag them here'
+                    : 'Choose one file or drag it here'}
             </Typography>
             <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', justifyContent: 'center' }}>
               {isArcgisWorkbook ? (

--- a/frontend/lib/ingestion/quadrat-overlap-contract.ts
+++ b/frontend/lib/ingestion/quadrat-overlap-contract.ts
@@ -1,0 +1,23 @@
+import type { QuadratOverlapSummary } from '@/lib/provisioning/quadrat-collection-validation';
+
+export const QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE = 'QUADRAT_OVERLAPS_REQUIRE_ACKNOWLEDGMENT';
+
+export function parseQuadratOverlapSummaries(payload: unknown): QuadratOverlapSummary[] | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const record = payload as Record<string, unknown>;
+  if (record.code !== QUADRAT_OVERLAP_ACKNOWLEDGMENT_REQUIRED_CODE || !Array.isArray(record.overlapSummaries)) return null;
+
+  const summaries = record.overlapSummaries.filter((summary): summary is QuadratOverlapSummary => {
+    if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return false;
+    const candidate = summary as Record<string, unknown>;
+    return (
+      typeof candidate.layoutSignature === 'string' &&
+      typeof candidate.reportedPairCount === 'number' &&
+      typeof candidate.minimumPairCount === 'number' &&
+      typeof candidate.truncated === 'boolean' &&
+      Array.isArray(candidate.pairs)
+    );
+  });
+
+  return summaries.length > 0 ? summaries : null;
+}

--- a/frontend/lib/ingestion/quadrat-write-boundary.ts
+++ b/frontend/lib/ingestion/quadrat-write-boundary.ts
@@ -1,0 +1,381 @@
+import ailogger from '@/ailogger';
+import type ConnectionManager from '@/lib/db/connectionmanager';
+import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import type { FileRow } from '@/config/macros/formdetails';
+import { UploadMode } from '@/config/uploadmodes';
+import { buildDivergentQuadratUploadError, quadratRevisionAppendsDivergentSet } from './quadrat-upload-guards';
+import {
+  acknowledgmentCoversLayout,
+  isBlankQuadratPaddingRow,
+  summarizeQuadratOverlaps,
+  toQuadratGeometry,
+  validateQuadratCollectionDetailed,
+  type QuadratCollectionIssue,
+  type QuadratOverlapSummary
+} from '@/lib/provisioning/quadrat-collection-validation';
+import {
+  DEFAULT_REFERENCE_CORNER,
+  isQuadratReferenceCorner,
+  normalizeToSouthwest,
+  type QuadratReferenceCorner
+} from '@/lib/provisioning/coordinate-reference-corner';
+import type { QuadratCsvRow } from '@/lib/provisioning/types';
+import { MAX_GENERATED_QUADRATS } from '@/lib/provisioning/grid-generator';
+
+const MAX_LISTED_ISSUES = 20;
+const CANONICAL_SOUTHWEST_CORNER: QuadratReferenceCorner = 'SW';
+
+export interface QuadratWriteResult {
+  insertedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  acknowledgedOverlapSummaries?: QuadratOverlapSummary[];
+}
+
+export class QuadratGeometryValidationError extends Error {}
+
+export class QuadratOverlapAcknowledgmentRequiredError extends Error {
+  constructor(
+    message: string,
+    readonly overlapSummary: QuadratOverlapSummary
+  ) {
+    super(message);
+    this.name = 'QuadratOverlapAcknowledgmentRequiredError';
+  }
+}
+
+export function parseQuadratReferenceCorner(value: unknown): QuadratReferenceCorner {
+  if (value === undefined || value === null) return DEFAULT_REFERENCE_CORNER;
+  if (!isQuadratReferenceCorner(value)) {
+    throw new QuadratGeometryValidationError('coordinateReferenceCorner must be SW, SE, NW, or NE');
+  }
+  return value;
+}
+
+function toNullableNumber(value: unknown): number | null {
+  if (value === undefined || value === null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function coerceGeometryField(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  return String(value);
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized === '' ? null : normalized;
+}
+
+function normalizeRequiredString(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function truncateAndJoin(items: string[], separator: string, maxItems: number = MAX_LISTED_ISSUES): string {
+  const truncatedItems = items.slice(0, maxItems);
+  const remainingCount = items.length - truncatedItems.length;
+  return truncatedItems.join(separator) + (remainingCount > 0 ? `${separator}...and ${remainingCount} more` : '');
+}
+
+function formatBlockedValues(values: string[], maxValues: number = MAX_LISTED_ISSUES): string {
+  const uniqueValues = Array.from(new Set(values.map(value => String(value ?? '').trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
+  return truncateAndJoin(uniqueValues, ', ', maxValues);
+}
+
+function formatGeometryMessages(messages: string[]): string {
+  return `Quadrat geometry validation failed: ${truncateAndJoin(messages, ' ')}`;
+}
+
+function formatGeometryIssues(issues: QuadratCollectionIssue[]): string {
+  return formatGeometryMessages(issues.map(issue => issue.message));
+}
+
+export async function writeQuadratUpload(
+  connectionManager: ConnectionManager,
+  schema: string,
+  plotID: number | undefined,
+  rows: FileRow[],
+  uploadMode: UploadMode,
+  referenceCorner: QuadratReferenceCorner,
+  overlapAcknowledgment: unknown,
+  transactionID: string
+): Promise<QuadratWriteResult> {
+  if (!plotID) {
+    throw new Error('PlotID is required for quadrat uploads');
+  }
+  if (rows.length === 0) {
+    throw new QuadratGeometryValidationError('Quadrat upload must contain at least one row.');
+  }
+  let insertedCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+
+  const rowConversionFailures: string[] = [];
+  const incomingGeometry: QuadratCsvRow[] = [];
+  rows.forEach((row, index) => {
+    const quadratName = normalizeRequiredString(row.quadrat);
+    if (!quadratName) {
+      if (isBlankQuadratPaddingRow(row)) {
+        skippedCount += 1;
+        return;
+      }
+      rowConversionFailures.push(`Quadrat upload row ${index + 1} has a missing or blank QuadratName.`);
+      return;
+    }
+
+    const geometry = toQuadratGeometry({
+      quadrat: quadratName,
+      startx: coerceGeometryField(row.startx),
+      starty: coerceGeometryField(row.starty),
+      dimx: coerceGeometryField(row.dimx),
+      dimy: coerceGeometryField(row.dimy)
+    });
+    if (!geometry) {
+      rowConversionFailures.push(
+        `Quadrat upload row ${index + 1} (QuadratName "${quadratName}") has missing, blank, or non-numeric ` +
+          `geometry (startx/starty/dimx/dimy). Fix the file and re-upload.`
+      );
+      return;
+    }
+    incomingGeometry.push(geometry);
+  });
+
+  if (rowConversionFailures.length > 0) {
+    throw new QuadratGeometryValidationError(`Quadrat upload has unusable rows: ${truncateAndJoin(rowConversionFailures, ' ')}`);
+  }
+  if (incomingGeometry.length > MAX_GENERATED_QUADRATS) {
+    throw new QuadratGeometryValidationError(
+      `Quadrat upload contains ${incomingGeometry.length} usable rows; maximum allowed per request is ${MAX_GENERATED_QUADRATS}.`
+    );
+  }
+  if (incomingGeometry.length === 0) {
+    throw new QuadratGeometryValidationError(`Quadrat upload contains no usable rows (${skippedCount} blank row(s) skipped).`);
+  }
+
+  const plotBoundsSQL = safeFormatQuery(schema, `SELECT DimensionX, DimensionY FROM ??.plots WHERE PlotID = ? LIMIT 1`);
+  const plotBoundsResult = await connectionManager.executeQuery(plotBoundsSQL, [plotID], transactionID);
+  const plotBoundsRow = Array.isArray(plotBoundsResult) ? plotBoundsResult[0] : undefined;
+  const plotDimensionX = toNullableNumber(plotBoundsRow?.DimensionX);
+  const plotDimensionY = toNullableNumber(plotBoundsRow?.DimensionY);
+  const plotBoundsUsable = !!plotBoundsRow && plotDimensionX !== null && plotDimensionY !== null && plotDimensionX > 0 && plotDimensionY > 0;
+  const plotBounds = plotBoundsUsable ? { dimensionX: plotDimensionX, dimensionY: plotDimensionY } : null;
+  if (!plotBounds) {
+    ailogger.warn(
+      `Plot ${plotID} has no valid DimensionX/DimensionY on record; quadrat plot-bounds checks are skipped for this upload. ` +
+        `Overlap and duplicate-name validation still applies. Record the plot dimensions to restore full validation.`
+    );
+  }
+
+  const normalizedIncoming = incomingGeometry.map(row => normalizeToSouthwest(row, referenceCorner));
+  const acknowledgedOverlapSummaries: QuadratOverlapSummary[] = [];
+  const requireOverlapAcknowledgment = (overlapSummary: QuadratOverlapSummary | null) => {
+    if (!overlapSummary) return;
+    if (!acknowledgmentCoversLayout(overlapAcknowledgment, overlapSummary.layoutSignature)) {
+      const pairMessages = overlapSummary.pairs.map(pair => pair.message);
+      const truncationNotice = overlapSummary.truncated
+        ? ` At least ${overlapSummary.minimumPairCount} pairs overlap; the response includes a ${overlapSummary.reportedPairCount}-pair sample.`
+        : '';
+      throw new QuadratOverlapAcknowledgmentRequiredError(
+        `Quadrat footprints overlap: ${truncateAndJoin(pairMessages, ' ')}${truncationNotice} ` +
+          `If these overlaps reflect field measurements, review and confirm the overlap acknowledgment, then re-submit.`,
+        overlapSummary
+      );
+    }
+    acknowledgedOverlapSummaries.push(overlapSummary);
+  };
+
+  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
+    const cleanValidation = validateQuadratCollectionDetailed(normalizedIncoming, plotBounds, CANONICAL_SOUTHWEST_CORNER);
+    if (cleanValidation.fatalIssues.length > 0) {
+      throw new QuadratGeometryValidationError(formatGeometryIssues(cleanValidation.fatalIssues));
+    }
+    requireOverlapAcknowledgment(cleanValidation.overlapSummary);
+
+    const blockingQuadratSQL = safeFormatQuery(
+      schema,
+      `SELECT q.QuadratID, q.QuadratName
+       FROM ??.quadrats q
+       WHERE q.PlotID = ?
+         AND q.IsActive = 1
+         AND EXISTS (
+           SELECT 1
+           FROM ??.stems s
+           WHERE s.QuadratID = q.QuadratID
+             AND s.IsActive = 1
+         )
+       ORDER BY q.QuadratName`
+    );
+    const blockingQuadratRows = await connectionManager.executeQuery(blockingQuadratSQL, [plotID], transactionID);
+    const blockingQuadrats = Array.isArray(blockingQuadratRows) ? blockingQuadratRows : [];
+    const blockingQuadratNames = blockingQuadrats.map((row: any) => {
+      const quadratName = String(row.QuadratName ?? '').trim();
+      return quadratName || `(unnamed QuadratID ${row.QuadratID})`;
+    });
+
+    if (blockingQuadrats.length > 0) {
+      throw new Error(
+        `Clean re-upload refused: active quadrat rows in plot ${plotID} are already referenced ` +
+          `by stems for the following QuadratName value(s): ${formatBlockedValues(blockingQuadratNames)}. ` +
+          `Deleting quadrats would cascade-delete stems and downstream measurements even if the same names appear in the upload. ` +
+          `Use Revisions Upload instead.`
+      );
+    }
+
+    const deleteSQL = safeFormatQuery(schema, `DELETE FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`);
+    await connectionManager.executeQuery(deleteSQL, [plotID], transactionID);
+  }
+
+  if (uploadMode === UploadMode.REVISIONS) {
+    const existingQuadratsSQL = safeFormatQuery(
+      schema,
+      `SELECT QuadratID, QuadratName, StartX, StartY, DimensionX, DimensionY FROM ??.quadrats WHERE PlotID = ? AND IsActive = 1`
+    );
+    const existingQuadratRows = await connectionManager.executeQuery(existingQuadratsSQL, [plotID], transactionID);
+    const existingQuadratList: any[] = Array.isArray(existingQuadratRows) ? existingQuadratRows : [];
+
+    const existingActiveNames = existingQuadratList.map(row => String(row.QuadratName ?? ''));
+    const incomingNames = rows.map(row => normalizeRequiredString(row.quadrat)).filter(Boolean);
+    if (quadratRevisionAppendsDivergentSet(existingActiveNames, incomingNames)) {
+      throw new Error(buildDivergentQuadratUploadError(plotID, existingActiveNames, incomingNames.length));
+    }
+
+    const incomingNamesLower = new Set(normalizedIncoming.map(row => row.quadratName.toLowerCase()));
+    const carryOverExisting: QuadratCsvRow[] = [];
+    const unvalidatableExistingNames: string[] = [];
+    for (const existingRow of existingQuadratList) {
+      const storedName = String(existingRow.QuadratName ?? '').trim();
+      if (storedName && incomingNamesLower.has(storedName.toLowerCase())) continue;
+
+      const displayName = storedName || `(unnamed QuadratID ${existingRow.QuadratID})`;
+      const geometry = toQuadratGeometry({
+        quadrat: displayName,
+        startx: coerceGeometryField(existingRow.StartX),
+        starty: coerceGeometryField(existingRow.StartY),
+        dimx: coerceGeometryField(existingRow.DimensionX),
+        dimy: coerceGeometryField(existingRow.DimensionY)
+      });
+      if (!geometry) {
+        unvalidatableExistingNames.push(displayName);
+        continue;
+      }
+      carryOverExisting.push(geometry);
+    }
+    if (unvalidatableExistingNames.length > 0) {
+      ailogger.warn(
+        `Plot ${plotID} has ${unvalidatableExistingNames.length} existing active quadrat(s) with malformed stored geometry; ` +
+          `they were excluded from revision geometry validation: ${truncateAndJoin(unvalidatableExistingNames, ', ')}. ` +
+          `Re-upload those quadrats with valid geometry to restore full validation.`
+      );
+    }
+
+    const prospectiveLayout = [...carryOverExisting, ...normalizedIncoming];
+    if (prospectiveLayout.length > MAX_GENERATED_QUADRATS) {
+      throw new QuadratGeometryValidationError(
+        `Prospective quadrat layout contains ${prospectiveLayout.length} rows; maximum allowed per plot is ${MAX_GENERATED_QUADRATS}.`
+      );
+    }
+
+    const incomingStartIndex = carryOverExisting.length;
+    const revisionFatalIssues = validateQuadratCollectionDetailed(prospectiveLayout, plotBounds, CANONICAL_SOUTHWEST_CORNER).fatalIssues;
+    const preExistingIssues = revisionFatalIssues.filter(issue => issue.rowIndex < incomingStartIndex);
+    const introducedIssues = revisionFatalIssues.filter(issue => issue.rowIndex >= incomingStartIndex);
+    if (preExistingIssues.length > 0) {
+      ailogger.warn(
+        `Plot ${plotID} has pre-existing quadrat layout defects not caused by this upload: ` +
+          `${truncateAndJoin(
+            preExistingIssues.map(issue => issue.message),
+            ' '
+          )}`
+      );
+    }
+    const preExistingOverlapSummary = summarizeQuadratOverlaps(carryOverExisting);
+    if (preExistingOverlapSummary) {
+      ailogger.warn(
+        `Plot ${plotID} has pre-existing quadrat layout defects not caused by this upload: ` +
+          `${truncateAndJoin(
+            preExistingOverlapSummary.pairs.map(pair => pair.message),
+            ' '
+          )}`
+      );
+    }
+
+    const incomingRowSet = new Set<QuadratCsvRow>(normalizedIncoming);
+    const sweepableLayout = prospectiveLayout.filter(row => row.dimensionX > 0 && row.dimensionY > 0);
+    const introducedOverlapSummary = summarizeQuadratOverlaps(sweepableLayout, (a, b) => incomingRowSet.has(a) || incomingRowSet.has(b));
+
+    const fatalIntroducedMessages = new Set<string>(introducedIssues.map(issue => issue.message));
+    if (fatalIntroducedMessages.size > 0) {
+      throw new QuadratGeometryValidationError(formatGeometryMessages([...fatalIntroducedMessages]));
+    }
+    requireOverlapAcknowledgment(introducedOverlapSummary);
+  }
+
+  const canonicalByName = new Map<string, QuadratCsvRow>();
+  for (const row of normalizedIncoming) {
+    canonicalByName.set(row.quadratName.toLowerCase(), row);
+  }
+
+  for (const row of rows) {
+    const quadratName = normalizeRequiredString(row.quadrat);
+    if (!quadratName) continue;
+    const canonical = canonicalByName.get(quadratName.toLowerCase());
+    if (!canonical) {
+      throw new QuadratGeometryValidationError(`Internal error: no canonical geometry resolved for quadrat "${quadratName}".`);
+    }
+
+    const payload = {
+      StartX: canonical.startX,
+      StartY: canonical.startY,
+      DimensionX: canonical.dimensionX,
+      DimensionY: canonical.dimensionY,
+      Area: row.area,
+      QuadratShape: normalizeOptionalString(row.quadratshape)
+    };
+
+    if (uploadMode === UploadMode.REVISIONS) {
+      const existingSQL = safeFormatQuery(
+        schema,
+        `SELECT QuadratID FROM ??.quadrats WHERE PlotID = ? AND LOWER(QuadratName) = LOWER(?) AND IsActive = 1 LIMIT 1`
+      );
+      const existingRows = await connectionManager.executeQuery(existingSQL, [plotID, quadratName], transactionID);
+      if (existingRows.length > 0) {
+        const updateSQL = safeFormatQuery(
+          schema,
+          `UPDATE ??.quadrats
+           SET QuadratName = ?, StartX = ?, StartY = ?, DimensionX = ?, DimensionY = ?, Area = ?, QuadratShape = ?, DeletedAt = NULL
+           WHERE QuadratID = ?`
+        );
+        await connectionManager.executeQuery(
+          updateSQL,
+          [quadratName, payload.StartX, payload.StartY, payload.DimensionX, payload.DimensionY, payload.Area, payload.QuadratShape, existingRows[0].QuadratID],
+          transactionID
+        );
+        updatedCount += 1;
+        continue;
+      }
+    }
+
+    const insertSQL = safeFormatQuery(
+      schema,
+      `INSERT INTO ??.quadrats
+       (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area, QuadratShape, IsActive, DeletedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, NULL)`
+    );
+    await connectionManager.executeQuery(
+      insertSQL,
+      [plotID, quadratName, payload.StartX, payload.StartY, payload.DimensionX, payload.DimensionY, payload.Area, payload.QuadratShape],
+      transactionID
+    );
+    insertedCount += 1;
+  }
+
+  return {
+    insertedCount,
+    updatedCount,
+    skippedCount,
+    ...(acknowledgedOverlapSummaries.length > 0 ? { acknowledgedOverlapSummaries } : {})
+  };
+}

--- a/frontend/lib/provisioning/input-schema.ts
+++ b/frontend/lib/provisioning/input-schema.ts
@@ -130,15 +130,23 @@ export const CanonicalProvisioningSchema = z
     // layout with overlapping footprints is valid provisioning input when the admin has
     // explicitly acknowledged them (the acknowledgment text travels in the stored payload).
     // Every other issue kind remains a hard validation error.
-    const { issues, overlapSummary } = validateQuadratCollectionDetailed(rows, input.plot, 'SW');
+    const { fatalIssues, overlapSummary } = validateQuadratCollectionDetailed(rows, input.plot, 'SW');
     const overlapsAcknowledged = overlapSummary !== null && acknowledgmentCoversLayout(input.quadrats.overlapAcknowledgment, overlapSummary.layoutSignature);
-    for (const issue of issues) {
-      if (issue.kind === 'overlap' && overlapsAcknowledged) continue;
+    for (const issue of fatalIssues) {
       ctx.addIssue({
         code: 'custom',
         path: ['quadrats', 'rows', issue.rowIndex],
-        message: issue.kind === 'overlap' ? `${issue.message} If the overlap reflects field measurements, confirm the overlap acknowledgment.` : issue.message
+        message: issue.message
       });
+    }
+    if (overlapSummary && !overlapsAcknowledged) {
+      for (const pair of overlapSummary.pairs) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['quadrats', 'rows'],
+          message: `${pair.message} If the overlap reflects field measurements, confirm the overlap acknowledgment.`
+        });
+      }
     }
   });
 

--- a/frontend/lib/provisioning/quadrat-collection-validation.test.ts
+++ b/frontend/lib/provisioning/quadrat-collection-validation.test.ts
@@ -3,7 +3,6 @@ import {
   acknowledgmentCoversLayout,
   buildQuadratOverlapAcknowledgment,
   toQuadratGeometry,
-  validateQuadratCollection,
   validateQuadratCollectionDetailed,
   type UploadShapedRow
 } from './quadrat-collection-validation';
@@ -11,6 +10,10 @@ import type { QuadratCsvRow, QuadratReferenceCorner } from './types';
 
 const PLOT_100x60 = { dimensionX: 100, dimensionY: 60 };
 const ALL_CORNERS: QuadratReferenceCorner[] = ['SW', 'SE', 'NW', 'NE'];
+
+function fatalIssuesFor(rows: QuadratCsvRow[], plot: { dimensionX: number; dimensionY: number } | null, corner: QuadratReferenceCorner) {
+  return validateQuadratCollectionDetailed(rows, plot, corner).fatalIssues;
+}
 
 /**
  * Inverse of normalizeToSouthwest: given a canonical (south-west) row, produces the row a file
@@ -94,12 +97,12 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'A', startX: 0, startY: 0, dimensionX: 30, dimensionY: 10 },
       { quadratName: 'B', startX: 40, startY: 0, dimensionX: 20, dimensionY: 20 }
     ];
-    expect(validateQuadratCollection(rows, PLOT_100x60, 'SW')).toEqual([]);
+    expect(fatalIssuesFor(rows, PLOT_100x60, 'SW')).toEqual([]);
   });
 
   it('reports a row extending past the plot, naming the offending quadrat', () => {
     const rows: QuadratCsvRow[] = [{ quadratName: 'TooFarEast', startX: 95, startY: 0, dimensionX: 20, dimensionY: 10 }];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'SW');
     expect(issues).toHaveLength(1);
     expect(issues[0].rowIndex).toBe(0);
     expect(issues[0].quadratName).toBe('TooFarEast');
@@ -108,7 +111,7 @@ describe('validateQuadratCollection', () => {
 
   it('rejects a zero-width dimension', () => {
     const rows: QuadratCsvRow[] = [{ quadratName: 'ZeroWidth', startX: 0, startY: 0, dimensionX: 0, dimensionY: 10 }];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'SW');
     expect(issues).toHaveLength(1);
     expect(issues[0].rowIndex).toBe(0);
     expect(issues[0].quadratName).toBe('ZeroWidth');
@@ -117,7 +120,7 @@ describe('validateQuadratCollection', () => {
 
   it('rejects a negative-height dimension', () => {
     const rows: QuadratCsvRow[] = [{ quadratName: 'NegativeHeight', startX: 0, startY: 0, dimensionX: 10, dimensionY: -5 }];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'SW');
     expect(issues).toHaveLength(1);
     expect(issues[0].rowIndex).toBe(0);
     expect(issues[0].quadratName).toBe('NegativeHeight');
@@ -128,7 +131,7 @@ describe('validateQuadratCollection', () => {
     // dimensionX is negative, so startX + dimensionX < plot.dimensionX would otherwise
     // look "in bounds" to a naive check even though the row is nonsensical.
     const rows: QuadratCsvRow[] = [{ quadratName: 'InvalidButWouldPassBoundsMath', startX: 98, startY: 0, dimensionX: -5, dimensionY: 10 }];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'SW');
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(/non-positive dimension/);
     expect(issues.some(issue => /extends past plot/.test(issue.message))).toBe(false);
@@ -144,7 +147,7 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'FilteredZeroDim', startX: 10, startY: 10, dimensionX: -5, dimensionY: 10 },
       { quadratName: 'OutOfBoundsNE', startX: 115, startY: 10, dimensionX: 20, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'NE');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'NE');
 
     const dimensionIssue = issues.find(issue => /non-positive dimension/.test(issue.message));
     const boundsIssue = issues.find(issue => /extends past plot/.test(issue.message));
@@ -155,22 +158,18 @@ describe('validateQuadratCollection', () => {
     expect(boundsIssue?.quadratName).toBe('OutOfBoundsNE');
   });
 
-  it('maps overlap issues back to the original array indices when a preceding row was filtered out for a non-positive dimension (NE reference corner)', () => {
-    // Same reasoning as the bounds case above, but for findFirstOverlap: the leading
-    // filtered row makes the two overlapping rows land at filtered-indices 0 and 1 while
-    // their real positions in the caller's array are 1 and 2. Without the remap, both
-    // overlap issues would report the wrong (filtered-array) indices.
+  it('excludes a non-positive-dimension row from the overlap summary', () => {
     const rows: QuadratCsvRow[] = [
       { quadratName: 'FilteredZeroDim', startX: 50, startY: 50, dimensionX: 0, dimensionY: 10 },
       { quadratName: 'OverlapLeftNE', startX: 10, startY: 10, dimensionX: 10, dimensionY: 10 },
       { quadratName: 'OverlapRightNE', startX: 15, startY: 15, dimensionX: 10, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'NE');
+    const validation = validateQuadratCollectionDetailed(rows, PLOT_100x60, 'NE');
 
-    const overlapIssues = issues.filter(issue => /overlaps quadrat/.test(issue.message));
-    expect(overlapIssues).toHaveLength(2);
-    expect(overlapIssues.map(issue => issue.rowIndex).sort()).toEqual([1, 2]);
-    expect(overlapIssues.map(issue => issue.quadratName).sort()).toEqual(['OverlapLeftNE', 'OverlapRightNE']);
+    expect(validation.fatalIssues).toHaveLength(1);
+    expect(validation.overlapSummary?.pairs).toHaveLength(1);
+    expect(validation.overlapSummary?.pairs[0].message).toMatch(/OverlapLeftNE.*overlaps.*OverlapRightNE/);
+    expect(validation.overlapSummary?.pairs[0].message).not.toContain('FilteredZeroDim');
   });
 
   it('reports duplicate quadrat names, including two names differing only by case', () => {
@@ -178,7 +177,7 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'Dup', startX: 0, startY: 0, dimensionX: 10, dimensionY: 10 },
       { quadratName: 'dup', startX: 50, startY: 0, dimensionX: 10, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor(rows, PLOT_100x60, 'SW');
     expect(issues).toHaveLength(2);
     expect(issues.map(issue => issue.rowIndex)).toEqual([0, 1]);
     expect(issues.map(issue => issue.quadratName)).toEqual(['Dup', 'dup']);
@@ -195,11 +194,11 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'Distant', startX: 50, startY: 0, dimensionX: 10, dimensionY: 10 },
       { quadratName: 'Right', startX: 5, startY: 5, dimensionX: 10, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
-    const overlapIssues = issues.filter(issue => /overlaps quadrat/.test(issue.message));
-    expect(overlapIssues).toHaveLength(2);
-    expect(overlapIssues.map(issue => issue.quadratName).sort()).toEqual(['Left', 'Right']);
-    expect(issues.some(issue => issue.quadratName === 'Distant')).toBe(false);
+    const validation = validateQuadratCollectionDetailed(rows, PLOT_100x60, 'SW');
+    expect(validation.fatalIssues).toEqual([]);
+    expect(validation.overlapSummary?.pairs).toHaveLength(1);
+    expect(validation.overlapSummary?.pairs[0].message).toMatch(/Left.*overlaps.*Right/);
+    expect(validation.overlapSummary?.pairs[0].message).not.toContain('Distant');
   });
 
   it('skips only the bounds checks when the plot is null; overlap and duplicate-name checks still run', () => {
@@ -210,12 +209,13 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'A', startX: 0, startY: 0, dimensionX: 10, dimensionY: 10 },
       { quadratName: 'a', startX: 5, startY: 5, dimensionX: 10, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, null, 'SW');
+    const validation = validateQuadratCollectionDetailed(rows, null, 'SW');
+    const issues = validation.fatalIssues;
 
     expect(issues.some(issue => /extends past plot/.test(issue.message))).toBe(false);
     expect(issues.some(issue => /negative start coordinate/.test(issue.message))).toBe(false);
     expect(issues.filter(issue => /used by more than one row/.test(issue.message))).toHaveLength(2);
-    expect(issues.filter(issue => /overlaps quadrat/.test(issue.message))).toHaveLength(2);
+    expect(validation.overlapSummary?.pairs).toHaveLength(1);
   });
 
   it('reports every overlapping pair, not just the first', () => {
@@ -228,9 +228,8 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'B1', startX: 50, startY: 0, dimensionX: 10, dimensionY: 10 },
       { quadratName: 'B2', startX: 55, startY: 5, dimensionX: 10, dimensionY: 10 }
     ];
-    const issues = validateQuadratCollection(rows, PLOT_100x60, 'SW');
-    const overlapIssues = issues.filter(issue => /overlaps quadrat/.test(issue.message));
-    expect(overlapIssues.map(issue => issue.quadratName).sort()).toEqual(['A1', 'A2', 'B1', 'B2']);
+    const summary = validateQuadratCollectionDetailed(rows, PLOT_100x60, 'SW').overlapSummary;
+    expect(summary?.pairs.map(pair => pair.message)).toEqual(['Quadrat "A1" overlaps quadrat "A2".', 'Quadrat "B1" overlaps quadrat "B2".']);
   });
 
   it('marks dense overlap reports as truncated and binds acknowledgment to the complete layout', () => {
@@ -264,12 +263,12 @@ describe('validateQuadratCollection', () => {
       { quadratName: 'X', startX: 0, startY: 0, dimensionX: 30, dimensionY: 10 },
       { quadratName: 'x', startX: 50, startY: 0, dimensionX: 10, dimensionY: 10 }
     ];
-    const expected = validateQuadratCollection(canonicalRows, PLOT_100x60, 'SW');
-    expect(expected.length).toBeGreaterThan(0); // sanity: this fixture is deliberately not clean (duplicate name)
+    const expected = validateQuadratCollectionDetailed(canonicalRows, PLOT_100x60, 'SW');
+    expect(expected.fatalIssues.length).toBeGreaterThan(0); // sanity: this fixture is deliberately not clean (duplicate name)
 
     for (const corner of ALL_CORNERS) {
       const declaredRows = canonicalRows.map(row => declareFromCorner(row, corner));
-      const actual = validateQuadratCollection(declaredRows, PLOT_100x60, corner);
+      const actual = validateQuadratCollectionDetailed(declaredRows, PLOT_100x60, corner);
       expect(actual).toEqual(expected);
     }
   });
@@ -277,14 +276,14 @@ describe('validateQuadratCollection', () => {
   it('correctly validates as clean under its true NE reference corner', () => {
     const canonicalRow: QuadratCsvRow = { quadratName: 'NEQuadrat', startX: 80, startY: 45, dimensionX: 15, dimensionY: 10 };
     const declaredAsNE = declareFromCorner(canonicalRow, 'NE');
-    expect(validateQuadratCollection([declaredAsNE], PLOT_100x60, 'NE')).toEqual([]);
+    expect(fatalIssuesFor([declaredAsNE], PLOT_100x60, 'NE')).toEqual([]);
   });
 
   it('flags a north-east file misread as south-west', () => {
     const canonicalRow: QuadratCsvRow = { quadratName: 'NEQuadrat', startX: 80, startY: 45, dimensionX: 15, dimensionY: 10 };
     const declaredAsNE = declareFromCorner(canonicalRow, 'NE');
 
-    const issues = validateQuadratCollection([declaredAsNE], PLOT_100x60, 'SW');
+    const issues = fatalIssuesFor([declaredAsNE], PLOT_100x60, 'SW');
     expect(issues.length).toBeGreaterThan(0);
     expect(issues[0].quadratName).toBe('NEQuadrat');
     expect(issues[0].message).toMatch(/extends past plot/);

--- a/frontend/lib/provisioning/quadrat-collection-validation.ts
+++ b/frontend/lib/provisioning/quadrat-collection-validation.ts
@@ -17,7 +17,7 @@ const LAYOUT_SIGNATURE_PREFIX = 'quadrat-layout-v1-';
  * warn-and-acknowledge condition while every other kind stays a hard error. The kind is
  * carried on the issue so that split never relies on message-string matching.
  */
-export type QuadratIssueKind = 'non-positive-dimension' | 'bounds' | 'duplicate-name' | 'overlap';
+export type QuadratIssueKind = 'non-positive-dimension' | 'bounds' | 'duplicate-name';
 
 /**
  * The confirmation statement a user accepts when proceeding with overlapping quadrat
@@ -46,7 +46,7 @@ export interface QuadratOverlapSummary {
 }
 
 export interface QuadratCollectionValidationResult {
-  issues: QuadratCollectionIssue[];
+  fatalIssues: QuadratCollectionIssue[];
   overlapSummary: QuadratOverlapSummary | null;
 }
 
@@ -133,13 +133,22 @@ export function acknowledgmentCoversLayout(value: unknown, layoutSignature: stri
 
 /** The Quadrats-page upload row shape (see app/api/sqlpacketload/route.ts). Values come straight off a parsed file row. */
 export interface UploadShapedRow {
-  quadrat?: string | null;
-  startx?: string | null;
-  starty?: string | null;
-  dimx?: string | null;
-  dimy?: string | null;
-  area?: string | null;
-  quadratshape?: string | null;
+  quadrat?: unknown;
+  startx?: unknown;
+  starty?: unknown;
+  dimx?: unknown;
+  dimy?: unknown;
+  area?: unknown;
+  quadratshape?: unknown;
+}
+
+function isBlankValue(value: unknown): boolean {
+  return value === undefined || value === null || String(value).trim() === '';
+}
+
+/** Matches the write boundary's padding policy: name and all geometry cells are blank. */
+export function isBlankQuadratPaddingRow(row: UploadShapedRow): boolean {
+  return [row.quadrat, row.startx, row.starty, row.dimx, row.dimy].every(isBlankValue);
 }
 
 /**
@@ -147,9 +156,9 @@ export interface UploadShapedRow {
  * never 0. `Number('')` is 0 in JavaScript, so a naive `Number(value)` would silently turn a
  * missing coordinate into a quadrat pinned to the plot origin.
  */
-function parseRequiredNumber(value: string | null | undefined): number | null {
+function parseRequiredNumber(value: unknown): number | null {
   if (value === null || value === undefined) return null;
-  const trimmed = value.trim();
+  const trimmed = String(value).trim();
   if (trimmed === '') return null;
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
@@ -163,7 +172,7 @@ function parseRequiredNumber(value: string | null | undefined): number | null {
  * at (0, 0).
  */
 export function toQuadratGeometry(row: UploadShapedRow): QuadratCsvRow | null {
-  const quadratName = row.quadrat?.trim();
+  const quadratName = typeof row.quadrat === 'string' ? row.quadrat.trim() : String(row.quadrat ?? '').trim();
   if (!quadratName) return null;
 
   const startX = parseRequiredNumber(row.startx);
@@ -200,7 +209,7 @@ export function validateQuadratCollectionDetailed(
   plot: { dimensionX: number; dimensionY: number } | null,
   referenceCorner: QuadratReferenceCorner
 ): QuadratCollectionValidationResult {
-  const issues: QuadratCollectionIssue[] = [];
+  const fatalIssues: QuadratCollectionIssue[] = [];
   const normalizedRows = rows.map(row => normalizeToSouthwest(row, referenceCorner));
 
   const geometricallyValidRows: QuadratCsvRow[] = [];
@@ -208,7 +217,7 @@ export function validateQuadratCollectionDetailed(
 
   normalizedRows.forEach((row, rowIndex) => {
     if (row.dimensionX <= 0 || row.dimensionY <= 0) {
-      issues.push({
+      fatalIssues.push({
         kind: 'non-positive-dimension',
         rowIndex,
         quadratName: row.quadratName,
@@ -228,7 +237,7 @@ export function validateQuadratCollectionDetailed(
         rowIndex: originalIndexByGeometricRow.get(geometricallyValidRows[issue.rowIndex]) ?? issue.rowIndex
       })
     );
-    issues.push(...boundsIssues);
+    fatalIssues.push(...boundsIssues);
   }
 
   const nameOccurrences = new Map<string, number>();
@@ -239,7 +248,7 @@ export function validateQuadratCollectionDetailed(
   normalizedRows.forEach((row, rowIndex) => {
     const key = row.quadratName.trim().toLowerCase();
     if ((nameOccurrences.get(key) ?? 0) > 1) {
-      issues.push({
+      fatalIssues.push({
         kind: 'duplicate-name',
         rowIndex,
         quadratName: row.quadratName,
@@ -248,34 +257,10 @@ export function validateQuadratCollectionDetailed(
     }
   });
 
-  // Ask for one pair beyond the reporting cap. This keeps pathological all-overlapping inputs
-  // bounded while allowing callers to distinguish a complete list from a truncated sample.
+  // Overlaps are represented once, as a bounded summary. Callers no longer receive duplicate
+  // directional issues that they immediately have to filter back out before applying policy.
   const geometricOverlapSummary = summarizeQuadratOverlaps(geometricallyValidRows);
   const overlapSummary = geometricOverlapSummary ? { ...geometricOverlapSummary, layoutSignature: createQuadratLayoutSignature(normalizedRows) } : null;
-  const overlapPairs = collectOverlappingPairs(geometricallyValidRows, MAX_REPORTED_OVERLAP_PAIRS);
 
-  for (const [first, second] of overlapPairs) {
-    issues.push({
-      kind: 'overlap',
-      rowIndex: originalIndexByGeometricRow.get(first) ?? -1,
-      quadratName: first.quadratName,
-      message: `Quadrat "${first.quadratName}" overlaps quadrat "${second.quadratName}".`
-    });
-    issues.push({
-      kind: 'overlap',
-      rowIndex: originalIndexByGeometricRow.get(second) ?? -1,
-      quadratName: second.quadratName,
-      message: `Quadrat "${second.quadratName}" overlaps quadrat "${first.quadratName}".`
-    });
-  }
-
-  return { issues, overlapSummary };
-}
-
-export function validateQuadratCollection(
-  rows: QuadratCsvRow[],
-  plot: { dimensionX: number; dimensionY: number } | null,
-  referenceCorner: QuadratReferenceCorner
-): QuadratCollectionIssue[] {
-  return validateQuadratCollectionDetailed(rows, plot, referenceCorner).issues;
+  return { fatalIssues, overlapSummary };
 }

--- a/frontend/lib/provisioning/quadrat-layout-gate.ts
+++ b/frontend/lib/provisioning/quadrat-layout-gate.ts
@@ -32,7 +32,7 @@ export function quadratLayoutIsValid(input: ProvisioningRequestInput): boolean {
   if (rows.length === 0) return false;
   // Acknowledged overlaps are valid field measurements, not layout defects (mirrors the
   // canonical schema's superRefine policy). Unacknowledged overlaps still fail the gate.
-  const { issues, overlapSummary } = validateQuadratCollectionDetailed(rows, input.plot, 'SW');
+  const { fatalIssues, overlapSummary } = validateQuadratCollectionDetailed(rows, input.plot, 'SW');
   const overlapsAcknowledged = overlapSummary !== null && acknowledgmentCoversLayout(csvQuadrats.overlapAcknowledgment, overlapSummary.layoutSignature);
-  return issues.filter(issue => !(issue.kind === 'overlap' && overlapsAcknowledged)).length === 0;
+  return fatalIssues.length === 0 && (overlapSummary === null || overlapsAcknowledged);
 }

--- a/frontend/lib/provisioning/steps/validate-inputs.ts
+++ b/frontend/lib/provisioning/steps/validate-inputs.ts
@@ -72,9 +72,11 @@ export const validateInputsStep: ProvisioningStep = {
       const validation = validateQuadratCollectionDetailed(input.quadrats.rows, input.plot, 'SW');
       const overlapsAcknowledged =
         validation.overlapSummary !== null && acknowledgmentCoversLayout(input.quadrats.overlapAcknowledgment, validation.overlapSummary.layoutSignature);
-      const issues = validation.issues.filter(issue => !(issue.kind === 'overlap' && overlapsAcknowledged));
-      if (issues.length > 0) {
-        throw new ProvisioningError(issues[0].message, 'invalid_input', { stepKey: 'validate_inputs' });
+      if (validation.fatalIssues.length > 0) {
+        throw new ProvisioningError(validation.fatalIssues[0].message, 'invalid_input', { stepKey: 'validate_inputs' });
+      }
+      if (validation.overlapSummary && !overlapsAcknowledged) {
+        throw new ProvisioningError(validation.overlapSummary.pairs[0].message, 'invalid_input', { stepKey: 'validate_inputs' });
       }
     }
   }

--- a/frontend/tests/integration/quadrat-upload-geometry.integration.test.ts
+++ b/frontend/tests/integration/quadrat-upload-geometry.integration.test.ts
@@ -120,7 +120,7 @@ import { POST } from '@/app/api/sqlpacketload/route';
 function buildQuadratUploadRequest(body: Record<string, unknown>) {
   return new Request('http://localhost/api/sqlpacketload', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-upload-session-id': 'quadrat-geometry-integration-session' },
     body: JSON.stringify(body)
   }) as any;
 }
@@ -296,18 +296,28 @@ describe('Quadrat upload geometry enforcement (server write boundary)', () => {
       )
     ))!;
 
-    expect(res.status, 'acknowledged overlaps must commit').toBe(HTTP_OK);
+    const responsePayload = await res.clone().json();
+    expect(res.status, `acknowledged overlaps must commit: ${JSON.stringify(responsePayload)}`).toBe(HTTP_OK);
     expect(await findQuadratByName(connection, plotID, 'ACKA')).not.toBeNull();
     expect(await findQuadratByName(connection, plotID, 'ACKB')).not.toBeNull();
 
-    const [changelogRows] = await connection.query<RowDataPacket[]>(
+    const [fileUploadRows] = await connection.query<RowDataPacket[]>(
       `SELECT NewRowState FROM unifiedchangelog WHERE TableName = 'file_upload' AND RecordID = 'quadrats.csv' ORDER BY ChangeID DESC LIMIT 1`
     );
-    expect(changelogRows.length, 'the file_upload changelog entry must exist').toBe(1);
-    const metadata = typeof changelogRows[0].NewRowState === 'string' ? JSON.parse(changelogRows[0].NewRowState) : changelogRows[0].NewRowState;
-    expect(metadata.overlapAcknowledgment.statement).toBe(QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT);
-    expect(metadata.overlapAcknowledgment.summaries[0].pairs.some((pair: { message: string }) => pair.message.includes('ACKA'))).toBe(true);
-    expect(metadata.overlapAcknowledgment.acknowledgedBy).toBeDefined();
+    expect(fileUploadRows.length, 'the file_upload changelog entry must exist').toBe(1);
+    const fileUploadMetadata = typeof fileUploadRows[0].NewRowState === 'string' ? JSON.parse(fileUploadRows[0].NewRowState) : fileUploadRows[0].NewRowState;
+    expect(fileUploadMetadata).not.toHaveProperty('overlapAcknowledgment');
+
+    const [acknowledgmentRows] = await connection.query<RowDataPacket[]>(
+      `SELECT NewRowState FROM unifiedchangelog
+       WHERE TableName = 'quadrat_overlap_acknowledgment' AND Operation = 'INSERT'
+       ORDER BY ChangeID DESC LIMIT 1`
+    );
+    expect(acknowledgmentRows.length, 'the append-only acknowledgment changelog event must exist').toBe(1);
+    const event = typeof acknowledgmentRows[0].NewRowState === 'string' ? JSON.parse(acknowledgmentRows[0].NewRowState) : acknowledgmentRows[0].NewRowState;
+    expect(event.statement).toBe(QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT);
+    expect(event.summaries[0].pairs.some((pair: { message: string }) => pair.message.includes('ACKA'))).toBe(true);
+    expect(event.acknowledgedBy).toBeDefined();
   });
 
   it('rejects a row with a blank StartX with 400', async () => {
@@ -411,7 +421,8 @@ describe('Quadrat upload geometry enforcement (server write boundary)', () => {
         quadratOverlapAcknowledgment: buildQuadratOverlapAcknowledgment([signature])
       })
     ))!;
-    expect(confirmedResponse.status).toBe(HTTP_OK);
+    const confirmedPayload = await confirmedResponse.clone().json();
+    expect(confirmedResponse.status, JSON.stringify(confirmedPayload)).toBe(HTTP_OK);
     expect(await findQuadratByName(connection, plotID, 'CHALLENGE-NEW')).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- enforce one file and one request for quadrat uploads
- simplify collection validation to fatal issues plus one bounded overlap summary
- extract the quadrat write boundary from the SQL packet route
- align client and server handling of blank padding rows, missing plot dimensions, and the 10,000-row cap
- persist overlap acknowledgments as immutable `quadrat_overlap_acknowledgment` rows in `unifiedchangelog`
- centralize the overlap-acknowledgment response contract

This removes the cross-file/prefix-signature and clean-reset chunk state that made the original flow difficult to reason about. The SQL packet route is net 403 lines smaller, and the overall change is approximately net-neutral after the write boundary is moved into its own module.

## Acknowledgment provenance

Acknowledgments no longer use a read-modify-write merge into the mutable `file_upload` JSON record. Each acknowledged layout writes a distinct `Operation='INSERT'` event with a deterministic retry key. This requires no new table, migration, or provisioning change.

## Stack

This PR intentionally targets the head branch of #361 so its diff contains only the follow-up simplification. After #361 merges, this PR can be retargeted to `forestgeo-app-development`.

## Verification

- full unit suite: 3,349 passed, 4 skipped
- focused provisioning suite: 66 passed
- real-MySQL quadrat upload suite: 19 passed
- focused route/upload UI suite: 86 passed
- Prettier and `git diff --check` pass
- Graphify knowledge graph refreshed

Repository-wide `tsc --noEmit` continues to report existing test typing errors outside the files changed here.
