### PR TITLE
Fix async-upload file-name identity, per-session census replacement, request bounds

### DIFF
--- a/frontend/app/api/files/[operation]/route.ts
+++ b/frontend/app/api/files/[operation]/route.ts
@@ -8,6 +8,7 @@ import { auth } from '@/auth';
 import { getSessionUserId } from '@/lib/auth-helpers';
 import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
+import { sanitizeUploadFileName as sanitizeFileName } from '@/lib/uploads/file-names';
 import path from 'path';
 import type { Session } from 'next-auth';
 import { FormType, normalizeSourceFormat, SourceFormat } from '@/config/macros/formdetails';
@@ -20,13 +21,6 @@ export const runtime = 'nodejs';
 const ALLOWED_FILE_EXTENSIONS = ['.csv', '.txt', '.xlsx'] as const;
 const ALLOWED_MIME_TYPES = ['text/csv', 'text/plain', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'] as const;
 const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB limit
-
-function sanitizeFileName(fileName: string): string {
-  // Remove path separators and special characters
-  const baseName = path.basename(fileName);
-  // Allow only alphanumeric, dots, hyphens, underscores
-  return baseName.replace(/[^a-zA-Z0-9._-]/g, '_');
-}
 
 function isValidFileExtension(fileName: string): boolean {
   const ext = path.extname(fileName).toLowerCase();

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -398,6 +398,115 @@ describe('POST /api/uploadjobs', () => {
     expect(mocks.runJobIfClaimable).toHaveBeenCalledWith(42);
   });
 
+  // /api/files/upload rewrites the stored file name through sanitizeFileName,
+  // and that stored name is what files[].fileName carries. Every later
+  // reference — payload map keys, the ArcGIS pre-flight file name — has to be
+  // compared in the same canonical form, or a file whose name contains a
+  // space (Harvard Forest 2014.csv) can never be queued.
+  it('accepts payload maps keyed by the sanitized name the blob upload stored', async () => {
+    const response = await callPost(
+      makeCreateRequest(
+        makeCreateBody({
+          files: [{ ...makeCreateBody().files[0], fileName: 'Harvard_Forest_2014.csv', blobName: 'uploads/job-1/Harvard_Forest_2014.csv' }],
+          payload: {
+            selectedDelimiters: { 'Harvard_Forest_2014.csv': ',' },
+            columnMappings: { 'Harvard_Forest_2014.csv': VALID_COLUMN_MAPPING }
+          }
+        })
+      )
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.createUploadBackgroundJob).toHaveBeenCalledWith(
+      'catalog-pool',
+      expect.objectContaining({
+        payload: expect.objectContaining({ selectedDelimiters: { 'Harvard_Forest_2014.csv': ',' } })
+      }),
+      'mason@example.com'
+    );
+  });
+
+  it('still rejects payload maps naming a file the job does not carry', async () => {
+    const response = await callPost(
+      makeCreateRequest(
+        makeCreateBody({
+          payload: { selectedDelimiters: { 'some-other-file.csv': ',' } }
+        })
+      )
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'payload.selectedDelimiters.some-other-file.csv', message: expect.stringContaining('unknown file name') })
+      ])
+    );
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it('accepts an ArcGIS job whose pre-flight file name only differs by blob-name sanitization', async () => {
+    const response = await callPost(
+      makeCreateRequest(
+        makeCreateBody({
+          sourceFormat: 'arcgis_xlsx',
+          files: [{ ...makeCreateBody().files[0], fileName: 'Harvard_Survey_2014.xlsx', blobName: 'Harvard_Survey_2014.xlsx', sourceFormat: 'arcgis_xlsx' }],
+          payload: {
+            // The pre-flight session records the raw browser name.
+            arcgisImportSession: { importSessionId: 'import-1', fileName: 'Harvard Survey 2014.xlsx', rowCount: 100 }
+          }
+        })
+      )
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.runJobIfClaimable).toHaveBeenCalledWith(42);
+  });
+
+  it('rejects an ArcGIS job whose file is not the pre-flight file at all', async () => {
+    const response = await callPost(
+      makeCreateRequest(
+        makeCreateBody({
+          sourceFormat: 'arcgis_xlsx',
+          files: [{ ...makeCreateBody().files[0], fileName: 'unrelated.xlsx', blobName: 'unrelated.xlsx', sourceFormat: 'arcgis_xlsx' }],
+          payload: { arcgisImportSession: { importSessionId: 'import-1', fileName: 'Harvard Survey 2014.xlsx', rowCount: 100 } }
+        })
+      )
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  // census.PlotCensusNumber is nullable. The scope guard reports that rather
+  // than denying access (other routes do not need the number), so THIS route —
+  // which needs it to name the blob container — must reject it itself, and as
+  // a request problem rather than an authorization failure.
+  it('rejects a census with no plot census number with 400, not 403', async () => {
+    mocks.assertCanEditMeasurementScope.mockResolvedValueOnce({ plotCensusNumber: null } as any);
+
+    const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: expect.stringContaining('no plot census number') });
+    expect(mocks.getContainerName).not.toHaveBeenCalled();
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized request before anything reads or parses the body', async () => {
+    const request = makeCreateRequest(makeCreateBody());
+    request.headers.set('content-length', String(8 * 1024 * 1024));
+    const jsonSpy = vi.spyOn(request, 'json');
+
+    const response = await callPost(request);
+
+    expect(response.status).toBe(413);
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(mocks.auth).not.toHaveBeenCalled();
+    expect(mocks.assertCanEditMeasurementScope).not.toHaveBeenCalled();
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it('rejects an ArcGIS job with more than one file', async () => {
     const file = makeCreateBody().files[0];
     const response = await callPost(

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -17,7 +17,8 @@ import { createUploadBackgroundJob, listBackgroundJobs } from '@/lib/background-
 import { IdempotencyKeyConflictError } from '@/lib/background-jobs/errors';
 import { isPrivilegedSession, parseOptionalPositiveInteger } from '@/lib/background-jobs/route-helpers';
 import { runJobIfClaimable } from '@/lib/background-jobs/worker';
-import { fromBody, fromQuery, withRouteAuthz } from '@/lib/route-authz';
+import { fromBody, fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
+import { sanitizeUploadFileName } from '@/lib/uploads/file-names';
 import { getContainerName, SchemaContainerNameError } from '@/config/macros/containernames';
 import ailogger from '@/ailogger';
 
@@ -26,6 +27,14 @@ export const runtime = 'nodejs';
 const ASYNC_UPLOADS_DISABLED_MESSAGE = 'Async uploads are not enabled for this form/site/user';
 const MAX_UPLOAD_JOB_FILES = 100;
 const MAX_UPLOAD_JOB_PAYLOAD_BYTES = 1024 * 1024;
+/**
+ * Whole-request ceiling, checked against Content-Length before anything reads
+ * the body. The payload cap below can only be measured after parsing, so it
+ * cannot stop an oversized request from being buffered — this can. The headroom
+ * over the payload cap covers the envelope and up to MAX_UPLOAD_JOB_FILES file
+ * descriptors.
+ */
+const MAX_UPLOAD_JOB_REQUEST_BYTES = 4 * 1024 * 1024;
 const MAX_UPLOAD_FILE_BYTES = 100 * 1024 * 1024;
 const MYSQL_SIGNED_INT_MAX = 2_147_483_647;
 
@@ -144,6 +153,9 @@ const CreateUploadJobSchema = z
       ctx.addIssue({ code: 'custom', path: ['files'], message: 'Combined expectedRows exceeds the supported job total' });
     }
 
+    // Second layer: bounds the payload the worker will persist and replay.
+    // MAX_UPLOAD_JOB_REQUEST_BYTES is what keeps an oversized body from being
+    // buffered in the first place.
     if (Buffer.byteLength(JSON.stringify(input.payload ?? {}), 'utf8') > MAX_UPLOAD_JOB_PAYLOAD_BYTES) {
       ctx.addIssue({ code: 'custom', path: ['payload'], message: 'Upload job payload exceeds the 1 MiB limit' });
     }
@@ -166,7 +178,10 @@ const CreateUploadJobSchema = z
           path: ['payload', 'arcgisImportSession'],
           message: 'ArcGIS uploads require payload.arcgisImportSession with importSessionId, fileName, and rowCount'
         });
-      } else if (input.files.length !== 1 || input.files[0]?.fileName !== arcgisSession.data.fileName) {
+        // The pre-flight session records the raw browser file name while
+        // files[].fileName is the sanitized name the blob upload stored, so the
+        // identity cross-check has to run on the canonical form of both.
+      } else if (input.files.length !== 1 || input.files[0]?.fileName !== sanitizeUploadFileName(arcgisSession.data.fileName)) {
         ctx.addIssue({
           code: 'custom',
           path: ['files'],
@@ -175,6 +190,18 @@ const CreateUploadJobSchema = z
       }
     }
   });
+
+/**
+ * Rejects an oversized request before any code reads its body. The authz
+ * wrapper resolves the schema with `fromBody`, which clones and fully parses
+ * the request, so this has to run ahead of the wrapper — not inside the handler
+ * it guards.
+ */
+function oversizedRequestResponse(request: NextRequest): NextResponse | null {
+  const declaredLength = Number(request.headers.get('content-length'));
+  if (!Number.isFinite(declaredLength) || declaredLength <= MAX_UPLOAD_JOB_REQUEST_BYTES) return null;
+  return NextResponse.json({ error: `Upload job request exceeds the ${MAX_UPLOAD_JOB_REQUEST_BYTES}-byte limit` }, { status: HTTPResponses.PAYLOAD_TOO_LARGE });
+}
 
 function validationErrorResponse(error: z.ZodError) {
   return NextResponse.json(
@@ -214,7 +241,7 @@ async function postHandler(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid schema' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  let authorizedScope: { plotCensusNumber: number };
+  let authorizedScope: { plotCensusNumber: number | null };
   try {
     authorizedScope = await assertCanEditMeasurementScope(ConnectionManager.getInstance(), session!, {
       schema: input.schema,
@@ -243,6 +270,18 @@ async function postHandler(request: NextRequest) {
           `received formType="${input.formType}" sourceFormat="${input.sourceFormat}"`
       },
       { status: HTTPResponses.FORBIDDEN }
+    );
+  }
+
+  // Blob containers are named after the plot census number, so THIS route
+  // cannot proceed without one. The scope guard deliberately does not reject
+  // such a census — routes that only need "does this scope exist and is it
+  // mine" (edits, revisions, upload sessions) must keep working for censuses
+  // whose nullable PlotCensusNumber was never populated.
+  if (authorizedScope.plotCensusNumber === null) {
+    return NextResponse.json(
+      { error: `Census ${input.censusID} has no plot census number; async uploads need one to address blob storage` },
+      { status: HTTPResponses.INVALID_REQUEST }
     );
   }
 
@@ -344,5 +383,12 @@ async function getHandler(request: NextRequest) {
   return NextResponse.json({ jobs }, { status: HTTPResponses.OK });
 }
 
-export const POST = withRouteAuthz('uploadjobs', postHandler, { schema: fromBody('schema') });
+const authorizedPost = withRouteAuthz('uploadjobs', postHandler, { schema: fromBody('schema') });
+
+export async function POST(request: NextRequest, context: RouteContext): Promise<Response> {
+  const oversized = oversizedRequestResponse(request);
+  if (oversized) return oversized;
+  return authorizedPost(request, context);
+}
+
 export const GET = withRouteAuthz('uploadjobs', getHandler, { schema: fromQuery('schema') });

--- a/frontend/components/client/uploadjobstatusbadge.test.ts
+++ b/frontend/components/client/uploadjobstatusbadge.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { selectVisibleJobs, type UploadJobSummary } from './uploadjobstatusbadge';
+import { selectVisibleJobs, summarizeJobs, type UploadJobSummary } from './uploadjobstatusbadge';
 
 const NOW = Date.parse('2026-07-28T12:00:00.000Z');
 
-function job(status: string, updatedAt: string): UploadJobSummary {
+function job(status: string, updatedAt: string, jobID = 1): UploadJobSummary {
   return {
-    jobID: 1,
+    jobID,
     status,
     phase: status,
     percentComplete: 0,
@@ -31,5 +31,39 @@ describe('selectVisibleJobs', () => {
     );
 
     expect(visible.map(entry => entry.status)).toEqual(['running', 'failed', 'completed']);
+  });
+});
+
+describe('summarizeJobs', () => {
+  // The API orders by UpdatedAt DESC and terminal jobs stay visible for a day,
+  // so a job that finished five minutes ago sorts ahead of one still sitting in
+  // 'queued' with its creation timestamp. Reading jobs[0] made the badge
+  // announce a completed job while live work was invisible behind it.
+  it('leads with live work even when a finished job sorted ahead of it', () => {
+    const jobs = [job('completed', '2026-07-28T11:55:00.000Z', 41), job('queued', '2026-07-28T11:30:00.000Z', 42)];
+
+    expect(summarizeJobs(jobs).primaryJob.jobID).toBe(42);
+  });
+
+  it('speaks for the most recently updated job when several are in flight', () => {
+    const jobs = [job('running', '2026-07-28T11:59:00.000Z', 43), job('queued', '2026-07-28T11:30:00.000Z', 44)];
+
+    expect(summarizeJobs(jobs).primaryJob.jobID).toBe(43);
+  });
+
+  it('does not report failure while another job is still in flight', () => {
+    const jobs = [job('failed', '2026-07-28T11:55:00.000Z', 41), job('running', '2026-07-28T11:30:00.000Z', 42)];
+
+    const summary = summarizeJobs(jobs);
+    expect(summary.hasFailure).toBe(false);
+    expect(summary.primaryJob.jobID).toBe(42);
+  });
+
+  it('reports failure once nothing is in flight', () => {
+    const jobs = [job('completed', '2026-07-28T11:55:00.000Z', 41), job('failed', '2026-07-28T11:30:00.000Z', 42)];
+
+    const summary = summarizeJobs(jobs);
+    expect(summary.hasFailure).toBe(true);
+    expect(summary.primaryJob.jobID).toBe(41);
   });
 });

--- a/frontend/components/client/uploadjobstatusbadge.tsx
+++ b/frontend/components/client/uploadjobstatusbadge.tsx
@@ -34,6 +34,25 @@ export function selectVisibleJobs(jobs: UploadJobSummary[], nowMs: number = Date
   });
 }
 
+/**
+ * Chooses the job the badge headline speaks for, and whether the badge reads as
+ * failed.
+ *
+ * The list arrives ordered by UpdatedAt and terminal jobs stay visible for a
+ * day, so `jobs[0]` is regularly a finished job standing in front of work that
+ * is still running. Live work is what the badge exists to surface, so an active
+ * job always outranks a terminal one, and a past failure only colours the badge
+ * once nothing is in flight — otherwise one failed job paints a healthy running
+ * upload red for the rest of the day.
+ */
+export function summarizeJobs(jobs: UploadJobSummary[]): { primaryJob: UploadJobSummary; hasFailure: boolean } {
+  const activeJobs = jobs.filter(job => ACTIVE_JOB_STATUSES.has(job.status));
+  return {
+    primaryJob: activeJobs[0] ?? jobs[0],
+    hasFailure: activeJobs.length === 0 && jobs.some(job => job.status === 'failed')
+  };
+}
+
 function formatPhase(phase: string): string {
   return phase
     .split('_')
@@ -144,9 +163,8 @@ export default function UploadJobStatusBadge({ schema, plotID, censusID }: { sch
 
   if (jobs.length === 0) return null;
 
-  const hasFailure = jobs.some(job => job.status === 'failed');
+  const { primaryJob, hasFailure } = summarizeJobs(jobs);
   const hasWaitingRetry = jobs.some(job => job.status === 'waiting_retry');
-  const primaryJob = jobs[0];
   const color = hasFailure ? 'danger' : hasWaitingRetry ? 'warning' : 'primary';
   const progressValue = Math.max(1, Math.round(primaryJob.percentComplete || 0));
 
@@ -221,7 +239,7 @@ export default function UploadJobStatusBadge({ schema, plotID, censusID }: { sch
                 <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
                   <Chip
                     variant="soft"
-                    color={job.status === 'waiting_retry' || job.status === 'cancel_requested' ? 'warning' : hasFailure ? 'danger' : 'primary'}
+                    color={job.status === 'waiting_retry' || job.status === 'cancel_requested' ? 'warning' : job.status === 'failed' ? 'danger' : 'primary'}
                     size="sm"
                   >
                     Job {job.jobID}

--- a/frontend/components/uploadsystem/segments/uploadasyncjob.test.ts
+++ b/frontend/components/uploadsystem/segments/uploadasyncjob.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ailogger from '@/ailogger';
-import { cleanupUploadedFiles, type BlobUploadResult } from './uploadasyncjob';
+import { cleanupUploadedFiles, rekeyByStoredFileName, type BlobUploadResult, type UploadedFileReference } from './uploadasyncjob';
 
 vi.mock('@/ailogger', () => ({
   default: { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
@@ -15,6 +15,43 @@ const file: BlobUploadResult = {
   formType: 'measurements',
   sourceFormat: 'csv'
 };
+
+describe('rekeyByStoredFileName', () => {
+  // /api/files/upload replaces every character outside [a-zA-Z0-9._-] with '_'
+  // and stores the blob under that name. The wizard keys its delimiter and
+  // column-mapping maps by the raw browser File.name, so without re-keying the
+  // job route rejects the whole request with "unknown file name" and the worker
+  // would never find the mapping for the file it is processing.
+  const uploadedFiles: UploadedFileReference[] = [
+    {
+      originalFileName: 'Harvard Forest 2014.csv',
+      blob: { ...file, fileName: 'Harvard_Forest_2014.csv', blobName: 'Harvard_Forest_2014.csv' }
+    },
+    {
+      originalFileName: 'plain.csv',
+      blob: { ...file, fileName: 'plain.csv', blobName: 'plain.csv' }
+    }
+  ];
+
+  it('re-keys wizard maps from the browser file name to the stored blob file name', () => {
+    const delimiters = { 'Harvard Forest 2014.csv': ',', 'plain.csv': '\t' };
+
+    expect(rekeyByStoredFileName(delimiters, uploadedFiles)).toEqual({
+      'Harvard_Forest_2014.csv': ',',
+      'plain.csv': '\t'
+    });
+  });
+
+  it('drops entries for files that were never uploaded rather than sending unknown names', () => {
+    const mappings = { 'Harvard Forest 2014.csv': { version: 1 }, 'removed-by-user.csv': { version: 1 } };
+
+    expect(rekeyByStoredFileName(mappings, uploadedFiles)).toEqual({ 'Harvard_Forest_2014.csv': { version: 1 } });
+  });
+
+  it('returns an empty map when nothing was uploaded', () => {
+    expect(rekeyByStoredFileName({ 'Harvard Forest 2014.csv': ',' }, [])).toEqual({});
+  });
+});
 
 describe('cleanupUploadedFiles', () => {
   afterEach(() => {

--- a/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
+++ b/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
@@ -72,6 +72,30 @@ function getExpectedRows(fileName: string, parsedData: FileCollectionRowSet, arc
   return rows ? Object.keys(rows).length : null;
 }
 
+/** An uploaded blob paired with the browser file name every wizard map is keyed by. */
+export interface UploadedFileReference {
+  originalFileName: string;
+  blob: BlobUploadResult;
+}
+
+/**
+ * Re-keys a wizard map from raw browser file names to the names the upload
+ * route actually stored. The job route validates payload keys against
+ * `files[].fileName` and the worker looks delimiters/mappings up by the same
+ * value, so a raw-keyed map is rejected outright (and, before it was
+ * validated, silently ignored). Entries with no uploaded counterpart are
+ * dropped rather than sent as unknown file names.
+ */
+export function rekeyByStoredFileName<T>(source: Record<string, T>, uploadedFiles: UploadedFileReference[]): Record<string, T> {
+  const storedNames = new Map(uploadedFiles.map(entry => [entry.originalFileName, entry.blob.fileName]));
+  return Object.fromEntries(
+    Object.entries(source).flatMap(([originalFileName, value]) => {
+      const storedFileName = storedNames.get(originalFileName);
+      return storedFileName ? [[storedFileName, value] as const] : [];
+    })
+  );
+}
+
 async function readErrorMessage(response: Response): Promise<string> {
   try {
     const payload = await response.json();
@@ -137,10 +161,22 @@ export default function UploadAsyncJob({
     if (hasStartedRef.current) return;
     hasStartedRef.current = true;
 
+    // Teardown only stops this run from writing THIS component's own progress
+    // state. It must NEVER abort the run: hasStartedRef makes the effect
+    // one-shot for the component instance, so an aborted run has no restart
+    // path — it would strand the dialog mid-progress and (via the cleanup
+    // below) delete blobs the user already uploaded. A re-render with new
+    // dependency identities, and React StrictMode's double-invoke in dev, both
+    // take this path. The outcome setters the parent owns (upload error, review
+    // state, unsaved flag) are always called: the parent outlives this dialog
+    // and a swallowed failure would leave the wizard reporting nothing at all.
     let cancelled = false;
+    const setStepIfLive = (step: string) => {
+      if (!cancelled) setCurrentStep(step);
+    };
 
     async function runAsyncUpload() {
-      const uploadedFiles: BlobUploadResult[] = [];
+      const uploadedFiles: UploadedFileReference[] = [];
       let cleanupAllowed = true;
       let cleanupScope: UploadStorageScope | null = null;
       try {
@@ -159,9 +195,8 @@ export default function UploadAsyncJob({
         const totalSteps = acceptedFiles.length + 1;
 
         for (let index = 0; index < acceptedFiles.length; index++) {
-          if (cancelled) return;
           const file = acceptedFiles[index];
-          setCurrentStep(`Uploading ${file.name} to cloud storage...`);
+          setStepIfLive(`Uploading ${file.name} to cloud storage...`);
 
           const params = new URLSearchParams({
             fileName: file.name,
@@ -185,12 +220,11 @@ export default function UploadAsyncJob({
             throw new Error(`Failed to upload ${file.name}: ${await readErrorMessage(response)}`);
           }
 
-          uploadedFiles.push((await response.json()) as BlobUploadResult);
-          setProgress(Math.round(((index + 1) / totalSteps) * 100));
+          uploadedFiles.push({ originalFileName: file.name, blob: (await response.json()) as BlobUploadResult });
+          if (!cancelled) setProgress(Math.round(((index + 1) / totalSteps) * 100));
         }
 
-        if (cancelled) return;
-        setCurrentStep('Queueing background processing job...');
+        setStepIfLive('Queueing background processing job...');
 
         // Once the queue request is on the wire, a network failure is ambiguous:
         // the server may already have committed the job. Do not delete blobs in
@@ -212,19 +246,19 @@ export default function UploadAsyncJob({
               plotName,
               plotCensusNumber,
               usesSubquadrats: currentPlot?.usesSubquadrats === true,
-              selectedDelimiters,
-              columnMappings: columnMappings ?? {},
+              selectedDelimiters: rekeyByStoredFileName(selectedDelimiters, uploadedFiles),
+              columnMappings: rekeyByStoredFileName(columnMappings ?? {}, uploadedFiles),
               arcgisImportSession: arcgisImportSession ?? null
             },
-            files: uploadedFiles.map(file => ({
-              fileName: file.fileName,
-              blobContainer: file.blobContainer,
-              blobName: file.blobName,
-              contentType: file.contentType,
-              byteSize: file.byteSize,
-              sourceFormat: file.sourceFormat,
-              formType: file.formType,
-              expectedRows: getExpectedRows(file.fileName, parsedData, arcgisImportSession)
+            files: uploadedFiles.map(({ originalFileName, blob }) => ({
+              fileName: blob.fileName,
+              blobContainer: blob.blobContainer,
+              blobName: blob.blobName,
+              contentType: blob.contentType,
+              byteSize: blob.byteSize,
+              sourceFormat: blob.sourceFormat,
+              formType: blob.formType,
+              expectedRows: getExpectedRows(originalFileName, parsedData, arcgisImportSession)
             }))
           })
         });
@@ -238,10 +272,11 @@ export default function UploadAsyncJob({
           throw new Error(jobPayload.error || jobPayload.details || `Failed to queue background upload job: HTTP ${jobResponse.status}`);
         }
 
+        setIsDataUnsaved(false);
+        if (cancelled) return;
         setQueuedJobID(jobPayload.job.jobID);
         setProgress(100);
         setCurrentStep('Background processing accepted.');
-        setIsDataUnsaved(false);
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
         ailogger.error('[UploadAsyncJob] Failed to start async upload:', err);
@@ -250,7 +285,10 @@ export default function UploadAsyncJob({
         setReviewState(ReviewStates.ERRORS);
       } finally {
         if (cleanupAllowed && cleanupScope && uploadedFiles.length > 0) {
-          await cleanupUploadedFiles(uploadedFiles, cleanupScope);
+          await cleanupUploadedFiles(
+            uploadedFiles.map(entry => entry.blob),
+            cleanupScope
+          );
         }
       }
     }

--- a/frontend/config/editplan/scopeguard.test.ts
+++ b/frontend/config/editplan/scopeguard.test.ts
@@ -72,9 +72,17 @@ describe('assertCanEditMeasurementScope', () => {
     ).rejects.toBeInstanceOf(ScopeAccessError);
   });
 
-  it('rejects a census row whose storage census number is invalid', async () => {
+  // census.PlotCensusNumber is nullable and legacy/ctfsweb-imported rows carry
+  // NULL. Authorization must not hinge on it — editing, revisions and upload
+  // sessions only need the scope to exist and belong to the user. Callers that
+  // genuinely need the number (blob container naming) reject the null.
+  it.each([
+    ['NULL', null],
+    ['zero', 0],
+    ['non-numeric', 'not-a-number']
+  ])('reports an unusable %s census number instead of denying access', async (_label, storedValue) => {
     const cm = makeConnectionManager();
-    cm.executeQuery.mockResolvedValueOnce([{ PlotCensusNumber: null }]);
+    cm.executeQuery.mockResolvedValueOnce([{ PlotCensusNumber: storedValue }]);
 
     await expect(
       assertCanEditMeasurementScope(cm, makeSession(), {
@@ -82,7 +90,7 @@ describe('assertCanEditMeasurementScope', () => {
         plotID: 1,
         censusID: 2
       })
-    ).rejects.toBeInstanceOf(ScopeAccessError);
+    ).resolves.toEqual({ plotCensusNumber: null });
   });
 });
 

--- a/frontend/config/editplan/scopeguard.ts
+++ b/frontend/config/editplan/scopeguard.ts
@@ -38,7 +38,15 @@ function hasSchemaAccess(session: Session, schema: string): boolean {
   return (session.user?.sites ?? []).some(site => site.schemaName === schema);
 }
 
-async function resolvePlotCensusNumber(cm: ConnectionManager, schema: string, plotID: number, censusID: number): Promise<number> {
+/**
+ * Existence check that also reports the scope's PlotCensusNumber. A missing or
+ * unusable number is NOT an authorization failure: `census.PlotCensusNumber` is
+ * nullable and legacy/ctfsweb-imported rows carry NULL, and most callers only
+ * need to know the plot/census exists and belongs to the user. Callers that
+ * genuinely require the number (blob container naming) reject the null
+ * themselves.
+ */
+async function resolvePlotCensusNumber(cm: ConnectionManager, schema: string, plotID: number, censusID: number): Promise<number | null> {
   const rows = await cm.executeQuery(
     safeFormatQuery(
       schema,
@@ -56,10 +64,7 @@ async function resolvePlotCensusNumber(cm: ConnectionManager, schema: string, pl
     throw new ScopeAccessError('plot/census scope is not available');
   }
   const plotCensusNumber = Number(rows[0].PlotCensusNumber);
-  if (!Number.isSafeInteger(plotCensusNumber) || plotCensusNumber <= 0) {
-    throw new ScopeAccessError('plot/census scope has an invalid census number');
-  }
-  return plotCensusNumber;
+  return Number.isSafeInteger(plotCensusNumber) && plotCensusNumber > 0 ? plotCensusNumber : null;
 }
 
 async function probeActiveUploadSession(cm: ConnectionManager, schema: string, plotID: number, censusID: number, transactionID?: string): Promise<void> {
@@ -144,7 +149,7 @@ export async function assertCanEditMeasurementScope(
   cm: ConnectionManager,
   session: Session,
   input: MeasurementScopeInput
-): Promise<{ plotCensusNumber: number }> {
+): Promise<{ plotCensusNumber: number | null }> {
   if (!hasSchemaAccess(session, input.schema)) {
     throw new ScopeAccessError();
   }

--- a/frontend/instrumentation-node.ts
+++ b/frontend/instrumentation-node.ts
@@ -49,7 +49,7 @@ void (async () => {
     ailogger.warn('provisioning.worker.startup_failed', { errorMessage });
   }
 
-  // Upload-job sweeper — guarded separately so a sweep failure cannot abort
+  // Upload-job sweeper — guarded separately so a start-up failure cannot abort
   // the rest of instrumentation, and the interval keeps running even when the
   // startup sweep fails (the next tick retries).
   try {
@@ -59,9 +59,14 @@ void (async () => {
     // Both shutdown hooks (provisioning's installShutdownHandler and this one)
     // coexist via separate process.once registrations.
     installUploadSweeperShutdown();
-    const result = await runSweepTick(pool);
-    if (result && (result.reclaimed.length > 0 || result.dispatched.length > 0)) {
-      ailogger.info('upload.sweeper.startup', result);
+    // runSweepTick reports rather than throws, so the startup sweep's own
+    // failure is escalated here: this pass IS the deploy-recovery moment, and
+    // missing it is louder news than a routine mid-life tick failure.
+    const outcome = await runSweepTick(pool);
+    if (outcome.status === 'failed') {
+      ailogger.error('upload.sweeper.startup_failed', outcome.error);
+    } else if (outcome.status === 'completed' && (outcome.result.reclaimed.length > 0 || outcome.result.dispatched.length > 0)) {
+      ailogger.info('upload.sweeper.startup', outcome.result);
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/frontend/lib/background-jobs/sweeper.ts
+++ b/frontend/lib/background-jobs/sweeper.ts
@@ -134,26 +134,33 @@ export async function sweepOnce(catalogPool: Pool, deps: SweepDeps = defaultSwee
 // ---------------------------------------------------------------------------
 
 /**
- * One interval tick: skips when a previous pass hasn't resolved yet (in-flight
- * guard), otherwise runs a sweep pass. Used by the interval and exported for
- * direct use in tests.
+ * Outcome of one tick. A skipped tick and a failed tick are different events —
+ * the startup caller escalates a failure (the deploy-recovery sweep did not
+ * happen) but not a skip — so they are reported as distinct variants rather
+ * than a shared null.
  */
-export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepResult | null> {
+export type SweepTickOutcome = { status: 'completed'; result: SweepResult } | { status: 'skipped_in_flight' } | { status: 'failed'; error: Error };
+
+/**
+ * One interval tick: skips when a previous pass hasn't resolved yet (in-flight
+ * guard), otherwise runs a sweep pass. Never throws — a failed pass must not
+ * kill the interval — so callers read the outcome instead of catching.
+ */
+export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepTickOutcome> {
   const sweeperGlobal = globalThis as SweeperGlobal;
   const sentinel = sweeperGlobal[SWEEPER_SENTINEL];
   if (sentinel?.inFlight) {
     ailogger.info('upload.sweeper.tick_skipped_in_flight');
-    return null;
+    return { status: 'skipped_in_flight' };
   }
   if (sentinel) sentinel.inFlight = true;
   try {
-    return await sweepOnce(catalogPool, deps);
+    return { status: 'completed', result: await sweepOnce(catalogPool, deps) };
   } catch (error: unknown) {
     // A failed pass must never kill the interval — the next tick retries.
-    ailogger.warn('upload.sweeper.pass_failed', {
-      errorMessage: error instanceof Error ? error.message : String(error)
-    });
-    return null;
+    const failure = error instanceof Error ? error : new Error(String(error));
+    ailogger.warn('upload.sweeper.pass_failed', { errorMessage: failure.message });
+    return { status: 'failed', error: failure };
   } finally {
     const afterSentinel = (globalThis as SweeperGlobal)[SWEEPER_SENTINEL];
     if (afterSentinel) afterSentinel.inFlight = false;

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -43,6 +43,7 @@ import type { ColumnMapping } from '@/lib/column-mapping/types';
 import { commitArcgisImport } from '@/lib/uploads/arcgis-commit';
 import { collapseCensus } from '@/lib/uploads/collapse-census';
 import { detectDelimiter } from '@/lib/uploads/detect-delimiter';
+import { sanitizeUploadFileName } from '@/lib/uploads/file-names';
 import { ingestBatch, IngestBatchAbortedError } from '@/lib/uploads/ingest-batch';
 import { deleteUnresolvedRowsForBatchFamily, recordInvalidRows } from '@/lib/uploads/record-invalid-rows';
 import { buildSubBatchPattern, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
@@ -873,7 +874,9 @@ async function runArcgisPipeline(ctx: WorkerRunContext): Promise<void> {
 
   for (const file of job.files) {
     await assertStillOwned(ctx);
-    if (file.fileName !== arcgisSession.fileName) {
+    // The pre-flight session records the raw browser file name; file.fileName
+    // is the sanitized name the blob upload stored. Compare the canonical form.
+    if (file.fileName !== sanitizeUploadFileName(arcgisSession.fileName)) {
       throw new NonRetryableJobError(`ArcGIS async upload file ${file.fileName} does not match pre-flight file ${arcgisSession.fileName}`);
     }
 

--- a/frontend/lib/uploads/file-names.ts
+++ b/frontend/lib/uploads/file-names.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+
+/**
+ * Canonical blob-safe form of an uploaded file's name.
+ *
+ * `/api/files/upload` stores the blob under this name and echoes it back, so it
+ * — not the raw browser `File.name` — is the identity every later reference
+ * uses: upload-job `files[].fileName`, the payload maps the worker looks up
+ * delimiters and column mappings by, and the ArcGIS pre-flight cross-check.
+ * Comparing a raw name against a stored one rejects any file whose name
+ * contains a space, parenthesis, comma, or accented character.
+ */
+export function sanitizeUploadFileName(fileName: string): string {
+  const baseName = path.basename(fileName);
+  return baseName.replace(/[^a-zA-Z0-9._-]/g, '_');
+}

--- a/frontend/lib/uploads/stage-measurements.ts
+++ b/frontend/lib/uploads/stage-measurements.ts
@@ -31,6 +31,7 @@ import {
   findDroppedMeasurementCandidates,
   insertTemporaryMeasurementsInBatches,
   isUnsignedIntFieldInvalid,
+  uploadSessionHasStagedRows,
   type DroppedMeasurementRow
 } from '@/lib/ingestion/temporary-measurements';
 
@@ -208,7 +209,18 @@ export async function stageMeasurementChunk(connectionManager: ConnectionManager
     if (uploadMode === UploadMode.CLEAN_REUPLOAD && !params.suppressCensusReplacementCleanup) {
       // Clean up data from any previous uploads for this census.
       // Clean re-upload is census replacement, not filename replacement.
-      await cleanupPreviousFileUploads(connectionManager, schema, fileName, batchID, plotID, censusID, transactionID);
+      //
+      // Exactly ONCE per upload session, though: the synchronous route stages
+      // every file before any ingestion, so a second file re-running the
+      // census-wide cleanup would delete the failure rows the earlier files of
+      // this same upload just recorded (their batch IDs are outside the
+      // incoming family, and no uploadmetrics row exists yet to identify them
+      // as ours). Rows already staged under this session are that first pass.
+      const sessionAlreadyReplacedCensus =
+        uploadSessionID !== null && (await uploadSessionHasStagedRows(connectionManager, schema, uploadSessionID, plotID, censusID, transactionID));
+      if (!sessionAlreadyReplacedCensus) {
+        await cleanupPreviousFileUploads(connectionManager, schema, fileName, batchID, plotID, censusID, transactionID);
+      }
     }
 
     await cleanupStaleMeasurementBatchesForFile(connectionManager, schema, fileName, batchID, plotID, censusID, transactionID);

--- a/frontend/tests/integration/stage-measurements.test.ts
+++ b/frontend/tests/integration/stage-measurements.test.ts
@@ -222,7 +222,9 @@ describe('stageMeasurementChunk — integration', () => {
     }
     await connection.query('DELETE FROM temporarymeasurements');
     await connection.query('DELETE FROM unifiedchangelog');
-    console.log('[beforeEach] cleared temporarymeasurements + unifiedchangelog');
+    await connection.query('DELETE FROM coremeasurements');
+    await connection.query('DELETE FROM uploadmetrics');
+    console.log('[beforeEach] cleared temporarymeasurements + unifiedchangelog + coremeasurements + uploadmetrics');
   });
 
   function baseParams(transactionID: string, overrides: Partial<StageMeasurementChunkParams> = {}): StageMeasurementChunkParams {
@@ -427,6 +429,72 @@ describe('stageMeasurementChunk — integration', () => {
     console.log(`[re-stage] changelog metadata: ${JSON.stringify(metadata)}`);
     expect(metadata.rowCount).toBe(EXPECTED_STAGED_ROW_COUNT * 2);
     expect(metadata.batchCount).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // CLEAN_REUPLOAD census replacement runs ONCE per upload session
+  // -------------------------------------------------------------------------
+
+  const SECOND_FILE_NAME = 'stage-measurements-fixture-b.csv';
+  const SECOND_BATCH_ID = 'stage-batch-0002';
+
+  /**
+   * Stands in for the failure rows an earlier file of the same upload already
+   * wrote to coremeasurements — insertIngestionFailureRows uses the file's own
+   * batch id, and /api/batchedupload mints a fresh one. Neither is in the next
+   * file's batch family, and neither has an uploadmetrics row yet.
+   */
+  async function seedEarlierFileFailureRow(uploadBatchID: string): Promise<void> {
+    await connection.query(
+      `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+         UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, IsActive)
+       VALUES (?, NULL, FALSE, ?, 1.0, 1.0, ?, ?, 'T0005', 1, 1)`,
+      [censusID, VALID_DATE, FILE_NAME, uploadBatchID]
+    );
+  }
+
+  async function countCensusMeasurements(): Promise<number> {
+    const [rows] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE CensusID = ?`, [censusID]);
+    return Number(rows[0].count);
+  }
+
+  it('keeps the failure rows an earlier file of the SAME upload session recorded', async () => {
+    // File A of the upload stages and records two rejected rows.
+    const firstTransactionID = await connectionManager.beginTransaction();
+    await stageMeasurementChunk(connectionManager, baseParams(firstTransactionID));
+    await connectionManager.commitTransaction(firstTransactionID);
+    await seedEarlierFileFailureRow('stage-batch-0001-fail');
+    await seedEarlierFileFailureRow('batchedupload-fresh-id');
+    expect(await countCensusMeasurements()).toBe(2);
+
+    // File B of the SAME upload stages next. The synchronous route stages every
+    // file before any ingestion, so file A has no uploadmetrics row yet and its
+    // batches are outside file B's family — a second census-wide replacement
+    // here would destroy the only record of what file A rejected.
+    const secondTransactionID = await connectionManager.beginTransaction();
+    await stageMeasurementChunk(
+      connectionManager,
+      baseParams(secondTransactionID, { fileName: SECOND_FILE_NAME, batchID: SECOND_BATCH_ID, uploadSessionID: UPLOAD_SESSION_ID })
+    );
+    await connectionManager.commitTransaction(secondTransactionID);
+
+    const surviving = await countCensusMeasurements();
+    console.log(`[same-session] failure rows surviving file B's staging: ${surviving}`);
+    expect(surviving).toBe(2);
+  });
+
+  it('still replaces the census when a NEW upload session starts', async () => {
+    // Rows left behind by a genuinely previous upload.
+    await seedEarlierFileFailureRow('previous-upload-batch');
+    expect(await countCensusMeasurements()).toBe(1);
+
+    const transactionID = await connectionManager.beginTransaction();
+    await stageMeasurementChunk(connectionManager, baseParams(transactionID, { uploadSessionID: 'a-different-upload-session' }));
+    await connectionManager.commitTransaction(transactionID);
+
+    const surviving = await countCensusMeasurements();
+    console.log(`[new-session] prior rows surviving the census replacement: ${surviving}`);
+    expect(surviving).toBe(0);
   });
 
   it('rolling back the caller-owned transaction leaves no staged rows behind', async () => {

--- a/frontend/tests/integration/upload-sweeper.test.ts
+++ b/frontend/tests/integration/upload-sweeper.test.ts
@@ -401,11 +401,14 @@ describe('runSweepTick — in-flight guard', () => {
         dispatchCalls.push(jobID);
       })
     };
-    await runSweepTick(pool, skippingDeps);
-    console.log(`[in-flight] after tick 2: dispatchCalls=[${dispatchCalls.join(', ')}]`);
+    const skippedOutcome = await runSweepTick(pool, skippingDeps);
+    console.log(`[in-flight] after tick 2: outcome=${skippedOutcome.status} dispatchCalls=[${dispatchCalls.join(', ')}]`);
 
     // tick 2 must NOT have dispatched anything — the skip guard fired.
     expect(skippingDeps.dispatch).not.toHaveBeenCalled();
+    // A skip and a failure are different events: the startup caller escalates
+    // one and not the other, so they must be distinguishable.
+    expect(skippedOutcome).toEqual({ status: 'skipped_in_flight' });
 
     // Unblock tick 1 and let it finish.
     resolveFirstDispatch();
@@ -417,8 +420,40 @@ describe('runSweepTick — in-flight guard', () => {
 
     // A third tick now runs freely.
     const { deps: deps3, calls: calls3 } = makeDispatchStub();
-    await runSweepTick(pool, deps3);
-    console.log(`[in-flight] tick 3 (free): calls=[${calls3.join(', ')}]`);
+    const freeOutcome = await runSweepTick(pool, deps3);
+    console.log(`[in-flight] tick 3 (free): outcome=${freeOutcome.status} calls=[${calls3.join(', ')}]`);
     expect(deps3.dispatch).toHaveBeenCalled();
+    expect(freeOutcome.status).toBe('completed');
+  });
+});
+
+describe('runSweepTick — failure reporting', () => {
+  // The startup sweep IS the deploy-recovery moment for jobs orphaned by the
+  // previous process. runSweepTick must not throw (that would kill the
+  // interval), but a caller has to be able to tell a failed pass from a skipped
+  // one, or a boot that never recovered anything looks like a routine tick.
+  it('reports a failed pass as a distinct outcome carrying the error, without throwing', async () => {
+    const failure = new Error('catalog unreachable');
+    const throwingDeps: SweepDeps = {
+      dispatch: vi.fn(async () => {
+        throw failure;
+      })
+    };
+    // sweepOnce catches per-job dispatch errors, so fail the pass at the query
+    // layer instead — a dead pool is the real-world shape of this failure.
+    const deadPool = {
+      query: async () => {
+        throw failure;
+      },
+      execute: async () => {
+        throw failure;
+      }
+    } as unknown as Pool;
+
+    const outcome = await runSweepTick(deadPool, throwingDeps);
+    console.log(`[failure] outcome=${outcome.status}`);
+
+    expect(outcome.status).toBe('failed');
+    expect(outcome.status === 'failed' && outcome.error.message).toBe(failure.message);
   });
 });


### PR DESCRIPTION
Five defects in the revived async upload path, all found while preparing the Harvard acceptance run. Follow-up to #381/#382/#383 on the same branch.

## File-name identity

`/api/files/upload` stores a blob under a *sanitized* name and echoes that back, so the sanitized form — not the raw browser `File.name` — is the identity every later reference uses: upload-job `files[].fileName`, the payload maps the worker looks up delimiters and column mappings by, and the ArcGIS pre-flight cross-check.

That cross-check compared the two forms directly, in both the job-creation schema and the worker, so any file whose name contained a space, parenthesis, comma or accented character was rejected as a mismatch. `sanitizeUploadFileName` moves to `lib/uploads/file-names` so the upload route, the creation guard and the worker all derive the canonical form from one place.

## Census replacement ran once per file, not once per upload

The synchronous route stages every file before any ingestion, so on a multi-file clean re-upload the second file's census-wide cleanup deleted the failure rows the first file had just recorded — those rows' batch IDs are outside the incoming family, and no `uploadmetrics` row exists yet to identify them as ours.

This only became reachable once the cleanup was made census-scoped in #382; the previous `uploadmetrics`-driven delete list could not see those rows, so it spared them by accident. Replacement is now gated on whether this upload session has already staged rows for the plot/census.

## Request size was bounded only after parsing

`MAX_UPLOAD_JOB_PAYLOAD_BYTES` is measured post-parse, and the authz wrapper's `fromBody` resolver clones and fully parses the request before the handler runs — so nothing stopped an oversized body from being buffered. A `Content-Length` check now runs ahead of the wrapper.

## Nullable PlotCensusNumber

Blob containers are named after it, so job creation cannot proceed without one. The shared scope guard must not reject such a census outright, though — edits, revisions and upload sessions have to keep working for censuses whose nullable column was never populated. The guard now reports it as nullable and this route rejects the null itself.

## Sweeper tick outcomes

`runSweepTick` returned `null` for both "skipped, a pass is already in flight" and "the pass failed", so instrumentation could not tell them apart. The startup sweep is the deploy-recovery moment for jobs orphaned by the previous process, and its failure is louder news than a routine mid-life tick failure. Ticks now report a discriminated outcome and startup escalates a failure.
