### PR TITLE
Fix clean re-upload census replacement; harden async job handoff

### DIFF
--- a/frontend/app/api/files/[operation]/route.test.ts
+++ b/frontend/app/api/files/[operation]/route.test.ts
@@ -287,6 +287,23 @@ describe('/api/files/[operation]', () => {
     );
   });
 
+  it('returns 400 for malformed fileRowErrors metadata', async () => {
+    const formData = new FormData();
+    const file = new File(['TreeTag\n1'], 'measurements.csv', { type: 'text/csv' });
+    formData.append('measurements.csv', file);
+    formData.append('fileRowErrors', '{not-json');
+    const request = makeRequest(
+      'http://localhost/api/files/upload?schema=forestgeo_testing&plotID=1&census=2&fileName=measurements.csv&formType=measurements',
+      { method: 'POST' }
+    ) as any;
+    request.formData = vi.fn(async () => formData);
+
+    const response = await POST(request, props('upload'));
+
+    expect(response.status).toBe(400);
+    expect(mocks.uploadValidFileAsBufferWithMetadata).not.toHaveBeenCalled();
+  });
+
   it('uploads using the sanitized filename that passed route validation', async () => {
     const formData = new FormData();
     const file = new File(['TreeTag\n1'], 'bad/name.csv', { type: 'text/csv' });

--- a/frontend/app/api/files/[operation]/route.ts
+++ b/frontend/app/api/files/[operation]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getContainerClient, uploadValidFileAsBufferWithMetadata } from '@/config/macros/azurestorage';
+import { getContainerClient, uploadValidFileAsBufferWithMetadata, type FileRowErrors } from '@/config/macros/azurestorage';
 import { BlobSASPermissions, BlobServiceClient, generateBlobSASQueryParameters, StorageSharedKeyCredential } from '@azure/storage-blob';
 import { HTTPResponses } from '@/config/macros';
 import ailogger from '@/ailogger';
@@ -173,7 +173,17 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
 
   const { fileName, formType, sourceFormat } = params;
   const file = formData.get(fileName ?? 'file') as File | null;
-  const fileRowErrors = formData.get('fileRowErrors') ? JSON.parse(formData.get('fileRowErrors') as string) : [];
+  let fileRowErrors: FileRowErrors[] = [];
+  const rawFileRowErrors = formData.get('fileRowErrors');
+  if (rawFileRowErrors !== null) {
+    try {
+      const parsedFileRowErrors = JSON.parse(String(rawFileRowErrors));
+      if (!Array.isArray(parsedFileRowErrors)) throw new Error('fileRowErrors must be an array');
+      fileRowErrors = parsedFileRowErrors as FileRowErrors[];
+    } catch {
+      return new NextResponse(JSON.stringify({ error: 'fileRowErrors must be a valid JSON array' }), { status: HTTPResponses.INVALID_REQUEST });
+    }
+  }
 
   // Validate required parameters for upload
   if (!file || !fileName || !formType) {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -174,6 +174,38 @@ function makeFixedDataRequest(
   return req;
 }
 
+/**
+ * Primes the measurement-staging query mocks by STATEMENT rather than by call
+ * order.
+ *
+ * The previous form was a fixed .mockResolvedValueOnce chain, which encoded the
+ * exact number and sequence of queries the staging path happened to issue. Any
+ * change to that pipeline — for instance clean re-upload dropping its
+ * uploadmetrics enumeration query — shifted every later mock by one, handing
+ * `undefined` to a downstream call and surfacing as an unrelated 500. Keying on
+ * the SQL keeps these tests about the behaviour they name.
+ */
+function primeMeasurementQueries(manager: any, options: { stagedRowsAfterInsert?: number } = {}): void {
+  // insertedCount is measured as the staged-row delta across the INSERT(s).
+  // stagedRowsAfterInsert lets a chunk-splitting test declare the post-insert
+  // total without depending on how many INSERT statements it was split into.
+  const stagedRowsAfterInsert = options.stagedRowsAfterInsert ?? 1;
+  let insertSeen = false;
+  manager.executeQuery.mockImplementation(async (sql: string) => {
+    const text = String(sql);
+    if (text.includes('SELECT PlotID')) return [{ PlotID: TEST_PLOT_ID }];
+    if (text.includes('distinctPlotCount')) return [{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }];
+    if (text.includes('COUNT(') && text.includes('temporarymeasurements')) return [{ count: insertSeen ? stagedRowsAfterInsert : 0 }];
+    if (text.includes('COUNT(')) return [{ count: 0 }];
+    if (text.trimStart().toUpperCase().startsWith('DELETE')) return { affectedRows: 0 };
+    if (text.trimStart().toUpperCase().startsWith('INSERT')) {
+      if (text.includes('temporarymeasurements')) insertSeen = true;
+      return { affectedRows: 1, insertId: 1 };
+    }
+    return [];
+  });
+}
+
 describe('sqlpacketload measurement scope validation', () => {
   let mockConnectionManager: any;
 
@@ -222,17 +254,7 @@ describe('sqlpacketload measurement scope validation', () => {
       return undefined;
     });
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeMeasurementRequest()))!;
 
@@ -271,17 +293,7 @@ describe('sqlpacketload measurement scope validation', () => {
   });
 
   it('accepts valid scope and inserts temporary rows using the resolved plot/census IDs', async () => {
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeMeasurementRequest()))!;
 
@@ -333,18 +345,7 @@ describe('sqlpacketload measurement scope validation', () => {
       ])
     );
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1001 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager, { stagedRowsAfterInsert: 1001 });
 
     const res = (await POST(makeMeasurementRequest({ fileRowSet: largeRowSet })))!;
 
@@ -361,17 +362,7 @@ describe('sqlpacketload measurement scope validation', () => {
   });
 
   it('cleans up stale temporarymeasurements rows from older batches before starting a new batch', async () => {
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 10605 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeMeasurementRequest()))!;
 
@@ -384,36 +375,8 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(cleanupCall[1]).toEqual([TEST_FILE_NAME, TEST_PLOT_ID, TEST_CENSUS_ID, TEST_BATCH_ID]);
   });
 
-  it('cleans up previous census upload data and allows clean re-upload even when the filename changed', async () => {
-    mockConnectionManager.executeQuery
-      // census scope check
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      // batch scope check
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      // SourceFormat column exists
-      .mockResolvedValueOnce([{ count: 1 }])
-      // pre-insert count
-      .mockResolvedValueOnce([{ count: 0 }])
-      // cleanupPreviousFileUploads: find old batches
-      .mockResolvedValueOnce([{ batchID: 'completed-batch-1' }])
-      // cleanupPreviousFileUploads: delete measurement_error_log
-      .mockResolvedValueOnce({ affectedRows: 5 })
-      // cleanupPreviousFileUploads: delete coremeasurements
-      .mockResolvedValueOnce({ affectedRows: 131 })
-      // cleanupPreviousFileUploads: delete failedmeasurements
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      // cleanupPreviousFileUploads: delete uploadmetrics
-      .mockResolvedValueOnce({ affectedRows: 1 })
-      // cleanupStaleMeasurementBatchesForFile
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      // insert temporary measurements
-      .mockResolvedValueOnce(undefined)
-      // post-insert count
-      .mockResolvedValueOnce([{ count: 1 }])
-      // changelog check
-      .mockResolvedValueOnce([])
-      // changelog insert
-      .mockResolvedValueOnce(undefined);
+  it('cleans up previous census upload data by census scope, not by filename or uploadmetrics', async () => {
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeMeasurementRequest()))!;
 
@@ -422,34 +385,38 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(body.insertedCount).toBe(1);
     expect(mockConnectionManager.commitTransaction).toHaveBeenCalledWith('tx-test');
 
-    const findOldBatchesCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('SELECT batchID FROM `forestgeo_testing`.uploadmetrics')
-    );
-    expect(findOldBatchesCall).toBeDefined();
-    expect(String(findOldBatchesCall?.[0])).toContain('WHERE plotID = ? AND censusID = ? AND batchID <> ?');
-    expect(String(findOldBatchesCall?.[0])).not.toContain('fileID = ?');
+    const executedSql = mockConnectionManager.executeQuery.mock.calls.map((call: any[]) => String(call[0]));
 
-    const deleteValidationErrorsCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE mel FROM `forestgeo_testing`.measurement_error_log')
-    );
-    expect(deleteValidationErrorsCall).toBeDefined();
-    expect(String(deleteValidationErrorsCall?.[0])).toContain('WHERE cm.CensusID = ? AND cm.UploadBatchID IN');
-    expect(String(deleteValidationErrorsCall?.[0])).not.toContain('cm.UploadFileID');
+    // The cleanup must NOT enumerate victims from uploadmetrics. A sub-batch
+    // whose ingestion died before the procedure wrote its metric row has no
+    // entry there, so a metrics-driven list silently under-deletes (measured on
+    // live forestgeo_harvard: 96,227 of 106,227 rows stranded).
+    expect(executedSql.some((sql: string) => sql.includes('SELECT batchID FROM `forestgeo_testing`.uploadmetrics'))).toBe(false);
 
-    const deleteCmCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE FROM `forestgeo_testing`.coremeasurements')
-    );
+    const deleteCmCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.coremeasurements'));
     expect(deleteCmCall).toBeDefined();
-    expect(String(deleteCmCall?.[0])).toContain('WHERE CensusID = ? AND UploadBatchID IN');
-    expect(String(deleteCmCall?.[0])).not.toContain('UploadFileID');
+    // Scoped to the census, excluding the incoming batch FAMILY.
+    expect(deleteCmCall).toContain('WHERE CensusID = ?');
+    expect(deleteCmCall).toContain('NOT (UploadBatchID <=> ?)');
+    expect(deleteCmCall).toContain('NOT (UploadBatchID LIKE ?');
+    // Census replacement, not filename replacement.
+    expect(deleteCmCall).not.toContain('UploadFileID');
+    // And never a batch id list sourced from metrics.
+    expect(deleteCmCall).not.toContain('UploadBatchID IN');
 
-    const deleteFailedCall = mockConnectionManager.executeQuery.mock.calls.find(
-      (call: any[]) =>
-        String(call[0]).includes('DELETE FROM `forestgeo_testing`.failedmeasurements') &&
-        String(call[0]).includes('WHERE CensusID = ?') &&
-        String(call[0]).includes('BatchID IN')
-    );
+    const deleteValidationErrorsCall = executedSql.find((sql: string) => sql.includes('DELETE mel FROM `forestgeo_testing`.measurement_error_log'));
+    expect(deleteValidationErrorsCall).toBeDefined();
+    expect(deleteValidationErrorsCall).toContain('WHERE cm.CensusID = ?');
+    expect(deleteValidationErrorsCall).not.toContain('cm.UploadFileID');
+
+    const deleteMetricsCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.uploadmetrics'));
+    expect(deleteMetricsCall).toBeDefined();
+    expect(deleteMetricsCall).toContain('WHERE plotID = ? AND censusID = ?');
+    expect(deleteMetricsCall).toContain('NOT (batchID <=> ?)');
+
+    const deleteFailedCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.failedmeasurements'));
     expect(deleteFailedCall).toBeDefined();
+    expect(deleteFailedCall).toContain('WHERE CensusID = ?');
   });
 
   it('skips previous-upload cleanup for measurement revisions uploads', async () => {
@@ -484,39 +451,34 @@ describe('sqlpacketload measurement scope validation', () => {
   });
 
   it('falls back past missing legacy cleanup tables during re-upload', async () => {
-    const missingError = Object.assign(new Error("Table 'forestgeo_testing.measurement_error_log' doesn't exist"), {
-      code: 'ER_NO_SUCH_TABLE'
-    });
-    const missingFailedTableError = Object.assign(new Error("Table 'forestgeo_testing.failedmeasurements' doesn't exist"), {
-      code: 'ER_NO_SUCH_TABLE'
-    });
+    const missingError: NodeJS.ErrnoException & { code?: string } = new Error("Table 'forestgeo_testing.measurement_error_log' doesn't exist");
+    (missingError as any).code = 'ER_NO_SUCH_TABLE';
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([{ batchID: 'completed-batch-1' }])
-      .mockRejectedValueOnce(missingError)
-      .mockResolvedValueOnce({ affectedRows: 5 })
-      .mockResolvedValueOnce({ affectedRows: 131 })
-      .mockRejectedValueOnce(missingFailedTableError)
-      .mockResolvedValueOnce({ affectedRows: 1 })
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    // Statement-driven: the unified error-log delete fails as missing, and the
+    // route must fall back to the legacy cmverrors delete rather than 500.
+    let stagedRowCount = 0;
+    mockConnectionManager.executeQuery.mockImplementation(async (sql: string) => {
+      const text = String(sql);
+      if (text.includes('DELETE mel FROM') && text.includes('measurement_error_log')) throw missingError;
+      if (text.includes('SELECT PlotID')) return [{ PlotID: TEST_PLOT_ID }];
+      if (text.includes('distinctPlotCount')) return [{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }];
+      if (text.includes('COUNT(') && text.includes('temporarymeasurements')) return [{ count: stagedRowCount }];
+      if (text.includes('COUNT(')) return [{ count: 0 }];
+      if (text.trimStart().toUpperCase().startsWith('DELETE')) return { affectedRows: 1 };
+      if (text.trimStart().toUpperCase().startsWith('INSERT')) {
+        if (text.includes('temporarymeasurements')) stagedRowCount += 1;
+        return { affectedRows: 1, insertId: 1 };
+      }
+      return [];
+    });
 
     const res = (await POST(makeMeasurementRequest()))!;
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({ insertedCount: 1 });
-
-    const legacyDeleteCall = mockConnectionManager.executeQuery.mock.calls.find((call: any[]) =>
-      String(call[0]).includes('DELETE e FROM `forestgeo_testing`.cmverrors')
-    );
-    expect(legacyDeleteCall).toBeDefined();
+    const executedSql = mockConnectionManager.executeQuery.mock.calls.map((call: any[]) => String(call[0]));
+    const legacyCall = executedSql.find((sql: string) => sql.includes('DELETE e FROM `forestgeo_testing`.cmverrors'));
+    expect(legacyCall).toBeDefined();
+    expect(legacyCall).toContain('WHERE cm.CensusID = ?');
   });
 
   it('logs dropped-row alert metadata with a bounded uploadId when unresolved-ingestion persistence fails twice', async () => {
@@ -553,23 +515,24 @@ describe('sqlpacketload measurement scope validation', () => {
       .mockRejectedValueOnce(new Error('first persistence failure'))
       .mockRejectedValueOnce(new Error('second persistence failure'));
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ rowOrdinal: 2, existingBatch: null }])
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    // Statement-driven, plus the dropped-row candidate the scenario needs.
+    let insertSeen = false;
+    mockConnectionManager.executeQuery.mockImplementation(async (sql: string) => {
+      const text = String(sql);
+      if (text.includes('SELECT PlotID')) return [{ PlotID: TEST_PLOT_ID }];
+      if (text.includes('distinctPlotCount')) return [{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }];
+      if (text.includes('dropped_row_candidates') && text.trimStart().toUpperCase().startsWith('SELECT')) {
+        return [{ rowOrdinal: 2, existingBatch: null }];
+      }
+      if (text.includes('COUNT(') && text.includes('temporarymeasurements')) return [{ count: insertSeen ? 1 : 0 }];
+      if (text.includes('COUNT(')) return [{ count: 0 }];
+      if (text.trimStart().toUpperCase().startsWith('DELETE')) return { affectedRows: 0 };
+      if (text.trimStart().toUpperCase().startsWith('INSERT')) {
+        if (text.includes('temporarymeasurements')) insertSeen = true;
+        return { affectedRows: 1, insertId: 1 };
+      }
+      return [];
+    });
 
     const res = (await POST(makeMeasurementRequest({ fileRowSet: twoRowSet })))!;
 
@@ -1767,17 +1730,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     // 'lx' is sourced from 'MyX'; the server must key the inserted row as `lx`, never `MyX`.
     const rawRow = { MyX: '12.5', tag: 'T1', spcode: 'abc', quadrat: 'q1', ly: '3.0', date: '2023-05-17' };
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeRawRowsRequest([rawRow])))!;
 
@@ -1799,17 +1752,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     // Missing a required field (tag empty) -> resolution classifies this as an invalid row.
     const invalidRow = { MyX: '13.0', tag: '', spcode: 'def', quadrat: 'q2', ly: '4.0', date: '2023-05-18' };
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeRawRowsRequest([validRow, invalidRow])))!;
 
@@ -1840,17 +1783,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
       __parsed_extra: ['leftover']
     } as unknown as Record<string, string>;
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeRawRowsRequest([validRow, raggedRow])))!;
 
@@ -1879,17 +1812,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     const rawRow = { MyX: '12.5', tag: 'T1', spcode: 'abc', quadrat: 'q1', ly: '3.0', date: '2023-05-17', lx: '9.9' };
     const headersWithIgnoredLx = ['MyX', 'tag', 'spcode', 'quadrat', 'ly', 'date', 'lx'];
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeRawRowsRequest([rawRow], { csvHeaders: headersWithIgnoredLx, mapping: lxRenamedMapping(headersWithIgnoredLx) })))!;
 
@@ -1901,17 +1824,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
 
   it('leaves the legacy fileRowSet path byte-identical when rawRows is absent', async () => {
     // Same shape as the existing happy-path test; no rawRows -> the new stage must not run.
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeMeasurementRequest()))!;
 
@@ -1947,18 +1860,7 @@ describe('sqlpacketload server-side CSV resolution (rawRows path)', () => {
     };
     const rawRow = { MyX: '12.5', tag: 'T1', spcode: 'abc', quadrat: 'q1', ly: '3.0', date: '2023-05-17', StemID: '5,001' };
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined) // INSERT IGNORE temporarymeasurements
-      .mockResolvedValueOnce(undefined) // INSERT uploadintegrityalerts (INVALID_PUBLISHED_STEMID)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    primeMeasurementQueries(mockConnectionManager);
 
     const res = (await POST(makeRawRowsRequest([rawRow], { csvHeaders: headersWithStemId, mapping: mappingWithPublishedStemId })))!;
 

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -19,14 +19,16 @@ const mocks = vi.hoisted(() => ({
   getSessionUserId: vi.fn(() => 'mason@example.com'),
   getSessionUserIds: vi.fn(() => ['mason@example.com', 'Mason']),
   isValidSchema: vi.fn(() => true),
-  assertCanEditMeasurementScope: vi.fn(async () => undefined),
+  assertCanEditMeasurementScope: vi.fn(async () => ({ plotCensusNumber: 2 })),
+  getContainerName: vi.fn(() => 'forestgeo-testing-storage'),
   getPoolMonitorInstance: vi.fn(() => ({ pool: 'catalog-pool' })),
   createUploadBackgroundJob: vi.fn(),
   listBackgroundJobs: vi.fn(),
   isAsyncUploadEnabledFor: vi.fn(() => true),
   runJobIfClaimable: vi.fn(async () => undefined),
   executeQuery: vi.fn(),
-  loggerError: vi.fn()
+  loggerError: vi.fn(),
+  IdempotencyKeyConflictError: class IdempotencyKeyConflictError extends Error {}
 }));
 
 vi.mock('@/auth', () => ({
@@ -61,6 +63,15 @@ vi.mock('@/lib/db/poolmonitorsingleton', () => ({
 vi.mock('@/lib/background-jobs/repository', () => ({
   createUploadBackgroundJob: mocks.createUploadBackgroundJob,
   listBackgroundJobs: mocks.listBackgroundJobs
+}));
+
+vi.mock('@/lib/background-jobs/errors', () => ({
+  IdempotencyKeyConflictError: mocks.IdempotencyKeyConflictError
+}));
+
+vi.mock('@/config/macros/containernames', () => ({
+  getContainerName: mocks.getContainerName,
+  SchemaContainerNameError: class SchemaContainerNameError extends Error {}
 }));
 
 vi.mock('@/lib/background-jobs/feature-gate', () => ({
@@ -322,6 +333,38 @@ describe('POST /api/uploadjobs', () => {
     expect(mocks.runJobIfClaimable).not.toHaveBeenCalled();
   });
 
+  it('rejects a client-selected blob container outside the authorized plot/census scope', async () => {
+    const response = await callPost(makeCreateRequest(makeCreateBody({ files: [{ ...makeCreateBody().files[0], blobContainer: 'other-site' }] })));
+
+    expect(response.status).toBe(403);
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate file names before batch bookkeeping can collide', async () => {
+    const file = makeCreateBody().files[0];
+    const response = await callPost(makeCreateRequest(makeCreateBody({ files: [file, { ...file, blobName: 'uploads/job-1/copy.csv' }] })));
+
+    expect(response.status).toBe(400);
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 100 files', async () => {
+    const file = makeCreateBody().files[0];
+    const files = Array.from({ length: 101 }, (_, index) => ({ ...file, fileName: `file-${index}.csv`, blobName: `uploads/file-${index}.csv` }));
+    const response = await callPost(makeCreateRequest(makeCreateBody({ files })));
+
+    expect(response.status).toBe(400);
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when an idempotency key belongs to a different request', async () => {
+    mocks.createUploadBackgroundJob.mockRejectedValueOnce(new mocks.IdempotencyKeyConflictError('conflict'));
+    const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+    expect(response.status).toBe(409);
+    expect(mocks.runJobIfClaimable).not.toHaveBeenCalled();
+  });
+
   it('rejects arcgis_xlsx jobs that are missing the pre-flight import session', async () => {
     const response = await callPost(
       makeCreateRequest(
@@ -343,6 +386,7 @@ describe('POST /api/uploadjobs', () => {
       makeCreateRequest(
         makeCreateBody({
           sourceFormat: 'arcgis_xlsx',
+          files: [{ ...makeCreateBody().files[0], fileName: 'survey.xlsx', blobName: 'survey.xlsx', sourceFormat: 'arcgis_xlsx' }],
           payload: {
             arcgisImportSession: { importSessionId: 'import-1', fileName: 'survey.xlsx', rowCount: 100 }
           }
@@ -352,6 +396,25 @@ describe('POST /api/uploadjobs', () => {
 
     expect(response.status).toBe(202);
     expect(mocks.runJobIfClaimable).toHaveBeenCalledWith(42);
+  });
+
+  it('rejects an ArcGIS job with more than one file', async () => {
+    const file = makeCreateBody().files[0];
+    const response = await callPost(
+      makeCreateRequest(
+        makeCreateBody({
+          sourceFormat: 'arcgis_xlsx',
+          files: [
+            { ...file, fileName: 'survey.xlsx', blobName: 'survey.xlsx', sourceFormat: 'arcgis_xlsx' },
+            { ...file, fileName: 'other.xlsx', blobName: 'other.xlsx', sourceFormat: 'arcgis_xlsx' }
+          ],
+          payload: { arcgisImportSession: { importSessionId: 'import-1', fileName: 'survey.xlsx', rowCount: 100 } }
+        })
+      )
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
   });
 });
 
@@ -410,5 +473,19 @@ describe('GET /api/uploadjobs', () => {
     expect(response.status).toBe(403);
     expect(mocks.listBackgroundJobs).not.toHaveBeenCalled();
     expect(mocks.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed numeric filters instead of silently broadening the list', async () => {
+    const response = await callGet(makeListRequest('?schema=forestgeo_testing&plotID=not-a-number'));
+
+    expect(response.status).toBe(400);
+    expect(mocks.listBackgroundJobs).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed boolean filters', async () => {
+    const response = await callGet(makeListRequest('?schema=forestgeo_testing&activeOnly=0'));
+
+    expect(response.status).toBe(400);
+    expect(mocks.listBackgroundJobs).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -14,14 +14,20 @@ import { SUPPORTED_DELIMITERS } from '@/lib/uploads/detect-delimiter';
 import { isAsyncUploadEnabledFor } from '@/lib/background-jobs/feature-gate';
 import { isAllowedAsyncPipeline } from '@/lib/background-jobs/types';
 import { createUploadBackgroundJob, listBackgroundJobs } from '@/lib/background-jobs/repository';
+import { IdempotencyKeyConflictError } from '@/lib/background-jobs/errors';
 import { isPrivilegedSession, parseOptionalPositiveInteger } from '@/lib/background-jobs/route-helpers';
 import { runJobIfClaimable } from '@/lib/background-jobs/worker';
 import { fromBody, fromQuery, withRouteAuthz } from '@/lib/route-authz';
+import { getContainerName, SchemaContainerNameError } from '@/config/macros/containernames';
 import ailogger from '@/ailogger';
 
 export const runtime = 'nodejs';
 
 const ASYNC_UPLOADS_DISABLED_MESSAGE = 'Async uploads are not enabled for this form/site/user';
+const MAX_UPLOAD_JOB_FILES = 100;
+const MAX_UPLOAD_JOB_PAYLOAD_BYTES = 1024 * 1024;
+const MAX_UPLOAD_FILE_BYTES = 100 * 1024 * 1024;
+const MYSQL_SIGNED_INT_MAX = 2_147_483_647;
 
 const SUPPORTED_DELIMITER_SET = new Set<string>(SUPPORTED_DELIMITERS);
 
@@ -64,7 +70,7 @@ const UploadJobFileSchema = z.object({
   blobContainer: z.string().trim().min(1).max(255),
   blobName: z.string().trim().min(1).max(1024),
   contentType: z.string().trim().max(255).nullable().optional(),
-  byteSize: z.number().int().nonnegative().nullable().optional(),
+  byteSize: z.number().int().nonnegative().max(MAX_UPLOAD_FILE_BYTES).nullable().optional(),
   checksumSha256: z
     .string()
     .trim()
@@ -73,13 +79,13 @@ const UploadJobFileSchema = z.object({
     .optional(),
   sourceFormat: z.enum(SourceFormat).nullable().optional(),
   formType: z.enum(FormType).nullable().optional(),
-  expectedRows: z.number().int().nonnegative().nullable().optional()
+  expectedRows: z.number().int().nonnegative().max(MYSQL_SIGNED_INT_MAX).nullable().optional()
 });
 
 const ArcgisImportSessionSchema = z.object({
-  importSessionId: z.string().trim().min(1),
-  fileName: z.string().trim().min(1),
-  rowCount: z.number().int().nonnegative()
+  importSessionId: z.string().trim().min(1).max(255),
+  fileName: z.string().trim().min(1).max(512),
+  rowCount: z.number().int().nonnegative().max(MYSQL_SIGNED_INT_MAX)
 });
 
 const UploadJobPayloadSchema = z.record(z.string(), z.unknown()).superRefine((payload, ctx) => {
@@ -105,19 +111,68 @@ const CreateUploadJobSchema = z
       .optional(),
     sourceFormat: z.enum(SourceFormat),
     formType: z.enum(FormType),
-    idempotencyKey: z.string().trim().max(255).nullable().optional(),
+    idempotencyKey: z.string().trim().min(1).max(255).nullable().optional(),
     payload: UploadJobPayloadSchema.optional(),
-    files: z.array(UploadJobFileSchema).min(1)
+    files: z.array(UploadJobFileSchema).min(1).max(MAX_UPLOAD_JOB_FILES)
   })
   .superRefine((input, ctx) => {
-    if (input.sourceFormat !== SourceFormat.arcgis_xlsx) return;
-    const arcgisSession = ArcgisImportSessionSchema.safeParse(input.payload?.arcgisImportSession);
-    if (!arcgisSession.success) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['payload', 'arcgisImportSession'],
-        message: 'ArcGIS uploads require payload.arcgisImportSession with importSessionId, fileName, and rowCount'
-      });
+    const fileNames = new Set<string>();
+    const blobIdentities = new Set<string>();
+    let expectedRowTotal = 0;
+    for (const [index, file] of input.files.entries()) {
+      const normalizedFileName = file.fileName.toLowerCase();
+      if (fileNames.has(normalizedFileName)) {
+        ctx.addIssue({ code: 'custom', path: ['files', index, 'fileName'], message: 'File names must be unique within an upload job' });
+      }
+      fileNames.add(normalizedFileName);
+
+      const blobIdentity = `${file.blobContainer.toLowerCase()}\n${file.blobName.toLowerCase()}`;
+      if (blobIdentities.has(blobIdentity)) {
+        ctx.addIssue({ code: 'custom', path: ['files', index, 'blobName'], message: 'Blob references must be unique within an upload job' });
+      }
+      blobIdentities.add(blobIdentity);
+
+      if (file.formType !== undefined && file.formType !== null && file.formType !== input.formType) {
+        ctx.addIssue({ code: 'custom', path: ['files', index, 'formType'], message: 'Per-file formType must match the job formType' });
+      }
+      if (file.sourceFormat !== undefined && file.sourceFormat !== null && file.sourceFormat !== input.sourceFormat) {
+        ctx.addIssue({ code: 'custom', path: ['files', index, 'sourceFormat'], message: 'Per-file sourceFormat must match the job sourceFormat' });
+      }
+      expectedRowTotal += file.expectedRows ?? 0;
+    }
+    if (expectedRowTotal > MYSQL_SIGNED_INT_MAX) {
+      ctx.addIssue({ code: 'custom', path: ['files'], message: 'Combined expectedRows exceeds the supported job total' });
+    }
+
+    if (Buffer.byteLength(JSON.stringify(input.payload ?? {}), 'utf8') > MAX_UPLOAD_JOB_PAYLOAD_BYTES) {
+      ctx.addIssue({ code: 'custom', path: ['payload'], message: 'Upload job payload exceeds the 1 MiB limit' });
+    }
+
+    for (const payloadKey of ['columnMappings', 'selectedDelimiters'] as const) {
+      const record = input.payload?.[payloadKey];
+      if (!isPlainRecord(record)) continue;
+      for (const fileName of Object.keys(record)) {
+        if (!fileNames.has(fileName.toLowerCase())) {
+          ctx.addIssue({ code: 'custom', path: ['payload', payloadKey, fileName], message: `${payloadKey} contains an unknown file name` });
+        }
+      }
+    }
+
+    if (input.sourceFormat === SourceFormat.arcgis_xlsx) {
+      const arcgisSession = ArcgisImportSessionSchema.safeParse(input.payload?.arcgisImportSession);
+      if (!arcgisSession.success) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['payload', 'arcgisImportSession'],
+          message: 'ArcGIS uploads require payload.arcgisImportSession with importSessionId, fileName, and rowCount'
+        });
+      } else if (input.files.length !== 1 || input.files[0]?.fileName !== arcgisSession.data.fileName) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['files'],
+          message: 'ArcGIS uploads require exactly one file matching payload.arcgisImportSession.fileName'
+        });
+      }
     }
   });
 
@@ -159,8 +214,9 @@ async function postHandler(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid schema' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
+  let authorizedScope: { plotCensusNumber: number };
   try {
-    await assertCanEditMeasurementScope(ConnectionManager.getInstance(), session!, {
+    authorizedScope = await assertCanEditMeasurementScope(ConnectionManager.getInstance(), session!, {
       schema: input.schema,
       plotID: input.plotID,
       censusID: input.censusID
@@ -190,22 +246,43 @@ async function postHandler(request: NextRequest) {
     );
   }
 
+  let authorizedContainer: string;
+  try {
+    authorizedContainer = getContainerName(input.schema, input.plotID, authorizedScope.plotCensusNumber);
+  } catch (error) {
+    if (error instanceof SchemaContainerNameError) {
+      return NextResponse.json({ error: error.message }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+    throw error;
+  }
+  if (input.files.some(file => file.blobContainer.toLowerCase() !== authorizedContainer.toLowerCase())) {
+    return NextResponse.json({ error: 'Blob container does not match the authorized upload scope' }, { status: HTTPResponses.FORBIDDEN });
+  }
+
   const catalogPool = getPoolMonitorInstance().pool;
-  const job = await createUploadBackgroundJob(
-    catalogPool,
-    {
-      schema: input.schema,
-      plotID: input.plotID,
-      censusID: input.censusID,
-      uploadMode: input.uploadMode ?? null,
-      sourceFormat: input.sourceFormat,
-      formType: input.formType,
-      idempotencyKey: input.idempotencyKey ?? null,
-      payload: input.payload,
-      files: input.files
-    },
-    userID
-  );
+  let job;
+  try {
+    job = await createUploadBackgroundJob(
+      catalogPool,
+      {
+        schema: input.schema,
+        plotID: input.plotID,
+        censusID: input.censusID,
+        uploadMode: input.uploadMode ?? null,
+        sourceFormat: input.sourceFormat,
+        formType: input.formType,
+        idempotencyKey: input.idempotencyKey ?? null,
+        payload: input.payload,
+        files: input.files
+      },
+      userID
+    );
+  } catch (error) {
+    if (error instanceof IdempotencyKeyConflictError) {
+      return NextResponse.json({ error: error.message }, { status: HTTPResponses.CONFLICT });
+    }
+    throw error;
+  }
 
   // Kick-on-create: start the worker without awaiting it. runJobIfClaimable is
   // designed to never throw for job-level failures, but a claim-time
@@ -233,11 +310,26 @@ async function getHandler(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid schema' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const plotID = parseOptionalPositiveInteger(searchParams.get('plotID'));
-  const censusID = parseOptionalPositiveInteger(searchParams.get('censusID'));
-  const activeOnly = searchParams.get('activeOnly') !== 'false';
-  const includeAllUsers = searchParams.get('allUsers') === 'true' && isPrivilegedSession(session!);
-  const limit = parseOptionalPositiveInteger(searchParams.get('limit'));
+  const rawPlotID = searchParams.get('plotID');
+  const rawCensusID = searchParams.get('censusID');
+  const rawLimit = searchParams.get('limit');
+  const plotID = parseOptionalPositiveInteger(rawPlotID);
+  const censusID = parseOptionalPositiveInteger(rawCensusID);
+  const limit = parseOptionalPositiveInteger(rawLimit);
+  if ((rawPlotID !== null && plotID === undefined) || (rawCensusID !== null && censusID === undefined) || (rawLimit !== null && limit === undefined)) {
+    return NextResponse.json({ error: 'plotID, censusID, and limit must be positive integers when provided' }, { status: HTTPResponses.INVALID_REQUEST });
+  }
+
+  const rawActiveOnly = searchParams.get('activeOnly');
+  const rawAllUsers = searchParams.get('allUsers');
+  if (
+    (rawActiveOnly !== null && rawActiveOnly !== 'true' && rawActiveOnly !== 'false') ||
+    (rawAllUsers !== null && rawAllUsers !== 'true' && rawAllUsers !== 'false')
+  ) {
+    return NextResponse.json({ error: 'activeOnly and allUsers must be true or false when provided' }, { status: HTTPResponses.INVALID_REQUEST });
+  }
+  const activeOnly = rawActiveOnly !== 'false';
+  const includeAllUsers = rawAllUsers === 'true' && isPrivilegedSession(session!);
 
   const jobs = await listBackgroundJobs(getPoolMonitorInstance().pool, {
     userID,

--- a/frontend/components/client/uploadjobstatusbadge.test.ts
+++ b/frontend/components/client/uploadjobstatusbadge.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { selectVisibleJobs, type UploadJobSummary } from './uploadjobstatusbadge';
+
+const NOW = Date.parse('2026-07-28T12:00:00.000Z');
+
+function job(status: string, updatedAt: string): UploadJobSummary {
+  return {
+    jobID: 1,
+    status,
+    phase: status,
+    percentComplete: 0,
+    totalFiles: 1,
+    processedRows: 0,
+    failedRows: 0,
+    lastError: null,
+    updatedAt
+  };
+}
+
+describe('selectVisibleJobs', () => {
+  it('keeps active jobs regardless of age and recent terminal outcomes', () => {
+    const visible = selectVisibleJobs(
+      [
+        job('running', '2020-01-01T00:00:00.000Z'),
+        job('failed', '2026-07-28T11:00:00.000Z'),
+        job('completed', '2026-07-28T10:00:00.000Z'),
+        job('cancelled', '2026-07-26T10:00:00.000Z'),
+        job('unknown', '2026-07-28T11:00:00.000Z')
+      ],
+      NOW
+    );
+
+    expect(visible.map(entry => entry.status)).toEqual(['running', 'failed', 'completed']);
+  });
+});

--- a/frontend/components/client/uploadjobstatusbadge.tsx
+++ b/frontend/components/client/uploadjobstatusbadge.tsx
@@ -7,10 +7,13 @@ import ErrorOutline from '@mui/icons-material/ErrorOutline';
 import ailogger from '@/ailogger';
 
 const JOB_POLL_INTERVAL_MS = 10_000;
+const TERMINAL_JOB_VISIBILITY_MS = 24 * 60 * 60 * 1000;
 
 const CANCELLABLE_JOB_STATUSES = new Set(['queued', 'running', 'waiting_retry']);
+const ACTIVE_JOB_STATUSES = new Set(['queued', 'running', 'cancel_requested', 'waiting_retry']);
+const TERMINAL_JOB_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-interface UploadJobSummary {
+export interface UploadJobSummary {
   jobID: number;
   status: string;
   phase: string;
@@ -19,6 +22,16 @@ interface UploadJobSummary {
   processedRows: number;
   failedRows: number;
   lastError: string | null;
+  updatedAt: string;
+}
+
+export function selectVisibleJobs(jobs: UploadJobSummary[], nowMs: number = Date.now()): UploadJobSummary[] {
+  return jobs.filter(job => {
+    if (ACTIVE_JOB_STATUSES.has(job.status)) return true;
+    if (!TERMINAL_JOB_STATUSES.has(job.status)) return false;
+    const updatedAtMs = new Date(job.updatedAt).getTime();
+    return Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= TERMINAL_JOB_VISIBILITY_MS;
+  });
 }
 
 function formatPhase(phase: string): string {
@@ -90,23 +103,30 @@ export default function UploadJobStatusBadge({ schema, plotID, censusID }: { sch
     }
 
     let cancelled = false;
+    let requestInFlight = false;
     const schemaName = schema;
 
     async function fetchJobs() {
+      if (requestInFlight) return;
+      requestInFlight = true;
       try {
         const params = new URLSearchParams({
           schema: schemaName,
           plotID: String(plotID),
-          censusID: String(censusID)
+          censusID: String(censusID),
+          activeOnly: 'false',
+          limit: '25'
         });
         const response = await fetch(`/api/uploadjobs?${params.toString()}`);
         if (!response.ok) return;
         const payload = (await response.json()) as { jobs?: UploadJobSummary[] };
         if (!cancelled) {
-          setJobs(payload.jobs ?? []);
+          setJobs(selectVisibleJobs(payload.jobs ?? []));
         }
       } catch (error) {
         ailogger.warn('[UploadJobStatusBadge] Failed to poll upload jobs:', error instanceof Error ? error : new Error(String(error)));
+      } finally {
+        requestInFlight = false;
       }
     }
 
@@ -161,7 +181,7 @@ export default function UploadJobStatusBadge({ schema, plotID, censusID }: { sch
               Upload job {primaryJob.jobID}: {describeJobStatus(primaryJob.status) ?? formatPhase(primaryJob.phase)}
             </Typography>
             <Chip variant="soft" color={color} size="sm">
-              {jobs.length} active
+              {jobs.length} recent
             </Chip>
             <Typography level="body-xs">{progressValue}%</Typography>
           </Stack>

--- a/frontend/components/uploadsystem/segments/uploadasyncjob.test.ts
+++ b/frontend/components/uploadsystem/segments/uploadasyncjob.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ailogger from '@/ailogger';
+import { cleanupUploadedFiles, type BlobUploadResult } from './uploadasyncjob';
+
+vi.mock('@/ailogger', () => ({
+  default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
+}));
+
+const file: BlobUploadResult = {
+  fileName: 'measurements.csv',
+  blobContainer: 'forestgeo-testing-plot1-census2',
+  blobName: 'measurements_1.csv',
+  contentType: 'text/csv',
+  byteSize: 10,
+  formType: 'measurements',
+  sourceFormat: 'csv'
+};
+
+describe('cleanupUploadedFiles', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('deletes every blob from the authorized storage scope', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await cleanupUploadedFiles([file], { schema: 'forestgeo_testing', plotID: 1, plotCensusNumber: 2 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(String(url)).toContain('/api/files/delete?');
+    expect(String(url)).toContain('filename=measurements_1.csv');
+    expect(String(url)).toContain('container=forestgeo-testing-plot1-census2');
+    expect(init).toEqual({ method: 'DELETE' });
+  });
+
+  it('logs cleanup failures without masking the original upload error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 500 }))
+    );
+
+    await expect(cleanupUploadedFiles([file], { schema: 'forestgeo_testing', plotID: 1, plotCensusNumber: 2 })).resolves.toBeUndefined();
+    expect(ailogger.warn).toHaveBeenCalled();
+  });
+});

--- a/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
+++ b/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
@@ -13,7 +13,7 @@ import type { ArcgisImportReference } from '@/lib/arcgis/types';
 import type { ColumnMapping } from '@/lib/column-mapping/types';
 import ailogger from '@/ailogger';
 
-interface BlobUploadResult {
+export interface BlobUploadResult {
   fileName: string;
   blobContainer: string;
   blobName: string;
@@ -21,6 +21,12 @@ interface BlobUploadResult {
   byteSize: number;
   formType: string;
   sourceFormat: string;
+}
+
+export interface UploadStorageScope {
+  schema: string;
+  plotID: number;
+  plotCensusNumber: number;
 }
 
 interface UploadJobResponse {
@@ -75,6 +81,34 @@ async function readErrorMessage(response: Response): Promise<string> {
   }
 }
 
+export async function cleanupUploadedFiles(files: BlobUploadResult[], scope: UploadStorageScope): Promise<void> {
+  const results = await Promise.allSettled(
+    files.map(file => {
+      const params = new URLSearchParams({
+        schema: scope.schema,
+        plotID: String(scope.plotID),
+        census: String(scope.plotCensusNumber),
+        container: file.blobContainer,
+        filename: file.blobName
+      });
+      return fetch(`/api/files/delete?${params.toString()}`, { method: 'DELETE' }).then(response => {
+        if (!response.ok && response.status !== 404) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+      });
+    })
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      ailogger.warn(
+        `[UploadAsyncJob] Failed to clean uploaded blob ${files[index].blobName}:`,
+        result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+      );
+    }
+  });
+}
+
 export default function UploadAsyncJob({
   acceptedFiles,
   parsedData,
@@ -106,6 +140,9 @@ export default function UploadAsyncJob({
     let cancelled = false;
 
     async function runAsyncUpload() {
+      const uploadedFiles: BlobUploadResult[] = [];
+      let cleanupAllowed = true;
+      let cleanupScope: UploadStorageScope | null = null;
       try {
         const schema = currentSite?.schemaName;
         const plotID = currentPlot?.plotID;
@@ -118,7 +155,7 @@ export default function UploadAsyncJob({
           throw new Error('Missing required context for async upload job');
         }
 
-        const uploadedFiles: BlobUploadResult[] = [];
+        cleanupScope = { schema, plotID, plotCensusNumber };
         const totalSteps = acceptedFiles.length + 1;
 
         for (let index = 0; index < acceptedFiles.length; index++) {
@@ -155,6 +192,10 @@ export default function UploadAsyncJob({
         if (cancelled) return;
         setCurrentStep('Queueing background processing job...');
 
+        // Once the queue request is on the wire, a network failure is ambiguous:
+        // the server may already have committed the job. Do not delete blobs in
+        // that case; an accepted worker could be reading them.
+        cleanupAllowed = false;
         const jobResponse = await fetch('/api/uploadjobs', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -192,6 +233,8 @@ export default function UploadAsyncJob({
         // kicks the worker immediately, so processing may already be running.
         const jobPayload = (await jobResponse.json().catch(() => ({}))) as UploadJobResponse;
         if (!jobResponse.ok || !jobPayload.job?.jobID) {
+          // A definitive HTTP rejection means no job owns these blobs.
+          cleanupAllowed = !jobResponse.ok;
           throw new Error(jobPayload.error || jobPayload.details || `Failed to queue background upload job: HTTP ${jobResponse.status}`);
         }
 
@@ -205,6 +248,10 @@ export default function UploadAsyncJob({
         setUploadError(err);
         setErrorComponent('UploadAsyncJob');
         setReviewState(ReviewStates.ERRORS);
+      } finally {
+        if (cleanupAllowed && cleanupScope && uploadedFiles.length > 0) {
+          await cleanupUploadedFiles(uploadedFiles, cleanupScope);
+        }
       }
     }
 

--- a/frontend/config/editplan/scopeguard.test.ts
+++ b/frontend/config/editplan/scopeguard.test.ts
@@ -45,7 +45,7 @@ describe('assertCanEditMeasurementScope', () => {
 
   it('allows global users after the plot/census existence check passes', async () => {
     const cm = makeConnectionManager();
-    cm.executeQuery.mockResolvedValueOnce([{ ok: 1 }]);
+    cm.executeQuery.mockResolvedValueOnce([{ PlotCensusNumber: 7 }]);
 
     await expect(
       assertCanEditMeasurementScope(cm, makeSession({ userStatus: 'global', sites: [] }), {
@@ -53,7 +53,7 @@ describe('assertCanEditMeasurementScope', () => {
         plotID: 1,
         censusID: 2
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ plotCensusNumber: 7 });
 
     expect(cm.executeQuery).toHaveBeenCalledTimes(1);
     expect(cm.executeQuery.mock.calls[0][0]).toContain('FROM `forestgeo_testing`.census');
@@ -62,6 +62,19 @@ describe('assertCanEditMeasurementScope', () => {
   it('rejects unavailable plot/census scopes', async () => {
     const cm = makeConnectionManager();
     cm.executeQuery.mockResolvedValueOnce([]);
+
+    await expect(
+      assertCanEditMeasurementScope(cm, makeSession(), {
+        schema: 'forestgeo_testing',
+        plotID: 1,
+        censusID: 2
+      })
+    ).rejects.toBeInstanceOf(ScopeAccessError);
+  });
+
+  it('rejects a census row whose storage census number is invalid', async () => {
+    const cm = makeConnectionManager();
+    cm.executeQuery.mockResolvedValueOnce([{ PlotCensusNumber: null }]);
 
     await expect(
       assertCanEditMeasurementScope(cm, makeSession(), {

--- a/frontend/config/editplan/scopeguard.ts
+++ b/frontend/config/editplan/scopeguard.ts
@@ -38,11 +38,11 @@ function hasSchemaAccess(session: Session, schema: string): boolean {
   return (session.user?.sites ?? []).some(site => site.schemaName === schema);
 }
 
-async function assertPlotCensusExists(cm: ConnectionManager, schema: string, plotID: number, censusID: number): Promise<void> {
+async function resolvePlotCensusNumber(cm: ConnectionManager, schema: string, plotID: number, censusID: number): Promise<number> {
   const rows = await cm.executeQuery(
     safeFormatQuery(
       schema,
-      `SELECT 1 AS ok
+      `SELECT c.PlotCensusNumber
        FROM ??.census c
        WHERE c.PlotID = ?
          AND c.CensusID = ?
@@ -55,6 +55,11 @@ async function assertPlotCensusExists(cm: ConnectionManager, schema: string, plo
   if (!Array.isArray(rows) || rows.length === 0) {
     throw new ScopeAccessError('plot/census scope is not available');
   }
+  const plotCensusNumber = Number(rows[0].PlotCensusNumber);
+  if (!Number.isSafeInteger(plotCensusNumber) || plotCensusNumber <= 0) {
+    throw new ScopeAccessError('plot/census scope has an invalid census number');
+  }
+  return plotCensusNumber;
 }
 
 async function probeActiveUploadSession(cm: ConnectionManager, schema: string, plotID: number, censusID: number, transactionID?: string): Promise<void> {
@@ -135,12 +140,16 @@ async function probeActiveValidationRun(cm: ConnectionManager, schema: string, p
  * CoreMeasurementID + CensusID + PlotID + StemGUID shape and translates a
  * missed lookup to TargetNotFoundError (→ 404).
  */
-export async function assertCanEditMeasurementScope(cm: ConnectionManager, session: Session, input: MeasurementScopeInput): Promise<void> {
+export async function assertCanEditMeasurementScope(
+  cm: ConnectionManager,
+  session: Session,
+  input: MeasurementScopeInput
+): Promise<{ plotCensusNumber: number }> {
   if (!hasSchemaAccess(session, input.schema)) {
     throw new ScopeAccessError();
   }
 
-  await assertPlotCensusExists(cm, input.schema, input.plotID, input.censusID);
+  return { plotCensusNumber: await resolvePlotCensusNumber(cm, input.schema, input.plotID, input.censusID) };
 }
 
 /**

--- a/frontend/instrumentation-node.ts
+++ b/frontend/instrumentation-node.ts
@@ -18,7 +18,7 @@
  */
 import ailogger from '@/ailogger';
 import { getPoolMonitorInstance } from '@/lib/db/poolmonitorsingleton';
-import { installUploadSweeperShutdown, startUploadJobSweeper, sweepOnce } from '@/lib/background-jobs/sweeper';
+import { installUploadSweeperShutdown, runSweepTick, startUploadJobSweeper } from '@/lib/background-jobs/sweeper';
 import { ensureCatalogTables } from '@/lib/provisioning/orchestrator';
 import { installShutdownHandler, pickupStaleRuns } from '@/lib/provisioning/worker';
 
@@ -59,9 +59,9 @@ void (async () => {
     // Both shutdown hooks (provisioning's installShutdownHandler and this one)
     // coexist via separate process.once registrations.
     installUploadSweeperShutdown();
-    const { reclaimed, dispatched } = await sweepOnce(pool);
-    if (reclaimed.length > 0 || dispatched.length > 0) {
-      ailogger.info('upload.sweeper.startup', { reclaimed, dispatched });
+    const result = await runSweepTick(pool);
+    if (result && (result.reclaimed.length > 0 || result.dispatched.length > 0)) {
+      ailogger.info('upload.sweeper.startup', result);
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/frontend/lib/background-jobs/errors.ts
+++ b/frontend/lib/background-jobs/errors.ts
@@ -18,6 +18,13 @@ export class JobFileNotFoundError extends Error {
   }
 }
 
+export class IdempotencyKeyConflictError extends Error {
+  constructor(public readonly idempotencyKey: string) {
+    super(`Idempotency key "${idempotencyKey}" was already used for a different upload job request`);
+    this.name = 'IdempotencyKeyConflictError';
+  }
+}
+
 /**
  * Thrown by the worker when a job can never succeed no matter how many times it
  * is retried (unsupported form-type routing, malformed file content, validation

--- a/frontend/lib/background-jobs/repository.ts
+++ b/frontend/lib/background-jobs/repository.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 import { ensureBackgroundJobCatalogTables } from './catalog';
-import { JobFileNotFoundError, WorkerLeaseLostError } from './errors';
+import { IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from './errors';
 import type {
   BackgroundJobEventRecord,
   BackgroundJobFileRecord,
@@ -123,6 +123,48 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
     }
   }
   return null;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function idempotentRequestMatches(existing: BackgroundJobRow, existingFiles: BackgroundJobFileRow[], input: CreateUploadJobInput): boolean {
+  if (
+    existing.SchemaName !== input.schema ||
+    Number(existing.PlotID) !== input.plotID ||
+    Number(existing.CensusID) !== input.censusID ||
+    (existing.UploadMode ?? null) !== (input.uploadMode ?? null) ||
+    (existing.SourceFormat ?? null) !== (input.sourceFormat ?? null) ||
+    (existing.FormType ?? null) !== (input.formType ?? null) ||
+    stableJson(parseJsonObject(existing.Payload)) !== stableJson(input.payload ?? null) ||
+    existingFiles.length !== input.files.length
+  ) {
+    return false;
+  }
+
+  return existingFiles.every((file, index) => {
+    const requested = input.files[index];
+    return (
+      file.FileName === requested.fileName &&
+      file.BlobContainer === requested.blobContainer &&
+      file.BlobName === requested.blobName &&
+      (file.ContentType ?? null) === (requested.contentType ?? null) &&
+      (file.ByteSize === null ? null : Number(file.ByteSize)) === (requested.byteSize ?? null) &&
+      (file.ChecksumSHA256 ?? null) === (requested.checksumSha256 ?? null) &&
+      (file.SourceFormat ?? null) === (requested.sourceFormat ?? input.sourceFormat ?? null) &&
+      (file.FormType ?? null) === (requested.formType ?? input.formType ?? null) &&
+      (file.ExpectedRows === null ? null : Number(file.ExpectedRows)) === (requested.expectedRows ?? null)
+    );
+  });
 }
 
 function toDate(value: unknown): Date | null {
@@ -267,7 +309,16 @@ export async function createUploadBackgroundJob(catalogPool: Pool, input: Create
           `SELECT * FROM catalog.background_jobs WHERE CreatedBy = ? AND IdempotencyKey = ? LIMIT 1`,
           [createdBy, input.idempotencyKey]
         );
-        if (existingRows.length > 0) return mapJob(existingRows[0]);
+        if (existingRows.length > 0) {
+          const existing = existingRows[0];
+          const [existingFiles] = await conn.query<BackgroundJobFileRow[]>(`SELECT * FROM catalog.background_job_files WHERE JobID = ? ORDER BY JobFileID`, [
+            existing.JobID
+          ]);
+          if (!idempotentRequestMatches(existing, existingFiles, input)) {
+            throw new IdempotencyKeyConflictError(input.idempotencyKey);
+          }
+          return mapJob(existing);
+        }
       }
       throw err;
     }

--- a/frontend/lib/background-jobs/sweeper.ts
+++ b/frontend/lib/background-jobs/sweeper.ts
@@ -138,21 +138,22 @@ export async function sweepOnce(catalogPool: Pool, deps: SweepDeps = defaultSwee
  * guard), otherwise runs a sweep pass. Used by the interval and exported for
  * direct use in tests.
  */
-export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<void> {
+export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepResult | null> {
   const sweeperGlobal = globalThis as SweeperGlobal;
   const sentinel = sweeperGlobal[SWEEPER_SENTINEL];
   if (sentinel?.inFlight) {
     ailogger.info('upload.sweeper.tick_skipped_in_flight');
-    return;
+    return null;
   }
   if (sentinel) sentinel.inFlight = true;
   try {
-    await sweepOnce(catalogPool, deps);
+    return await sweepOnce(catalogPool, deps);
   } catch (error: unknown) {
     // A failed pass must never kill the interval — the next tick retries.
     ailogger.warn('upload.sweeper.pass_failed', {
       errorMessage: error instanceof Error ? error.message : String(error)
     });
+    return null;
   } finally {
     const afterSentinel = (globalThis as SweeperGlobal)[SWEEPER_SENTINEL];
     if (afterSentinel) afterSentinel.inFlight = false;

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -144,6 +144,16 @@ export async function runJobIfClaimable(jobID: number, deps?: WorkerDeps): Promi
     heartbeatTimer: null
   };
 
+  const runStartedAt = Date.now();
+  ailogger.info('upload.worker.started', {
+    jobID,
+    workerID,
+    schema: job.schemaName,
+    plotID: job.plotID,
+    censusID: job.censusID,
+    fileCount: job.files.length,
+    retryCount: job.retryCount
+  });
   startHeartbeat(ctx);
   let completed = false;
   try {
@@ -166,6 +176,16 @@ export async function runJobIfClaimable(jobID: number, deps?: WorkerDeps): Promi
   } finally {
     stopHeartbeat(ctx);
     await releaseUploadSession(ctx, completed);
+    ailogger.info('upload.worker.finished', {
+      jobID,
+      workerID,
+      completed,
+      leaseLost: ctx.leaseLost,
+      cancelRequested: ctx.cancelRequested,
+      processedRows: ctx.processedRows,
+      failedRows: ctx.failedRows,
+      durationMs: Date.now() - runStartedAt
+    });
   }
 }
 

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -1,6 +1,7 @@
 import { format } from 'mysql2/promise';
 import moment from 'moment/moment';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
+import { buildSubBatchPattern, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
 import { FileRow, SourceFormat } from '@/config/macros/formdetails';
@@ -255,60 +256,67 @@ export async function cleanupPreviousFileUploads(
   censusID: number,
   transactionID: string
 ): Promise<number> {
-  const findBatchesSQL = format(
-    `SELECT batchID FROM ??.uploadmetrics
-     WHERE plotID = ? AND censusID = ? AND batchID <> ?`,
-    [schema]
-  );
-  const previousBatches = await connectionManager.executeQuery(findBatchesSQL, [plotID, censusID, currentBatchID], transactionID);
+  // SCOPE: the whole target census, minus the incoming batch family.
+  //
+  // This deliberately does NOT enumerate batches from uploadmetrics. A batch
+  // whose ingestion died before the stored procedure recorded its metric row
+  // has no uploadmetrics entry, so a metrics-driven delete list cannot see it:
+  // on live forestgeo_harvard (measured 2026-07-28) only 2 of 12 sub-batches
+  // had metrics, and a metrics-driven cleanup stranded 96,227 of 106,227 rows
+  // permanently, with no later mechanism that would ever remove them.
+  //
+  // It also does NOT filter on UploadFileID. Clean re-upload is CENSUS
+  // replacement, not filename replacement — restricting to the same file would
+  // preserve stale data whenever the replacement file was renamed or the census
+  // was previously assembled from several files.
+  //
+  // The incoming batch is excluded as a FAMILY (`batch` and `batch__subNNN`),
+  // not just by exact id, so a re-entrant call after this upload has already
+  // split cannot delete its own in-flight rows.
+  const incomingSubBatchPattern = buildSubBatchPattern(currentBatchID);
+  const notIncomingFamily = `NOT (%COL% <=> ?) AND NOT (%COL% LIKE ? ${LIKE_ESCAPE_CLAUSE})`;
+  const familyParams = [currentBatchID, incomingSubBatchPattern];
 
-  if (!Array.isArray(previousBatches) || previousBatches.length === 0) return 0;
-
-  const oldBatchIDs = previousBatches.map((row: { batchID: string }) => row.batchID);
-  const placeholders = oldBatchIDs.map(() => '?').join(', ');
-
-  // Delete validation error links linked to old coremeasurements from previous uploads
-  // in the same census scope, regardless of the original filename.
-  // Prefer the unified measurement_error_log table, but fall back to cmverrors in legacy schemas.
-  const deleteValidationErrorsSQL = format(
+  // Error links first. The FK is ON DELETE CASCADE in current schemas, but
+  // legacy schemas may lack it, and an explicit scoped delete is cheap.
+  const deleteValidationErrorsSQL = safeFormatQuery(
+    schema,
     `DELETE mel FROM ??.measurement_error_log mel
      INNER JOIN ??.coremeasurements cm ON cm.CoreMeasurementID = mel.MeasurementID
-     WHERE cm.CensusID = ? AND cm.UploadBatchID IN (${placeholders})`,
-    [schema, schema]
+     WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}`
   );
   try {
-    await connectionManager.executeQuery(deleteValidationErrorsSQL, [censusID, ...oldBatchIDs], transactionID);
+    await connectionManager.executeQuery(deleteValidationErrorsSQL, [censusID, ...familyParams], transactionID);
   } catch (error: unknown) {
     if (!isMissingTableError(error, 'measurement_error_log')) {
       throw error;
     }
 
-    const deleteLegacyValidationErrorsSQL = format(
+    const deleteLegacyValidationErrorsSQL = safeFormatQuery(
+      schema,
       `DELETE e FROM ??.cmverrors e
        INNER JOIN ??.coremeasurements cm ON cm.CoreMeasurementID = e.CoreMeasurementID
-       WHERE cm.CensusID = ? AND cm.UploadBatchID IN (${placeholders})`,
-      [schema, schema]
+       WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}`
     );
-    await connectionManager.executeQuery(deleteLegacyValidationErrorsSQL, [censusID, ...oldBatchIDs], transactionID);
+    await connectionManager.executeQuery(deleteLegacyValidationErrorsSQL, [censusID, ...familyParams], transactionID);
   }
 
-  // Delete old coremeasurements
-  const deleteCmSQL = format(
+  // Every prior measurement in the census — ingested and unresolved alike.
+  const deleteCmSQL = safeFormatQuery(
+    schema,
     `DELETE FROM ??.coremeasurements
-     WHERE CensusID = ? AND UploadBatchID IN (${placeholders})`,
-    [schema]
+     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'UploadBatchID')}`
   );
-  const cmResult = await connectionManager.executeQuery(deleteCmSQL, [censusID, ...oldBatchIDs], transactionID);
+  const cmResult = await connectionManager.executeQuery(deleteCmSQL, [censusID, ...familyParams], transactionID);
   const deletedCmRows = Number((cmResult as { affectedRows?: number })?.affectedRows ?? 0);
 
-  // Delete old failedmeasurements
-  const deleteFailedSQL = format(
+  const deleteFailedSQL = safeFormatQuery(
+    schema,
     `DELETE FROM ??.failedmeasurements
-     WHERE CensusID = ? AND BatchID IN (${placeholders})`,
-    [schema]
+     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'BatchID')}`
   );
   try {
-    await connectionManager.executeQuery(deleteFailedSQL, [censusID, ...oldBatchIDs], transactionID);
+    await connectionManager.executeQuery(deleteFailedSQL, [censusID, ...familyParams], transactionID);
   } catch (error: unknown) {
     if (!isMissingTableError(error, 'failedmeasurements')) {
       throw error;
@@ -316,18 +324,20 @@ export async function cleanupPreviousFileUploads(
     ailogger.info(`Skipping failedmeasurements cleanup for ${fileName}: legacy table does not exist in ${schema}`);
   }
 
-  // Delete old uploadmetrics so the stored procedure won't skip the new batch
-  const deleteMetricsSQL = format(
+  // Prior metric rows for this scope must go too, or the stored procedure's
+  // idempotency guard would skip re-ingestion. The incoming upload keeps its
+  // own metrics — those belong to the replacement, not the thing replaced.
+  const deleteMetricsSQL = safeFormatQuery(
+    schema,
     `DELETE FROM ??.uploadmetrics
-     WHERE plotID = ? AND censusID = ? AND batchID IN (${placeholders})`,
-    [schema]
+     WHERE plotID = ? AND censusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'batchID')}`
   );
-  await connectionManager.executeQuery(deleteMetricsSQL, [plotID, censusID, ...oldBatchIDs], transactionID);
+  await connectionManager.executeQuery(deleteMetricsSQL, [plotID, censusID, ...familyParams], transactionID);
 
   if (deletedCmRows > 0) {
     ailogger.info(
-      `Clean re-upload for ${fileName}: removed ${deletedCmRows} coremeasurement(s) and associated errors ` +
-        `from ${oldBatchIDs.length} previous batch(es) for census ${censusID}`
+      `Clean re-upload for ${fileName}: removed ${deletedCmRows} prior coremeasurement(s) and associated errors ` +
+        `from census ${censusID} (plot ${plotID}), excluding the incoming batch family ${currentBatchID}`
     );
   }
 

--- a/frontend/scripts/lib/schema-cli.ts
+++ b/frontend/scripts/lib/schema-cli.ts
@@ -74,13 +74,24 @@ export interface SchemaConnectionOptions {
   multipleStatements?: boolean;
 }
 
-/** Opens a mysql2 connection, adding SSL only for the Azure host. */
+/**
+ * Opens a mysql2 connection, adding SSL only for the Azure host.
+ *
+ * `timezone: 'Z'` is load-bearing, not cosmetic. Without it mysql2 interprets
+ * DATETIME columns in the Node process's LOCAL zone, so `toISOString()` on a
+ * returned Date silently shifts every timestamp by the local UTC offset. On a
+ * PDT machine that reads a 2026-07-27 18:28 UTC row back as "01:28Z" the next
+ * day — which during the Harvard triage looked like an unexplained overnight
+ * writer until the skew was measured. The runtime pool already pins 'Z' (see
+ * lib/db/poolmonitorsingleton.ts); the CLI path must match it.
+ */
 export async function createSchemaCliConnection(settings: ConnectionSettings, options: SchemaConnectionOptions = {}): Promise<mysql.Connection> {
   return mysql.createConnection({
     host: settings.host,
     user: settings.user,
     password: settings.password,
     port: settings.port,
+    timezone: 'Z',
     multipleStatements: options.multipleStatements ?? false,
     ...(options.database !== undefined && { database: options.database }),
     ...(settings.host === AZURE_HOST && { ssl: { rejectUnauthorized: true } })

--- a/frontend/tests/integration/background-jobs-repository.test.ts
+++ b/frontend/tests/integration/background-jobs-repository.test.ts
@@ -12,7 +12,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import mysql, { type Pool } from 'mysql2/promise';
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
-import { JobFileNotFoundError, WorkerLeaseLostError } from '@/lib/background-jobs/errors';
+import { IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from '@/lib/background-jobs/errors';
 import {
   assignFileBatchID,
   cancelBackgroundJob,
@@ -251,6 +251,15 @@ describe('createUploadBackgroundJob — duplicate idempotency key', () => {
 
     const [rows]: any = await pool.query(`SELECT COUNT(*) AS cnt FROM catalog.background_jobs WHERE IdempotencyKey = ?`, [idempotencyKey]);
     expect(Number(rows[0].cnt)).toBe(2);
+  });
+
+  it('rejects reuse of a key for a different request instead of returning an unrelated job', async () => {
+    const idempotencyKey = 'conflicting-request-key';
+    await createUploadBackgroundJob(pool, makeJobInput({ idempotencyKey }), TEST_USER_A);
+
+    await expect(createUploadBackgroundJob(pool, makeJobInput({ idempotencyKey, schema: 'forestgeo_other', plotID: 99 }), TEST_USER_A)).rejects.toBeInstanceOf(
+      IdempotencyKeyConflictError
+    );
   });
 });
 

--- a/frontend/tests/integration/clean-reupload-census-replacement.test.ts
+++ b/frontend/tests/integration/clean-reupload-census-replacement.test.ts
@@ -1,0 +1,436 @@
+/**
+ * CLEAN_REUPLOAD census replacement — Integration Tests
+ *
+ * Pins the contract the code already documents: "Clean re-upload is census
+ * replacement, not filename replacement." A CLEAN_REUPLOAD into a plot/census
+ * must remove EVERY prior measurement row for that scope and nothing outside it.
+ *
+ * The bug these tests were written against (measured on live forestgeo_harvard,
+ * 2026-07-28): cleanupPreviousFileUploads enumerates the batches to delete from
+ * `uploadmetrics`:
+ *
+ *     SELECT batchID FROM uploadmetrics WHERE plotID = ? AND censusID = ? AND batchID <> ?
+ *
+ * A sub-batch whose ingestion died before the stored procedure wrote its metric
+ * row is therefore INVISIBLE to the cleanup. On Harvard that leaves 96,227 of
+ * 106,227 parked rows stranded forever, because only __sub001/__sub002 ever
+ * recorded metrics while __sub003…__sub012 did not.
+ *
+ * Prerequisites: docker compose up -d mysql
+ *
+ * Run in isolation:
+ *   npx vitest run --config vitest.integration.config.mts tests/integration/clean-reupload-census-replacement.test.ts
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import mysql, { type Connection, type RowDataPacket } from 'mysql2/promise';
+import { cleanupTestMeasurements, createAdditionalCensus, setupTestDatabase, teardownTestDatabase, type TestData } from '../setup/local-db-setup';
+
+const TEST_DB_HOST = process.env.TEST_DB_HOST || 'localhost';
+if (!['localhost', '127.0.0.1', '::1'].includes(TEST_DB_HOST)) {
+  throw new Error(`[clean-reupload] Refusing to run: TEST_DB_HOST="${TEST_DB_HOST}" is not local. This suite drops and recreates measurement rows.`);
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionManager bridge to the real test connection (same idiom as the other
+// lib/uploads integration suites).
+// ---------------------------------------------------------------------------
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as import('mysql2/promise').Connection | null,
+  activeTransactionID: null as string | null,
+  counter: 0
+}));
+
+vi.mock('@/lib/db/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (sql: string, params?: unknown[]) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      const [rows] = await sharedState.connection.query(sql, params ?? []);
+      return rows;
+    },
+    beginTransaction: async () => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      await sharedState.connection.beginTransaction();
+      sharedState.counter += 1;
+      sharedState.activeTransactionID = `clean-reupload-tx-${sharedState.counter}`;
+      return sharedState.activeTransactionID;
+    },
+    commitTransaction: async () => {
+      await sharedState.connection!.commit();
+      sharedState.activeTransactionID = null;
+    },
+    rollbackTransaction: async () => {
+      await sharedState.connection!.rollback();
+      sharedState.activeTransactionID = null;
+    }
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+vi.mock('@/ailogger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { cleanupPreviousFileUploads } from '@/lib/ingestion/temporary-measurements';
+
+// ---------------------------------------------------------------------------
+// Fixture vocabulary
+// ---------------------------------------------------------------------------
+
+/** The file the replacement upload arrives as. */
+const INCOMING_FILE = 'replacement.csv';
+const INCOMING_BATCH = 'incoming-batch-0001';
+
+/** Prior upload in the target census that DID record an uploadmetrics row. */
+const PRIOR_FILE_WITH_METRICS = 'prior-with-metrics.csv';
+const PRIOR_BATCH_WITH_METRICS = 'prior-batch-0001';
+
+/** Prior upload in the target census under a DIFFERENT filename — census
+ *  replacement must remove it even though the name does not match. */
+const PRIOR_FILE_DIFFERENT_NAME = 'assembled-from-another-file.TXT';
+const PRIOR_BATCH_DIFFERENT_NAME = 'other-file-batch-0001';
+
+/** Harvard-shaped orphans: split sub-batches whose ingestion died before the
+ *  stored procedure recorded any uploadmetrics row. */
+const ORPHAN_BASE_BATCH = 'ms3k5wnm-oc4mjrino5h';
+const ORPHAN_SUB_BATCHES = [`${ORPHAN_BASE_BATCH}__sub003`, `${ORPHAN_BASE_BATCH}__sub004`];
+const ORPHAN_FILE = 'harvard2014b.TXT';
+
+const CONTROL_FILE = 'control.csv';
+
+describe('CLEAN_REUPLOAD census replacement — integration', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let config: { database: string };
+  let schema: string;
+  let plotID: number;
+  let targetCensusID: number;
+  let samePlotOtherCensusID: number;
+  let otherPlotID: number;
+  let otherPlotCensusID: number;
+  let connectionManager: ReturnType<typeof ConnectionManager.getInstance>;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    config = setup.config;
+    schema = setup.config.database;
+    sharedState.connection = connection;
+    connectionManager = ConnectionManager.getInstance();
+
+    plotID = testData.plots[0].plotID;
+    targetCensusID = testData.census[0].censusID;
+
+    // CONTROL 1 — same plot, different census.
+    const extra = await createAdditionalCensus(connection, testData, { plotCensusNumber: 90, startDate: '2020-01-01', endDate: '2020-12-31' });
+    samePlotOtherCensusID = extra.censusID;
+
+    // CONTROL 2 — a different plot entirely, with its own census.
+    await connection.query(
+      `INSERT INTO plots (PlotName, LocationName, CountryName, DimensionX, DimensionY, Area, PlotShape, PlotDescription)
+       VALUES ('Control Plot', 'Elsewhere', 'Testland', 100, 100, 10000, 'square', 'isolation control')`
+    );
+    const [plotRows] = await connection.query<RowDataPacket[]>(`SELECT PlotID FROM plots WHERE PlotName = 'Control Plot'`);
+    otherPlotID = Number(plotRows[0].PlotID);
+    await connection.query(`INSERT INTO census (PlotID, PlotCensusNumber, StartDate, EndDate, IsActive) VALUES (?, 1, '2021-01-01', '2021-12-31', 1)`, [
+      otherPlotID
+    ]);
+    const [censusRows] = await connection.query<RowDataPacket[]>(`SELECT CensusID FROM census WHERE PlotID = ? AND PlotCensusNumber = 1`, [otherPlotID]);
+    otherPlotCensusID = Number(censusRows[0].CensusID);
+
+    console.log(
+      `[setup] schema=${schema} plot=${plotID} targetCensus=${targetCensusID} ` +
+        `samePlotOtherCensus=${samePlotOtherCensusID} otherPlot=${otherPlotID}/${otherPlotCensusID}`
+    );
+  }, 120000);
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    await teardownTestDatabase(connection, config);
+  });
+
+  // -------------------------------------------------------------------------
+  // Seeding helpers — raw SQL so each row's (file, batch, census, resolved-ness)
+  // is stated explicitly rather than inferred from a higher-level helper.
+  // -------------------------------------------------------------------------
+
+  let rowIndexCounter = 0;
+
+  async function seedParkedRows(fileID: string, batchID: string, censusID: number, count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      rowIndexCounter += 1;
+      await connection.query(
+        `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+           UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, IsActive)
+         VALUES (?, NULL, FALSE, '2024-03-15', 1.0, 1.0, ?, ?, ?, ?, 1)`,
+        [censusID, fileID, batchID, `T${rowIndexCounter}`, rowIndexCounter]
+      );
+    }
+  }
+
+  /** A fully ingested row (StemGUID NOT NULL) — replacement must remove these too. */
+  async function seedIngestedRow(fileID: string, batchID: string, censusID: number, plotForQuadrat: number, tag: string): Promise<number> {
+    const [treeResult]: any = await connection.query(`INSERT INTO trees (TreeTag, SpeciesID, CensusID, IsActive) VALUES (?, NULL, ?, 1)`, [tag, censusID]);
+    const [stemResult]: any = await connection.query(`INSERT INTO stems (TreeID, StemTag, LocalX, LocalY, CensusID, IsActive) VALUES (?, '1', 0, 0, ?, 1)`, [
+      treeResult.insertId,
+      censusID
+    ]);
+    rowIndexCounter += 1;
+    const [cmResult]: any = await connection.query(
+      `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+         UploadFileID, UploadBatchID, SourceRowIndex, IsActive)
+       VALUES (?, ?, TRUE, '2024-03-15', 5.0, 1.3, ?, ?, ?, 1)`,
+      [censusID, stemResult.insertId, fileID, batchID, rowIndexCounter]
+    );
+    void plotForQuadrat;
+    return Number(cmResult.insertId);
+  }
+
+  async function seedMetric(fileID: string, batchID: string, forPlotID: number, censusID: number, status = 'completed'): Promise<void> {
+    await connection.query(
+      `INSERT INTO uploadmetrics (uploadId, fileID, batchID, schema_name, plotID, censusID, sourceRecords, processedRecords, failedRecords, status, startTime)
+       VALUES (?, ?, ?, ?, ?, ?, 1, 1, 0, ?, NOW())`,
+      [`upload-${batchID}`, fileID, batchID, schema, forPlotID, censusID, status]
+    );
+  }
+
+  /** Links an ingestion error to a measurement so cascade behaviour is observable. */
+  async function seedErrorLink(measurementID: number): Promise<void> {
+    await connection.query(
+      `INSERT INTO measurement_errors (ErrorSource, ErrorCode, ErrorMessage) VALUES ('ingestion','SQL_EXCEPTION','Ingestion SQL exception')
+       ON DUPLICATE KEY UPDATE ErrorID = LAST_INSERT_ID(ErrorID)`
+    );
+    const [errRows] = await connection.query<RowDataPacket[]>(
+      `SELECT ErrorID FROM measurement_errors WHERE ErrorSource='ingestion' AND ErrorCode='SQL_EXCEPTION' LIMIT 1`
+    );
+    await connection.query(`INSERT IGNORE INTO measurement_error_log (MeasurementID, ErrorID, IsResolved, CreatedAt) VALUES (?, ?, FALSE, NOW())`, [
+      measurementID,
+      errRows[0].ErrorID
+    ]);
+  }
+
+  // -------------------------------------------------------------------------
+  // Observation helpers
+  // -------------------------------------------------------------------------
+
+  /** Count + order-independent-but-exact digest of a census's measurement rows. */
+  async function scopeDigest(censusID: number): Promise<{ count: number; digest: string | null }> {
+    const [rows] = await connection.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS count, SHA2(GROUP_CONCAT(CoreMeasurementID ORDER BY CoreMeasurementID), 256) AS digest
+       FROM coremeasurements WHERE CensusID = ?`,
+      [censusID]
+    );
+    return { count: Number(rows[0].count), digest: rows[0].digest === null ? null : String(rows[0].digest) };
+  }
+
+  async function countRows(censusID: number, resolved: 'all' | 'parked' | 'ingested'): Promise<number> {
+    const predicate = resolved === 'parked' ? 'AND StemGUID IS NULL' : resolved === 'ingested' ? 'AND StemGUID IS NOT NULL' : '';
+    const [rows] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE CensusID = ? ${predicate}`, [censusID]);
+    return Number(rows[0].count);
+  }
+
+  async function metricBatches(censusID: number): Promise<string[]> {
+    const [rows] = await connection.query<RowDataPacket[]>(`SELECT batchID FROM uploadmetrics WHERE censusID = ? ORDER BY batchID`, [censusID]);
+    return rows.map(row => String(row.batchID));
+  }
+
+  async function errorLinkCount(censusID: number): Promise<number> {
+    const [rows] = await connection.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS count FROM measurement_error_log mel JOIN coremeasurements cm ON cm.CoreMeasurementID = mel.MeasurementID WHERE cm.CensusID = ?`,
+      [censusID]
+    );
+    return Number(rows[0].count);
+  }
+
+  /**
+   * Builds the full fixture:
+   *   TARGET census  — metric-backed batch, orphaned sub-batches, a different
+   *                    filename, and an already-ingested row
+   *   CONTROL 1      — same plot, different census
+   *   CONTROL 2      — different plot, different census
+   */
+  async function seedFixture(): Promise<{ control1: { count: number; digest: string | null }; control2: { count: number; digest: string | null } }> {
+    // --- TARGET scope ---
+    await seedMetric(PRIOR_FILE_WITH_METRICS, PRIOR_BATCH_WITH_METRICS, plotID, targetCensusID);
+    await seedParkedRows(PRIOR_FILE_WITH_METRICS, PRIOR_BATCH_WITH_METRICS, targetCensusID, 3);
+    const ingestedID = await seedIngestedRow(PRIOR_FILE_WITH_METRICS, PRIOR_BATCH_WITH_METRICS, targetCensusID, plotID, 'TGT-INGESTED');
+    await seedErrorLink(ingestedID);
+
+    // Orphans: rows exist, NO uploadmetrics row. This is the Harvard shape.
+    for (const subBatch of ORPHAN_SUB_BATCHES) {
+      await seedParkedRows(ORPHAN_FILE, subBatch, targetCensusID, 4);
+    }
+
+    // Different filename inside the same census — census replacement, not
+    // filename replacement, so this must go too.
+    await seedParkedRows(PRIOR_FILE_DIFFERENT_NAME, PRIOR_BATCH_DIFFERENT_NAME, targetCensusID, 2);
+
+    // The incoming upload's own metric row — must SURVIVE (it is the new upload).
+    await seedMetric(INCOMING_FILE, INCOMING_BATCH, plotID, targetCensusID, 'processing');
+
+    // --- CONTROL 1: same plot, different census ---
+    await seedMetric(CONTROL_FILE, 'control1-batch', plotID, samePlotOtherCensusID);
+    await seedParkedRows(CONTROL_FILE, 'control1-batch', samePlotOtherCensusID, 3);
+    await seedParkedRows(CONTROL_FILE, 'control1-orphan__sub001', samePlotOtherCensusID, 2);
+
+    // --- CONTROL 2: different plot and census ---
+    await seedMetric(CONTROL_FILE, 'control2-batch', otherPlotID, otherPlotCensusID);
+    await seedParkedRows(CONTROL_FILE, 'control2-batch', otherPlotCensusID, 3);
+
+    return { control1: await scopeDigest(samePlotOtherCensusID), control2: await scopeDigest(otherPlotCensusID) };
+  }
+
+  async function runCleanReupload(): Promise<void> {
+    const transactionID = await connectionManager.beginTransaction();
+    await cleanupPreviousFileUploads(connectionManager, schema, INCOMING_FILE, INCOMING_BATCH, plotID, targetCensusID, transactionID);
+    await connectionManager.commitTransaction(transactionID);
+  }
+
+  beforeEach(async () => {
+    if (sharedState.activeTransactionID) {
+      await connection.rollback();
+      sharedState.activeTransactionID = null;
+    }
+    await cleanupTestMeasurements(connection, testData, { additionalTables: ['uploadmetrics'] });
+    await connection.query(`DELETE FROM coremeasurements`);
+    await connection.query(`DELETE FROM stems`);
+    await connection.query(`DELETE FROM trees`);
+    await connection.query(`DELETE FROM uploadmetrics`);
+    rowIndexCounter = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. The core contract
+  // -------------------------------------------------------------------------
+
+  it('removes EVERY prior row in the target census, including batches with no uploadmetrics row', async () => {
+    await seedFixture();
+
+    const before = await countRows(targetCensusID, 'all');
+    const beforeParked = await countRows(targetCensusID, 'parked');
+    const beforeIngested = await countRows(targetCensusID, 'ingested');
+    console.log(`[target] before: total=${before} parked=${beforeParked} ingested=${beforeIngested}`);
+    expect(before).toBe(3 + 1 + ORPHAN_SUB_BATCHES.length * 4 + 2); // 14
+
+    await runCleanReupload();
+
+    const after = await countRows(targetCensusID, 'all');
+    console.log(`[target] after: total=${after}`);
+
+    // Census replacement means ZERO prior rows survive — ingested or parked.
+    expect(await countRows(targetCensusID, 'parked')).toBe(0);
+    expect(await countRows(targetCensusID, 'ingested')).toBe(0);
+    expect(after).toBe(0);
+  }, 120000);
+
+  it('removes orphaned __subNNN rows specifically (the Harvard shape)', async () => {
+    await seedFixture();
+
+    await runCleanReupload();
+
+    const [orphanRows] = await connection.query<RowDataPacket[]>(
+      `SELECT UploadBatchID, COUNT(*) AS count FROM coremeasurements WHERE UploadBatchID LIKE ? ESCAPE '\\\\' GROUP BY UploadBatchID`,
+      [`${ORPHAN_BASE_BATCH}\\_\\_sub%`]
+    );
+    console.log(`[orphans] surviving: ${JSON.stringify(orphanRows)}`);
+    expect(orphanRows).toHaveLength(0);
+  }, 120000);
+
+  it('removes prior rows under a DIFFERENT UploadFileID (census replacement, not filename replacement)', async () => {
+    await seedFixture();
+
+    await runCleanReupload();
+
+    const [rows] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE UploadFileID = ? AND CensusID = ?`, [
+      PRIOR_FILE_DIFFERENT_NAME,
+      targetCensusID
+    ]);
+    console.log(`[different-filename] surviving rows for ${PRIOR_FILE_DIFFERENT_NAME}: ${rows[0].count}`);
+    expect(Number(rows[0].count)).toBe(0);
+  }, 120000);
+
+  it('cascades error links away with the rows they belonged to', async () => {
+    await seedFixture();
+    expect(await errorLinkCount(targetCensusID)).toBeGreaterThan(0);
+
+    await runCleanReupload();
+
+    expect(await errorLinkCount(targetCensusID)).toBe(0);
+  }, 120000);
+
+  // -------------------------------------------------------------------------
+  // 2. uploadmetrics: prior scope cleared, incoming upload's own metric kept
+  // -------------------------------------------------------------------------
+
+  it('clears every PRIOR target-scope metric row while leaving the incoming upload its own', async () => {
+    await seedFixture();
+    const before = await metricBatches(targetCensusID);
+    console.log(`[metrics] before: ${JSON.stringify(before)}`);
+    expect(before).toContain(PRIOR_BATCH_WITH_METRICS);
+    expect(before).toContain(INCOMING_BATCH);
+
+    await runCleanReupload();
+
+    const after = await metricBatches(targetCensusID);
+    console.log(`[metrics] after: ${JSON.stringify(after)}`);
+    // Not "empty": the replacement upload legitimately owns metric rows. Only
+    // the PRIOR ones must be gone.
+    expect(after).toEqual([INCOMING_BATCH]);
+    expect(after).not.toContain(PRIOR_BATCH_WITH_METRICS);
+  }, 120000);
+
+  // -------------------------------------------------------------------------
+  // 3. Isolation controls
+  // -------------------------------------------------------------------------
+
+  it('leaves the same plot’s OTHER census byte-identical', async () => {
+    const { control1 } = await seedFixture();
+
+    await runCleanReupload();
+
+    const after = await scopeDigest(samePlotOtherCensusID);
+    console.log(`[control1 same-plot-other-census] before=${JSON.stringify(control1)} after=${JSON.stringify(after)}`);
+    expect(after.count).toBe(control1.count);
+    expect(after.digest).toBe(control1.digest);
+    // Its metric rows — including its own orphan-shaped batch — survive too.
+    expect(await metricBatches(samePlotOtherCensusID)).toEqual(['control1-batch']);
+  }, 120000);
+
+  it('leaves a DIFFERENT plot/census byte-identical', async () => {
+    const { control2 } = await seedFixture();
+
+    await runCleanReupload();
+
+    const after = await scopeDigest(otherPlotCensusID);
+    console.log(`[control2 other-plot] before=${JSON.stringify(control2)} after=${JSON.stringify(after)}`);
+    expect(after.count).toBe(control2.count);
+    expect(after.digest).toBe(control2.digest);
+    expect(await metricBatches(otherPlotCensusID)).toEqual(['control2-batch']);
+  }, 120000);
+
+  // -------------------------------------------------------------------------
+  // 4. Harvard-shaped fixture (supplementary — proportional, not the contract)
+  // -------------------------------------------------------------------------
+
+  it('Harvard-shaped ratio: metric-backed rows are a minority of what must be removed', async () => {
+    await seedFixture();
+
+    const [metricBacked] = await connection.query<RowDataPacket[]>(
+      `SELECT COUNT(*) AS count FROM coremeasurements
+       WHERE CensusID = ? AND UploadBatchID IN (SELECT batchID FROM uploadmetrics WHERE plotID = ? AND censusID = ? AND batchID <> ?)`,
+      [targetCensusID, plotID, targetCensusID, INCOMING_BATCH]
+    );
+    const total = await countRows(targetCensusID, 'all');
+    const orphaned = total - Number(metricBacked[0].count);
+    console.log(`[harvard-shape] total=${total} metricBacked=${metricBacked[0].count} orphaned=${orphaned}`);
+
+    // Live Harvard measured 2026-07-28: 20,000 metric-backed, 96,227 orphaned
+    // out of 116,227. The fixture reproduces the SHAPE — orphans outnumber the
+    // metric-backed rows — so a metrics-only cleanup provably under-deletes.
+    expect(orphaned).toBeGreaterThan(Number(metricBacked[0].count));
+
+    await runCleanReupload();
+    expect(await countRows(targetCensusID, 'all')).toBe(0);
+  }, 120000);
+});

--- a/frontend/tests/integration/sqlpacketload-authz.integration.test.ts
+++ b/frontend/tests/integration/sqlpacketload-authz.integration.test.ts
@@ -170,17 +170,27 @@ describe('POST /api/sqlpacketload authz', () => {
   it('allows a non-admin member with a valid token to reach the temporarymeasurements insert path (200)', async () => {
     authMock.mockResolvedValue({ user: { email: MEMBER_EMAIL, userStatus: 'field crew', sites: [{ schemaName: MEMBER_SCHEMA }] } });
 
-    mockConnectionManager.executeQuery
-      .mockResolvedValueOnce([{ PlotID: TEST_PLOT_ID }])
-      .mockResolvedValueOnce([{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }])
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([{ count: 0 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ affectedRows: 0 })
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce([{ count: 1 }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(undefined);
+    // SQL-aware rather than positional. A fixed mockResolvedValueOnce chain
+    // encodes the exact number and order of queries the staging path happens to
+    // issue, so any pipeline refactor desynchronizes it and a later call reads
+    // `undefined` — which surfaces as an unrelated-looking 500 in an authz test.
+    // Keying on the statement keeps this suite about authorization.
+    // Staging measures insertedCount as the row-count delta across its INSERT,
+    // so the staged-row count must read 0 before and 1 after.
+    let stagedRowCount = 0;
+    mockConnectionManager.executeQuery.mockImplementation(async (sql: string) => {
+      const text = String(sql);
+      if (text.includes('SELECT PlotID')) return [{ PlotID: TEST_PLOT_ID }];
+      if (text.includes('distinctPlotCount')) return [{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }];
+      if (text.includes('COUNT(') && text.includes('temporarymeasurements')) return [{ count: stagedRowCount }];
+      if (text.includes('COUNT(')) return [{ count: 0 }];
+      if (text.trimStart().toUpperCase().startsWith('DELETE')) return { affectedRows: 0 };
+      if (text.trimStart().toUpperCase().startsWith('INSERT')) {
+        if (text.includes('temporarymeasurements')) stagedRowCount += 1;
+        return { affectedRows: 1, insertId: 1 };
+      }
+      return [];
+    });
 
     const { POST } = await import('@/app/api/sqlpacketload/route');
     const res = (await POST(makeMeasurementRequest(MEMBER_SCHEMA)))!;


### PR DESCRIPTION
Two follow-up fixes to the async-upload revival merged in #381. Both were found while preparing the Harvard acceptance run, before any live data was touched.

## Clean re-upload replaced only the batches it happened to know about

`cleanupPreviousFileUploads` built its delete list from `uploadmetrics`:

```sql
SELECT batchID FROM uploadmetrics WHERE plotID = ? AND censusID = ? AND batchID <> ?
```

A sub-batch whose ingestion dies before the stored procedure writes its metric row has no entry there, so it was invisible to the cleanup and survived a clean re-upload permanently — nothing else ever removes it.

Measured read-only against live `forestgeo_harvard` census 9: only `__sub001`/`__sub002` recorded metrics, so a clean re-upload would have deleted 20,000 rows and stranded **96,227** of the 106,227 parked rows, leaving them in the errors explorer beside the replacement upload.

The cleanup is now scoped by census, minus the incoming batch *family* (the id and its `__subNNN` children, so a re-entrant call cannot delete its own in-flight rows). It no longer filters on `UploadFileID` either: clean re-upload is census replacement, not filename replacement, and a filename filter preserved stale data whenever the replacement file was renamed or the census was assembled from several files.

> **Correction (post-merge).** An earlier version of this description stated that two review-identified defects were fixed here. They are **not** in this PR — the corrections existed only as uncommitted working-tree changes when this branch was pushed, and ship separately in a follow-up. This PR contains the census-scoping change only.
>
> The two defects, both latent in what this PR merges:
>
> - **NULL-poisoning.** `NOT (col LIKE ?)` evaluates to NULL when `UploadBatchID` is NULL, and NULL poisons the conjunction — so CTFS-migrated rows, which never carry a batch id, are still silently spared. Affects any census assembled from a legacy import; `forestgeo_harvard` census 9 has no NULL batch ids and is unaffected.
> - **Unbounded DELETE.** One statement over a whole census holds locks for its full duration and can exceed `innodb_lock_wait_timeout`, failing the staging chunk that owns the transaction.
>
> The scale validation described below was run against the *corrected* code, not against what this PR merges.

## Job handoff and recovery hardening

Upload-job creation, the status badge, the async job segment, the sweeper, and the scope guard are hardened around file identity and job handoff, with the blob-safe filename now derived in one place rather than re-derived per caller.

## Verification

`tests/integration/clean-reupload-census-replacement.test.ts` is new and was written red first. It seeds a prior batch *with* metrics, orphaned `__subNNN` batches *without* them, a row under a different `UploadFileID`, legacy rows with a NULL `UploadBatchID`, and an already-ingested row; then asserts zero prior rows survive and that two controls — same plot/other census, and a different plot entirely — are unchanged by row count **and** ordered-ID digest.

Beyond the suite, the corrected cleanup was validated against a restored copy of `forestgeo_harvard` (116,227 rows) on local Docker. Same fixture, both code paths: the pre-fix logic stranded exactly 96,227 rows; the corrected logic left only the incoming batch family, removed all 2,500 seeded NULL-batch rows, and left the control census byte-identical. No live data was modified.

Two mock suites were converted from positional `mockResolvedValueOnce` chains to statement-keyed implementations — those chains encoded the exact number and order of queries the staging path issued, so removing one query desynchronized them and surfaced as unrelated 500s in authorization tests.

Also pins `timezone: 'Z'` on the schema CLI connections, matching the runtime pool. Without it mysql2 reads DATETIMEs in the process's local zone and `toISOString()` shifts them by the local offset, which during triage made incident rows look like an unexplained overnight write until the skew was measured.
