### PR TITLE
Fix NULL-safety and unbounded deletes in census replacement

### DIFF
--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -398,16 +398,23 @@ describe('sqlpacketload measurement scope validation', () => {
     // Scoped to the census, excluding the incoming batch FAMILY.
     expect(deleteCmCall).toContain('WHERE CensusID = ?');
     expect(deleteCmCall).toContain('NOT (UploadBatchID <=> ?)');
-    expect(deleteCmCall).toContain('NOT (UploadBatchID LIKE ?');
+    // Both arms NULL-safe: a bare `NOT (col LIKE ?)` yields NULL for the
+    // nullable UploadBatchID, which would spare every CTFS-migrated row.
+    expect(deleteCmCall).toContain('(UploadBatchID IS NULL OR UploadBatchID NOT LIKE ?');
+    // Bounded so one statement never locks a whole 100k-row census.
+    expect(deleteCmCall).toContain('LIMIT');
     // Census replacement, not filename replacement.
     expect(deleteCmCall).not.toContain('UploadFileID');
     // And never a batch id list sourced from metrics.
     expect(deleteCmCall).not.toContain('UploadBatchID IN');
 
-    const deleteValidationErrorsCall = executedSql.find((sql: string) => sql.includes('DELETE mel FROM `forestgeo_testing`.measurement_error_log'));
+    const deleteValidationErrorsCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.measurement_error_log'));
     expect(deleteValidationErrorsCall).toBeDefined();
     expect(deleteValidationErrorsCall).toContain('WHERE cm.CensusID = ?');
     expect(deleteValidationErrorsCall).not.toContain('cm.UploadFileID');
+    // Single-table DELETE over a subquery: MySQL rejects LIMIT on a
+    // multi-table DELETE ... JOIN, and this delete must stay bounded too.
+    expect(deleteValidationErrorsCall).toContain('LIMIT');
 
     const deleteMetricsCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.uploadmetrics'));
     expect(deleteMetricsCall).toBeDefined();
@@ -459,7 +466,7 @@ describe('sqlpacketload measurement scope validation', () => {
     let stagedRowCount = 0;
     mockConnectionManager.executeQuery.mockImplementation(async (sql: string) => {
       const text = String(sql);
-      if (text.includes('DELETE mel FROM') && text.includes('measurement_error_log')) throw missingError;
+      if (text.includes('DELETE FROM') && text.includes('measurement_error_log')) throw missingError;
       if (text.includes('SELECT PlotID')) return [{ PlotID: TEST_PLOT_ID }];
       if (text.includes('distinctPlotCount')) return [{ distinctPlotCount: 0, distinctCensusCount: 0, plotID: null, censusID: null }];
       if (text.includes('COUNT(') && text.includes('temporarymeasurements')) return [{ count: stagedRowCount }];
@@ -476,7 +483,7 @@ describe('sqlpacketload measurement scope validation', () => {
 
     expect(res.status).toBe(200);
     const executedSql = mockConnectionManager.executeQuery.mock.calls.map((call: any[]) => String(call[0]));
-    const legacyCall = executedSql.find((sql: string) => sql.includes('DELETE e FROM `forestgeo_testing`.cmverrors'));
+    const legacyCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.cmverrors'));
     expect(legacyCall).toBeDefined();
     expect(legacyCall).toContain('WHERE cm.CensusID = ?');
   });

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -241,6 +241,66 @@ export async function cleanupStaleMeasurementBatchesForFile(
 }
 
 /**
+ * Rows removed per statement by the census-replacement deletes. A single
+ * unbounded DELETE over a large census (Harvard: 106,227 rows) locks the whole
+ * row set in one statement and can exceed innodb_lock_wait_timeout, failing the
+ * staging chunk that owns the transaction and re-running on every retry.
+ */
+export const CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE = 5000;
+
+/**
+ * "Belongs to a batch other than the incoming family" — `batch` itself and its
+ * `batch__subNNN` children.
+ *
+ * Both arms must be NULL-safe. `UploadBatchID` is nullable and CTFS-migrated
+ * rows carry NULL; a bare `NOT (col LIKE ?)` evaluates to NULL for those rows,
+ * which poisons the conjunction and silently spares every legacy row from a
+ * census replacement that claims to have replaced them. A NULL batch id belongs
+ * to no family, so it is always a prior row.
+ */
+function buildNotIncomingFamilyPredicate(column: string): string {
+  return `NOT (${column} <=> ?) AND (${column} IS NULL OR ${column} NOT LIKE ? ${LIKE_ESCAPE_CLAUSE})`;
+}
+
+/**
+ * Runs a `DELETE ... LIMIT n` until it stops filling the limit, returning the
+ * total rows removed. The statement is re-issued verbatim: each pass deletes a
+ * fresh window because the previous window's rows no longer match.
+ */
+async function deleteInBoundedChunks(connectionManager: ConnectionManager, deleteSQL: string, params: unknown[], transactionID: string): Promise<number> {
+  let totalDeleted = 0;
+  for (;;) {
+    const result = await connectionManager.executeQuery(deleteSQL, params, transactionID);
+    const deleted = Number((result as { affectedRows?: number })?.affectedRows ?? 0);
+    totalDeleted += deleted;
+    if (deleted < CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE) return totalDeleted;
+  }
+}
+
+/**
+ * True when the given upload session has already staged measurement rows for
+ * this plot/census — i.e. the session's census replacement already ran on an
+ * earlier file or chunk.
+ */
+export async function uploadSessionHasStagedRows(
+  connectionManager: ConnectionManager,
+  schema: string,
+  uploadSessionID: string,
+  plotID: number,
+  censusID: number,
+  transactionID: string
+): Promise<boolean> {
+  const probeSQL = safeFormatQuery(
+    schema,
+    `SELECT 1 FROM ??.temporarymeasurements
+     WHERE SessionID = ? AND PlotID = ? AND CensusID = ?
+     LIMIT 1`
+  );
+  const rows = await connectionManager.executeQuery(probeSQL, [uploadSessionID, plotID, censusID], transactionID);
+  return Array.isArray(rows) && rows.length > 0;
+}
+
+/**
  * Clean up all data from previous uploads for the same plot/census scope.
  * Clean measurement uploads are census replacements: a new upload fully replaces
  * any earlier measurement batches for that census, even if the filename changed.
@@ -274,19 +334,25 @@ export async function cleanupPreviousFileUploads(
   // not just by exact id, so a re-entrant call after this upload has already
   // split cannot delete its own in-flight rows.
   const incomingSubBatchPattern = buildSubBatchPattern(currentBatchID);
-  const notIncomingFamily = `NOT (%COL% <=> ?) AND NOT (%COL% LIKE ? ${LIKE_ESCAPE_CLAUSE})`;
+  const notIncomingFamily = buildNotIncomingFamilyPredicate('%COL%');
   const familyParams = [currentBatchID, incomingSubBatchPattern];
 
   // Error links first. The FK is ON DELETE CASCADE in current schemas, but
   // legacy schemas may lack it, and an explicit scoped delete is cheap.
+  // Expressed as a single-table DELETE over a subquery rather than a
+  // multi-table DELETE ... JOIN, because MySQL rejects LIMIT on the latter and
+  // these deletes must stay bounded (see deleteInBoundedChunks).
   const deleteValidationErrorsSQL = safeFormatQuery(
     schema,
-    `DELETE mel FROM ??.measurement_error_log mel
-     INNER JOIN ??.coremeasurements cm ON cm.CoreMeasurementID = mel.MeasurementID
-     WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}`
+    `DELETE FROM ??.measurement_error_log
+     WHERE MeasurementID IN (
+       SELECT cm.CoreMeasurementID FROM ??.coremeasurements cm
+       WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}
+     )
+     LIMIT ${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}`
   );
   try {
-    await connectionManager.executeQuery(deleteValidationErrorsSQL, [censusID, ...familyParams], transactionID);
+    await deleteInBoundedChunks(connectionManager, deleteValidationErrorsSQL, [censusID, ...familyParams], transactionID);
   } catch (error: unknown) {
     if (!isMissingTableError(error, 'measurement_error_log')) {
       throw error;
@@ -294,29 +360,33 @@ export async function cleanupPreviousFileUploads(
 
     const deleteLegacyValidationErrorsSQL = safeFormatQuery(
       schema,
-      `DELETE e FROM ??.cmverrors e
-       INNER JOIN ??.coremeasurements cm ON cm.CoreMeasurementID = e.CoreMeasurementID
-       WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}`
+      `DELETE FROM ??.cmverrors
+       WHERE CoreMeasurementID IN (
+         SELECT cm.CoreMeasurementID FROM ??.coremeasurements cm
+         WHERE cm.CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'cm.UploadBatchID')}
+       )
+       LIMIT ${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}`
     );
-    await connectionManager.executeQuery(deleteLegacyValidationErrorsSQL, [censusID, ...familyParams], transactionID);
+    await deleteInBoundedChunks(connectionManager, deleteLegacyValidationErrorsSQL, [censusID, ...familyParams], transactionID);
   }
 
   // Every prior measurement in the census — ingested and unresolved alike.
   const deleteCmSQL = safeFormatQuery(
     schema,
     `DELETE FROM ??.coremeasurements
-     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'UploadBatchID')}`
+     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'UploadBatchID')}
+     LIMIT ${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}`
   );
-  const cmResult = await connectionManager.executeQuery(deleteCmSQL, [censusID, ...familyParams], transactionID);
-  const deletedCmRows = Number((cmResult as { affectedRows?: number })?.affectedRows ?? 0);
+  const deletedCmRows = await deleteInBoundedChunks(connectionManager, deleteCmSQL, [censusID, ...familyParams], transactionID);
 
   const deleteFailedSQL = safeFormatQuery(
     schema,
     `DELETE FROM ??.failedmeasurements
-     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'BatchID')}`
+     WHERE CensusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'BatchID')}
+     LIMIT ${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}`
   );
   try {
-    await connectionManager.executeQuery(deleteFailedSQL, [censusID, ...familyParams], transactionID);
+    await deleteInBoundedChunks(connectionManager, deleteFailedSQL, [censusID, ...familyParams], transactionID);
   } catch (error: unknown) {
     if (!isMissingTableError(error, 'failedmeasurements')) {
       throw error;
@@ -330,9 +400,10 @@ export async function cleanupPreviousFileUploads(
   const deleteMetricsSQL = safeFormatQuery(
     schema,
     `DELETE FROM ??.uploadmetrics
-     WHERE plotID = ? AND censusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'batchID')}`
+     WHERE plotID = ? AND censusID = ? AND ${notIncomingFamily.replace(/%COL%/g, 'batchID')}
+     LIMIT ${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}`
   );
-  await connectionManager.executeQuery(deleteMetricsSQL, [plotID, censusID, ...familyParams], transactionID);
+  await deleteInBoundedChunks(connectionManager, deleteMetricsSQL, [plotID, censusID, ...familyParams], transactionID);
 
   if (deletedCmRows > 0) {
     ailogger.info(

--- a/frontend/tests/integration/clean-reupload-census-replacement.test.ts
+++ b/frontend/tests/integration/clean-reupload-census-replacement.test.ts
@@ -71,7 +71,7 @@ vi.mock('@/lib/db/connectionmanager', () => {
 vi.mock('@/ailogger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
 
 import ConnectionManager from '@/lib/db/connectionmanager';
-import { cleanupPreviousFileUploads } from '@/lib/ingestion/temporary-measurements';
+import { CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE, cleanupPreviousFileUploads } from '@/lib/ingestion/temporary-measurements';
 
 // ---------------------------------------------------------------------------
 // Fixture vocabulary
@@ -95,6 +95,9 @@ const PRIOR_BATCH_DIFFERENT_NAME = 'other-file-batch-0001';
 const ORPHAN_BASE_BATCH = 'ms3k5wnm-oc4mjrino5h';
 const ORPHAN_SUB_BATCHES = [`${ORPHAN_BASE_BATCH}__sub003`, `${ORPHAN_BASE_BATCH}__sub004`];
 const ORPHAN_FILE = 'harvard2014b.TXT';
+
+/** CTFS-migrated rows: real data, but no UploadBatchID was ever recorded. */
+const LEGACY_MIGRATED_FILE = 'ctfs-migration';
 
 const CONTROL_FILE = 'control.csv';
 
@@ -187,6 +190,23 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     return Number(cmResult.insertId);
   }
 
+  /**
+   * Rows with a NULL UploadBatchID. `coremeasurements.UploadBatchID` is
+   * nullable and the CTFS migration inserts never populate it, so any census
+   * assembled from a legacy import is entirely this shape.
+   */
+  async function seedNullBatchRows(fileID: string, censusID: number, count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      rowIndexCounter += 1;
+      await connection.query(
+        `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+           UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, IsActive)
+         VALUES (?, NULL, FALSE, '2024-03-15', 1.0, 1.0, ?, NULL, ?, ?, 1)`,
+        [censusID, fileID, `L${rowIndexCounter}`, rowIndexCounter]
+      );
+    }
+  }
+
   async function seedMetric(fileID: string, batchID: string, forPlotID: number, censusID: number, status = 'completed'): Promise<void> {
     await connection.query(
       `INSERT INTO uploadmetrics (uploadId, fileID, batchID, schema_name, plotID, censusID, sourceRecords, processedRecords, failedRecords, status, startTime)
@@ -266,6 +286,9 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     // filename replacement, so this must go too.
     await seedParkedRows(PRIOR_FILE_DIFFERENT_NAME, PRIOR_BATCH_DIFFERENT_NAME, targetCensusID, 2);
 
+    // Legacy CTFS-migrated rows with a NULL UploadBatchID.
+    await seedNullBatchRows(LEGACY_MIGRATED_FILE, targetCensusID, 3);
+
     // The incoming upload's own metric row — must SURVIVE (it is the new upload).
     await seedMetric(INCOMING_FILE, INCOMING_BATCH, plotID, targetCensusID, 'processing');
 
@@ -311,7 +334,7 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     const beforeParked = await countRows(targetCensusID, 'parked');
     const beforeIngested = await countRows(targetCensusID, 'ingested');
     console.log(`[target] before: total=${before} parked=${beforeParked} ingested=${beforeIngested}`);
-    expect(before).toBe(3 + 1 + ORPHAN_SUB_BATCHES.length * 4 + 2); // 14
+    expect(before).toBe(3 + 1 + ORPHAN_SUB_BATCHES.length * 4 + 2 + 3); // 17
 
     await runCleanReupload();
 
@@ -336,6 +359,57 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     console.log(`[orphans] surviving: ${JSON.stringify(orphanRows)}`);
     expect(orphanRows).toHaveLength(0);
   }, 120000);
+
+  /**
+   * `NOT (col <=> ?) AND NOT (col LIKE ?)` looks NULL-safe because of the <=>,
+   * but the LIKE arm returns NULL for a NULL column, and `TRUE AND NULL` is
+   * NULL — so every legacy row silently survived a replacement that reported
+   * success, leaving the census duplicated with no way to ever clean it.
+   */
+  it('removes legacy rows whose UploadBatchID is NULL', async () => {
+    await seedFixture();
+
+    const [before] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE CensusID = ? AND UploadBatchID IS NULL`, [
+      targetCensusID
+    ]);
+    console.log(`[null-batch] before: ${before[0].count} row(s) with UploadBatchID IS NULL`);
+    expect(Number(before[0].count)).toBe(3);
+
+    await runCleanReupload();
+
+    const [after] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE CensusID = ? AND UploadBatchID IS NULL`, [
+      targetCensusID
+    ]);
+    console.log(`[null-batch] after: ${after[0].count}`);
+    expect(Number(after[0].count)).toBe(0);
+  }, 120000);
+
+  /**
+   * The deletes are issued as `DELETE ... LIMIT n` in a loop so no single
+   * statement locks an entire 100k-row census. The loop has to keep going past
+   * the first window — a seeded set larger than one chunk proves it does, and
+   * that it terminates.
+   */
+  it('deletes a census larger than one delete chunk, not just the first window', async () => {
+    const overOneChunk = CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE + 137;
+    // Generated set-wise: 5137 single-row INSERTs would dominate the suite.
+    // The server default caps recursive CTEs at 1000 iterations.
+    await connection.query(`SET SESSION cte_max_recursion_depth = ?`, [overOneChunk + 1]);
+    await connection.query(
+      `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+         UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, IsActive)
+       WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?)
+       SELECT ?, NULL, FALSE, '2024-03-15', 1.0, 1.0, ?, 'bulk-prior-batch', CONCAT('B', n), n, 1 FROM seq`,
+      [overOneChunk, targetCensusID, PRIOR_FILE_WITH_METRICS]
+    );
+    expect(await countRows(targetCensusID, 'all')).toBe(overOneChunk);
+
+    await runCleanReupload();
+
+    const surviving = await countRows(targetCensusID, 'all');
+    console.log(`[chunked-delete] seeded=${overOneChunk} chunk=${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE} surviving=${surviving}`);
+    expect(surviving).toBe(0);
+  }, 180000);
 
   it('removes prior rows under a DIFFERENT UploadFileID (census replacement, not filename replacement)', async () => {
     await seedFixture();


### PR DESCRIPTION
Follow-up to #382. That PR made clean re-upload census-scoped instead of uploadmetrics-driven, which stopped it stranding rows whose batch never recorded a metric. Review of that change found two defects in it; the corrections existed only as uncommitted working-tree changes when #382 was pushed, so they were not included in it and land here.

Both are latent in what #382 merged — that version is still a strict improvement on the metrics-driven original, but neither defect is fixed there.

## NULL-poisoning

`NOT (col LIKE ?)` evaluates to NULL when `UploadBatchID` is NULL, and NULL poisons the surrounding conjunction, so the row matched no delete.

`coremeasurements.UploadBatchID` is nullable and the CTFS migration never populates it, so a census assembled from a legacy import is entirely that shape — every one of its rows was silently spared by a "census replacement" that reported success. Both arms of the family predicate are now NULL-safe: a NULL batch id belongs to no family, so it is always a prior row.

`forestgeo_harvard` census 9 carries a batch id on all 116,227 rows and is unaffected; sites with CTFS-migrated data are not.

## Unbounded DELETE

A single statement over a whole census (Harvard: 116,227 rows) locks the entire row set for the duration of the statement and can exceed `innodb_lock_wait_timeout`, failing the staging chunk that owns the transaction and re-running on every retry.

Deletes are now bounded at 5,000 rows per statement, re-issued until a pass stops filling the limit. The multi-table `DELETE ... JOIN` became a single-table `DELETE` over a subquery, because MySQL rejects `LIMIT` on multi-table deletes.

## Verification

The integration suite gains legacy rows with a NULL `UploadBatchID` in both the target census (must be removed) and the control census (must be untouched) — the shape the previous fixture lacked, which is why it could not catch this.

Validated at scale against a restored copy of `forestgeo_harvard` on local Docker: 118,729 rows in the target census including 2,500 seeded NULL-batch rows, all removed except the incoming batch family, with the control census byte-identical by ordered-ID digest and its own 500 NULL-batch rows intact. Bounded deletes took 27.4s versus 25.6s unbounded, so chunking costs little. No live data was modified.

Also carries `uploadSessionHasStagedRows`, a probe for in-flight work on session-scoped census replacement. It is exported but not yet called.
