### PR TITLE
fix(db): kill and quarantine timed-out query connections

### DIFF
--- a/frontend/lib/db/connectionmanager.ts
+++ b/frontend/lib/db/connectionmanager.ts
@@ -2,7 +2,7 @@
 import '@/lib/connectionlogger';
 import { PoolConnection } from 'mysql2/promise';
 import chalk from 'chalk';
-import { getConn, runQuery } from '@/lib/db/primitives';
+import { getConn, killQueryOnThread, runQuery } from '@/lib/db/primitives';
 import { v4 as uuidv4 } from 'uuid';
 import { patchConnectionManager, flushTransactionChangelog, discardTransactionChangelog } from '@/lib/connectionlogger';
 import ailogger from '@/ailogger';
@@ -399,33 +399,6 @@ class ConnectionManager {
     }
   }
 
-  /**
-   * Abort the statement currently executing on `threadId` by issuing
-   * `KILL QUERY` from a SEPARATE pooled connection. Used by withTransaction on
-   * timeout: the transaction's own connection is blocked behind the runaway
-   * statement, so the abort must come from a different connection. KILL QUERY
-   * stops only the active statement and leaves the connection/thread alive, so
-   * the queued ROLLBACK can then run and release the connection.
-   *
-   * KILL is not preparable in MySQL, so this uses the text protocol with a
-   * numeric thread id (never user input) rather than a bound parameter.
-   */
-  private async killRunningQuery(threadId: number): Promise<void> {
-    if (!Number.isInteger(threadId)) return;
-    let killConnection: PoolConnection | null = null;
-    try {
-      killConnection = await this.acquireConnectionInternal();
-      await killConnection.query(`KILL QUERY ${threadId}`);
-      ailogger.warn(chalk.yellow(`KILL QUERY issued for thread ${threadId} (transaction timeout)`));
-    } catch (killError: unknown) {
-      // The statement may have just finished (thread no longer running a query)
-      // — KILL then errors harmlessly. Log and proceed to rollback regardless.
-      ailogger.warn(`KILL QUERY for thread ${threadId} failed (may have already completed): ${getErrorMessage(killError)}`);
-    } finally {
-      killConnection?.release();
-    }
-  }
-
   // Close connection method (no-op for compatibility)
   public async closeConnection(): Promise<void> {
     // console.warn(chalk.yellow('Warning: closeConnection is deprecated for concurrency. Connections are managed dynamically and do not persist.'));
@@ -443,7 +416,7 @@ class ConnectionManager {
    * could not run until it finished on its own — which would defeat the timeout
    * and pin the slot. To avoid that, on timeout this method issues
    * `KILL QUERY <threadId>` from a SEPARATE connection (see {@link
-   * killRunningQuery}) to abort the running statement, so the queued ROLLBACK
+   * killQueryOnThread}) to abort the running statement, so the queued ROLLBACK
    * and connection release proceed promptly — returning control to the caller
    * at ~timeoutMs and freeing the transaction slot. An `AbortSignal` cannot
    * substitute for this: MySQL has no protocol-level statement abort, so the
@@ -601,7 +574,7 @@ class ConnectionManager {
         const txConnection = this.transactionConnections.get(transactionId!) as PoolConnectionWithThreadId | undefined;
         const threadId = txConnection?.threadId;
         if (typeof threadId === 'number') {
-          await this.killRunningQuery(threadId);
+          await killQueryOnThread(threadId, 'transaction timeout');
         }
       }
 

--- a/frontend/lib/db/primitives.ts
+++ b/frontend/lib/db/primitives.ts
@@ -4,6 +4,27 @@ import { escape } from 'mysql2';
 import { getPoolMonitorInstance } from '@/lib/db/poolmonitorsingleton';
 import ailogger from '@/ailogger';
 
+// JS-side backstop for statements MySQL cannot bound on its own:
+// MAX_EXECUTION_TIME applies only to top-level SELECTs, so a long CALL or
+// INSERT ... SELECT has NO server-side timeout. Kept above the longest
+// legitimate statement (cross-census validation SELECTs run with a 10-minute
+// MAX_EXECUTION_TIME) so the server-side limit still fires first where one exists.
+const DEFAULT_QUERY_TIMEOUT_MS = 660000; // 660 seconds (11 minutes)
+
+export class QueryTimeoutError extends Error {
+  readonly timeoutMs: number;
+  readonly threadId: number | undefined;
+
+  constructor(timeoutMs: number, threadId: number | undefined) {
+    super(`Query execution timed out after ${timeoutMs}ms (thread ${threadId ?? 'unknown'})`);
+    this.name = 'QueryTimeoutError';
+    this.timeoutMs = timeoutMs;
+    this.threadId = threadId;
+  }
+}
+
+type PoolConnectionWithThreadId = PoolConnection & { threadId?: number };
+
 async function getSqlConnection(tries: number): Promise<PoolConnection> {
   let connection: PoolConnection | null = null;
   let connectionAcquired = false;
@@ -56,32 +77,68 @@ export async function getConn() {
   return conn;
 }
 
-export async function runQuery(connection: PoolConnection, query: string, params?: any[]): Promise<any> {
-  // Must exceed the longest MySQL MAX_EXECUTION_TIME (cross-census validations
-  // use 10 min).  Set to 11 min so the MySQL-level timeout fires first with a
-  // proper error instead of this generic JS-level rejection.
-  const QUERY_TIMEOUT_MS = 660000; // 660 seconds (11 minutes)
+/**
+ * Abort the statement running on `threadId` by issuing KILL QUERY from a
+ * SEPARATE pooled connection. Destroying the client socket alone is not
+ * enough: the server may not notice the closed socket until the statement
+ * finishes on its own (and, inside a CALL, commits its work). KILL QUERY stops
+ * only the active statement and leaves the thread alive.
+ *
+ * KILL is not preparable in MySQL, so this uses the text protocol with a
+ * numeric thread id (never user input) rather than a bound parameter.
+ */
+export async function killQueryOnThread(threadId: number, context: string): Promise<void> {
+  if (!Number.isInteger(threadId)) return;
+  let killConnection: PoolConnection | null = null;
+  try {
+    killConnection = await getPoolMonitorInstance().getConnection();
+    await killConnection.query(`KILL QUERY ${threadId}`);
+    ailogger.warn(chalk.yellow(`KILL QUERY issued for thread ${threadId} (${context})`));
+  } catch (killError: unknown) {
+    // The statement may have just finished (thread no longer running a query)
+    // — KILL then errors harmlessly. Log and let the caller proceed regardless.
+    const message = killError instanceof Error ? killError.message : String(killError);
+    ailogger.warn(`KILL QUERY for thread ${threadId} failed (may have already completed): ${message}`);
+  } finally {
+    killConnection?.release();
+  }
+}
+
+export async function runQuery(connection: PoolConnection, query: string, params?: any[], timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS): Promise<any> {
+  const threadId = (connection as PoolConnectionWithThreadId).threadId;
   let timeoutHandle: NodeJS.Timeout | undefined;
   const timer = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(() => reject(new Error('Query execution timed out')), QUERY_TIMEOUT_MS);
+    timeoutHandle = setTimeout(() => reject(new QueryTimeoutError(timeoutMs, threadId)), timeoutMs);
   });
+  let inFlight: Promise<unknown> | undefined;
   try {
     if (params) {
       params = params.map(param => (param === undefined ? null : param));
     }
-    if (query.trim().startsWith('CALL')) {
-      const [rows] = await Promise.race([connection.query(query, params), timer]);
-      return rows;
-    } else {
-      // mysql2's execute() uses prepared statements which don't support
-      // bulk INSERT ... VALUES ? with nested arrays. Use query() for those.
-      const hasBulkValues = params?.some(p => Array.isArray(p) && p.length > 0 && Array.isArray(p[0]));
-      const method = hasBulkValues ? connection.query.bind(connection) : connection.execute.bind(connection);
-      const [rows, _fields] = await Promise.race([method(query, params), timer]);
-
-      return rows;
-    }
+    // mysql2's execute() uses prepared statements, which don't support
+    // bulk INSERT ... VALUES ? with nested arrays or CALL. Use query() for those.
+    const hasBulkValues = params?.some(p => Array.isArray(p) && p.length > 0 && Array.isArray(p[0]));
+    const useTextProtocol = query.trim().startsWith('CALL') || hasBulkValues;
+    inFlight = useTextProtocol ? connection.query(query, params) : connection.execute(query, params);
+    const [rows] = (await Promise.race([inFlight, timer])) as [any, unknown];
+    return rows;
   } catch (error: any) {
+    if (error instanceof QueryTimeoutError) {
+      // The raced statement is still executing server-side. Log its eventual
+      // settlement (expected: ER_QUERY_INTERRUPTED from the KILL below) so it
+      // can never surface as an unhandled rejection.
+      inFlight?.catch((orphanError: unknown) => {
+        const message = orphanError instanceof Error ? orphanError.message : String(orphanError);
+        ailogger.warn(`Orphaned statement settled after query timeout (expected after KILL): ${message}`);
+      });
+      if (typeof threadId === 'number') {
+        await killQueryOnThread(threadId, 'query timeout');
+      }
+      // Quarantine: a connection with a statement in flight must never re-enter
+      // the pool — the next borrower's commands would queue behind it. destroy()
+      // removes it from the pool; a later release() on it is a safe no-op.
+      connection.destroy();
+    }
     ailogger.error(chalk.red(`Error executing query: ${query}`));
     ailogger.error(chalk.red('Error message:', error.message));
     throw error;

--- a/frontend/tests/integration/runquery-timeout-quarantine.integration.test.ts
+++ b/frontend/tests/integration/runquery-timeout-quarantine.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * runQuery timeout quarantine — REAL server-side kill semantics against local MySQL.
+ *
+ * ── The bug this guards against (the Harvard 106k-row incident) ───────────────
+ * runQuery raced the statement against an 11-minute JS timer and, on timeout,
+ * rejected the caller WITHOUT killing the statement. MySQL kept executing it
+ * (MAX_EXECUTION_TIME applies only to top-level SELECTs — a CALL or
+ * INSERT ... SELECT has NO server-side limit), and the still-busy connection
+ * was released back to the pool. mysql2 serializes commands per connection, so
+ * the next borrower — including the retry of the same sub-batch — queued
+ * behind the runaway statement, and a CALL managing its own transaction could
+ * still COMMIT long after the caller had given up on it.
+ *
+ * ── The fix (in runQuery) ─────────────────────────────────────────────────────
+ * On timeout: issue KILL QUERY <threadId> from a SEPARATE pooled connection,
+ * then destroy() the timed-out connection so it can never re-enter the pool.
+ * This suite proves, against a real server:
+ *   1. runQuery settles at ~timeout, not at the statement's natural end.
+ *   2. The server-side statement is actually gone well before it would have
+ *      finished on its own — for both the execute() path and the CALL path.
+ *   3. The timed-out connection is out of the pool (destroy() nulled its pool
+ *      backref), a later release() is a harmless no-op, and no subsequent
+ *      pool acquisition ever hands back the poisoned thread.
+ *
+ * CRITICAL SAFETY: ConnectionManager's pool host is process.env.AZURE_SQL_SERVER,
+ * which defaults to PRODUCTION Azure MySQL. vitest.integration.config.mts pins
+ * that env to the local docker container (127.0.0.1) for ALL integration tests.
+ * The beforeAll guard below HARD-FAILS before anything runs if the host is not
+ * local, so this suite can never touch a real database even if the config
+ * regresses.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Connection, PoolConnection } from 'mysql2/promise';
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { getConn, QueryTimeoutError, runQuery } from '@/lib/db/primitives';
+import { setupTestDatabase, teardownTestDatabase, DEFAULT_TEST_CONFIG, type TestDatabaseConfig } from '../setup/local-db-setup';
+
+const LOCAL_HOSTS = ['127.0.0.1', 'localhost'] as const;
+
+// A short runQuery timeout paired with a much longer server-side statement, so
+// "settled at ~timeout" and "statement killed early" are unambiguous.
+const SLEEP_SECONDS = 15;
+const RUNQUERY_TIMEOUT_MS = 1500;
+// Timeout + slack for acquiring the kill connection and the KILL round-trip.
+const MAX_SETTLE_MS = RUNQUERY_TIMEOUT_MS + 3500;
+// The killed statement must be gone from the processlist well before its
+// natural completion at SLEEP_SECONDS.
+const KILL_CONFIRM_DEADLINE_MS = 8000;
+const PROCESSLIST_POLL_MS = 250;
+const POOL_SWEEP_ACQUISITIONS = 3;
+const SLEEPY_PROCEDURE = 'runquery_timeout_probe_sleepy';
+
+let setupConnection: Connection | null = null;
+let config: TestDatabaseConfig;
+let schema: string;
+
+const connectionManager = ConnectionManager.getInstance();
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+type QuarantinedConnection = PoolConnection & { threadId?: number; connection?: { _pool: unknown } };
+
+/** True while `threadId` still has the probe statement in flight server-side. */
+async function statementStillRunning(threadId: number): Promise<boolean> {
+  const rows = await connectionManager.executeQuery(`SELECT COUNT(*) AS running FROM information_schema.PROCESSLIST WHERE ID = ? AND INFO LIKE '%SLEEP%'`, [
+    threadId
+  ]);
+  return Number(rows[0].running) > 0;
+}
+
+/** Polls until the statement on `threadId` is gone; returns how long that took. */
+async function confirmStatementKilled(threadId: number): Promise<number> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < KILL_CONFIRM_DEADLINE_MS) {
+    if (!(await statementStillRunning(threadId))) {
+      return Date.now() - startedAt;
+    }
+    await wait(PROCESSLIST_POLL_MS);
+  }
+  throw new Error(
+    `Statement on thread ${threadId} was still running ${KILL_CONFIRM_DEADLINE_MS}ms after the timeout — KILL QUERY did not land; ` +
+      `it would have run to its natural end at ${SLEEP_SECONDS * 1000}ms (the pre-fix behavior).`
+  );
+}
+
+/**
+ * Full contract check shared by both statement shapes: settle time, server-side
+ * kill, and pool quarantine of the timed-out connection.
+ */
+async function expectTimeoutKillAndQuarantine(query: string, params: unknown[]): Promise<void> {
+  const connection = (await getConn()) as QuarantinedConnection;
+  const threadId = connection.threadId;
+  expect(typeof threadId).toBe('number');
+
+  const startedAt = Date.now();
+  const rejection = await runQuery(connection, query, params, RUNQUERY_TIMEOUT_MS).then(
+    () => {
+      throw new Error(`runQuery resolved — the ${SLEEP_SECONDS}s statement should have timed out at ${RUNQUERY_TIMEOUT_MS}ms`);
+    },
+    (err: unknown) => err
+  );
+  const settledMs = Date.now() - startedAt;
+  // eslint-disable-next-line no-console
+  console.log(`[runquery-timeout] '${query}' settled in ${settledMs}ms (timeout ${RUNQUERY_TIMEOUT_MS}ms, natural end ${SLEEP_SECONDS * 1000}ms)`);
+
+  expect(rejection).toBeInstanceOf(QueryTimeoutError);
+  expect((rejection as QueryTimeoutError).threadId).toBe(threadId);
+  expect(settledMs).toBeLessThan(MAX_SETTLE_MS);
+
+  const killConfirmMs = await confirmStatementKilled(threadId!);
+  // eslint-disable-next-line no-console
+  console.log(`[runquery-timeout] statement on thread ${threadId} confirmed gone ${killConfirmMs}ms after settle`);
+
+  // destroy() nulls the mysql2 pool backref — the connection can never be
+  // handed out again (white-box on mysql2's BasePoolConnection._removeFromPool,
+  // which is exactly the mechanism release() checks before re-pooling).
+  expect(connection.connection?._pool ?? null).toBeNull();
+
+  // Callers' `finally { connection.release() }` blocks still run after the
+  // timeout; on a destroyed connection that must be a harmless no-op.
+  expect(() => connection.release()).not.toThrow();
+
+  // Behavioral proof: the pool never hands the poisoned thread back out.
+  const sweep: QuarantinedConnection[] = [];
+  try {
+    for (let i = 0; i < POOL_SWEEP_ACQUISITIONS; i++) {
+      sweep.push((await getConn()) as QuarantinedConnection);
+    }
+    const sweepThreadIds = sweep.map(c => c.threadId);
+    // eslint-disable-next-line no-console
+    console.log(`[runquery-timeout] post-timeout pool sweep threads: ${sweepThreadIds.join(', ')} (poisoned: ${threadId})`);
+    expect(sweepThreadIds).not.toContain(threadId);
+  } finally {
+    sweep.forEach(c => c.release());
+  }
+}
+
+beforeAll(async () => {
+  const host = process.env.AZURE_SQL_SERVER;
+  // eslint-disable-next-line no-console
+  console.log(`[runquery-timeout] resolved ConnectionManager host = '${host}'`);
+  if (!host || !LOCAL_HOSTS.includes(host as (typeof LOCAL_HOSTS)[number])) {
+    throw new Error(`REFUSING TO RUN: ConnectionManager host is '${host}', not local. Aborting to avoid touching a real database.`);
+  }
+
+  const setup = await setupTestDatabase(DEFAULT_TEST_CONFIG);
+  setupConnection = setup.connection;
+  config = setup.config;
+  schema = config.database;
+
+  // Mirrors the incident's statement shape: a CALL whose long-running work has
+  // no server-side timeout. The statement after SLEEP proves the kill flag
+  // aborts the whole CALL, not just the statement it interrupted.
+  await setupConnection.query(`DROP PROCEDURE IF EXISTS \`${schema}\`.${SLEEPY_PROCEDURE}`);
+  await setupConnection.query(
+    `CREATE PROCEDURE \`${schema}\`.${SLEEPY_PROCEDURE}(IN sleep_seconds INT)
+     BEGIN
+       SELECT SLEEP(sleep_seconds) AS slept;
+       SELECT 1 AS after_sleep;
+     END`
+  );
+}, 90000);
+
+afterAll(async () => {
+  await connectionManager.closeConnection();
+  await teardownTestDatabase(setupConnection, config);
+});
+
+describe('runQuery timeout — server-side kill + pool quarantine (real MySQL)', () => {
+  it('kills a timed-out execute()-path statement and quarantines its connection', async () => {
+    await expectTimeoutKillAndQuarantine('SELECT SLEEP(?) AS slept', [SLEEP_SECONDS]);
+  }, 30000);
+
+  it('kills a timed-out CALL (no MAX_EXECUTION_TIME backstop exists for CALL) and quarantines its connection', async () => {
+    await expectTimeoutKillAndQuarantine(`CALL \`${schema}\`.${SLEEPY_PROCEDURE}(?)`, [SLEEP_SECONDS]);
+  }, 30000);
+
+  it('leaves the connection pooled and reusable after an ordinary (non-timeout) query error', async () => {
+    const connection = (await getConn()) as QuarantinedConnection;
+    try {
+      await expect(runQuery(connection, `SELECT * FROM \`${schema}\`.table_that_does_not_exist_xyz`, [])).rejects.toSatisfy(
+        (err: unknown) => !(err instanceof QueryTimeoutError)
+      );
+      // Still attached to the pool and still usable — ordinary errors must not
+      // trigger the quarantine path.
+      expect(connection.connection?._pool ?? null).not.toBeNull();
+      const rows = await runQuery(connection, 'SELECT 1 AS ok', []);
+      expect(Number(rows[0].ok)).toBe(1);
+    } finally {
+      connection.release();
+    }
+  }, 30000);
+});

--- a/frontend/tests/unit/runquery-timeout-quarantine.test.ts
+++ b/frontend/tests/unit/runquery-timeout-quarantine.test.ts
@@ -1,0 +1,169 @@
+/**
+ * runQuery timeout quarantine — unit-level contract (no DB).
+ *
+ * Guards the fix for the Harvard 106k-row upload incident: runQuery's JS-side
+ * timeout used to reject the caller while the statement kept executing
+ * server-side, and the still-busy connection was released back to the pool.
+ * Any later borrower of that connection (including the retry of the same
+ * sub-batch) had its commands queued behind the runaway statement, and — for a
+ * CALL managing its own transaction — the "timed-out" statement could still
+ * COMMIT afterwards. MAX_EXECUTION_TIME offers no server-side backstop here:
+ * it applies only to top-level SELECTs, never to CALL / INSERT ... SELECT.
+ *
+ * The contract asserted here:
+ *   1. On timeout, runQuery rejects with QueryTimeoutError (message keeps the
+ *      'timed out' phrase that error classifiers match on) carrying the
+ *      connection's threadId.
+ *   2. KILL QUERY <threadId> is issued from a SEPARATE pooled connection, which
+ *      is then released.
+ *   3. The timed-out connection is destroy()ed — never released — so it cannot
+ *      re-enter the pool with a statement still in flight.
+ *   4. The orphaned in-flight promise's eventual rejection is swallowed (logged)
+ *      instead of surfacing as an unhandled rejection.
+ *   5. Ordinary query errors and successes do NOT kill or destroy anything.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PoolConnection } from 'mysql2/promise';
+import { killQueryOnThread, QueryTimeoutError, runQuery } from '@/lib/db/primitives';
+import { getPoolMonitorInstance } from '@/lib/db/poolmonitorsingleton';
+import ailogger from '@/ailogger';
+
+vi.mock('@/lib/db/poolmonitorsingleton', () => ({
+  getPoolMonitorInstance: vi.fn()
+}));
+vi.mock('@/ailogger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+const SHORT_TIMEOUT_MS = 25;
+const STUCK_THREAD_ID = 4242;
+const NEVER_SETTLES = () => new Promise<never>(() => {});
+const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
+
+type MockKillConnection = { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> };
+type MockTargetConnection = PoolConnection & {
+  query: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+};
+
+let killConnection: MockKillConnection;
+
+function makeTargetConnection(threadId: number | undefined, statementImpl: () => Promise<unknown>): MockTargetConnection {
+  return {
+    threadId,
+    query: vi.fn(statementImpl),
+    execute: vi.fn(statementImpl),
+    destroy: vi.fn(),
+    release: vi.fn()
+  } as unknown as MockTargetConnection;
+}
+
+beforeEach(() => {
+  killConnection = {
+    query: vi.fn().mockResolvedValue([[], []]),
+    release: vi.fn()
+  };
+  vi.mocked(getPoolMonitorInstance).mockReturnValue({
+    getConnection: vi.fn().mockResolvedValue(killConnection),
+    signalActivity: vi.fn()
+  } as unknown as ReturnType<typeof getPoolMonitorInstance>);
+});
+
+describe('runQuery timeout quarantine', () => {
+  it('rejects with QueryTimeoutError carrying threadId, KILLs the statement, and destroys the connection (CALL path)', async () => {
+    const connection = makeTargetConnection(STUCK_THREAD_ID, NEVER_SETTLES);
+
+    const rejection = await runQuery(connection, 'CALL bulkingestionprocess(?, ?)', ['schema', 'batch'], SHORT_TIMEOUT_MS).then(
+      () => {
+        throw new Error('runQuery resolved but the statement never settles — timeout did not fire');
+      },
+      (err: unknown) => err
+    );
+
+    expect(rejection).toBeInstanceOf(QueryTimeoutError);
+    const timeoutError = rejection as QueryTimeoutError;
+    expect(timeoutError.threadId).toBe(STUCK_THREAD_ID);
+    expect(timeoutError.timeoutMs).toBe(SHORT_TIMEOUT_MS);
+    // ingest-batch classifies retryable timeouts via message.includes('timed out') —
+    // the phrase is load-bearing, not cosmetic.
+    expect(timeoutError.message).toContain('timed out');
+
+    expect(connection.query).toHaveBeenCalledTimes(1);
+    expect(killConnection.query).toHaveBeenCalledWith(`KILL QUERY ${STUCK_THREAD_ID}`);
+    expect(killConnection.release).toHaveBeenCalledTimes(1);
+    expect(connection.destroy).toHaveBeenCalledTimes(1);
+    // Releasing is the caller's job; runQuery must not release (and after
+    // destroy(), the caller's release() is a mysql2 no-op).
+    expect(connection.release).not.toHaveBeenCalled();
+  });
+
+  it('quarantines the execute() path the same way (non-CALL, non-bulk statement)', async () => {
+    const connection = makeTargetConnection(STUCK_THREAD_ID, NEVER_SETTLES);
+
+    await expect(runQuery(connection, 'SELECT * FROM coremeasurements', [], SHORT_TIMEOUT_MS)).rejects.toBeInstanceOf(QueryTimeoutError);
+
+    expect(connection.execute).toHaveBeenCalledTimes(1);
+    expect(killConnection.query).toHaveBeenCalledWith(`KILL QUERY ${STUCK_THREAD_ID}`);
+    expect(connection.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still destroys the connection when threadId is unavailable, but attempts no KILL', async () => {
+    const connection = makeTargetConnection(undefined, NEVER_SETTLES);
+
+    await expect(runQuery(connection, 'CALL anything()', [], SHORT_TIMEOUT_MS)).rejects.toBeInstanceOf(QueryTimeoutError);
+
+    expect(killConnection.query).not.toHaveBeenCalled();
+    expect(connection.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows and logs the orphaned statement rejection after a timeout', async () => {
+    let rejectInFlight!: (err: Error) => void;
+    const connection = makeTargetConnection(
+      STUCK_THREAD_ID,
+      () =>
+        new Promise((_, reject) => {
+          rejectInFlight = reject;
+        })
+    );
+
+    await expect(runQuery(connection, 'CALL anything()', [], SHORT_TIMEOUT_MS)).rejects.toBeInstanceOf(QueryTimeoutError);
+
+    // Simulate the KILLed statement settling later with ER_QUERY_INTERRUPTED.
+    // If unhandled, vitest fails the run; the explicit warn proves the swallow
+    // handler (not luck) absorbed it.
+    rejectInFlight(new Error('Query execution was interrupted'));
+    await flushMicrotasks();
+    expect(vi.mocked(ailogger.warn)).toHaveBeenCalledWith(expect.stringContaining('Orphaned statement settled after query timeout'));
+  });
+
+  it('does not kill or destroy on an ordinary query error', async () => {
+    const sqlError = new Error("Table 'x.nonexistent' doesn't exist");
+    const connection = makeTargetConnection(STUCK_THREAD_ID, () => Promise.reject(sqlError));
+
+    await expect(runQuery(connection, 'SELECT * FROM nonexistent', [], SHORT_TIMEOUT_MS)).rejects.toBe(sqlError);
+
+    expect(killConnection.query).not.toHaveBeenCalled();
+    expect(connection.destroy).not.toHaveBeenCalled();
+  });
+
+  it('does not kill or destroy on success and returns the rows', async () => {
+    const rows = [{ total: 3 }];
+    const connection = makeTargetConnection(STUCK_THREAD_ID, () => Promise.resolve([rows, []]));
+
+    await expect(runQuery(connection, 'SELECT COUNT(*) AS total FROM plots', [], SHORT_TIMEOUT_MS)).resolves.toEqual(rows);
+
+    expect(killConnection.query).not.toHaveBeenCalled();
+    expect(connection.destroy).not.toHaveBeenCalled();
+  });
+
+  it('killQueryOnThread releases its own connection even when KILL fails, and never throws', async () => {
+    killConnection.query.mockRejectedValue(new Error('Unknown thread id'));
+
+    await expect(killQueryOnThread(STUCK_THREAD_ID, 'unit test')).resolves.toBeUndefined();
+
+    expect(killConnection.release).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(ailogger.warn)).toHaveBeenCalledWith(expect.stringContaining(`KILL QUERY for thread ${STUCK_THREAD_ID} failed`));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the DB-layer correctness hazard behind the Harvard 106k-row upload incident.

`runQuery` raced every statement against an 11-minute JS timer and, on timeout, rejected the caller **without stopping the statement**. MySQL kept executing it — `MAX_EXECUTION_TIME` applies only to top-level `SELECT`s, so a `CALL` or `INSERT ... SELECT` has no server-side limit — and the still-busy connection was released back into the pool. Because mysql2 serializes commands per connection, the next borrower (including the retry of the same ingestion sub-batch) queued behind the runaway statement, and a `CALL` managing its own transaction could still commit long after the caller had given up on it.

Changes:
- On timeout, `runQuery` now issues `KILL QUERY <threadId>` from a separate pooled connection, then `destroy()`s the timed-out connection so it can never re-enter the pool (a later `release()` on a destroyed connection is a mysql2 no-op).
- The orphaned in-flight promise's eventual settlement is swallowed and logged instead of surfacing as an unhandled rejection.
- `runQuery` throws a typed `QueryTimeoutError` carrying the thread id; the message keeps the `timed out` phrase existing error classifiers match on.
- The kill helper (`killQueryOnThread`) is shared with `withTransaction`'s existing transaction-timeout path, replacing its private duplicate (`killRunningQuery`).
- Corrects the comment that claimed the MySQL-side timeout would fire first for these statements.

New tests:
- `tests/unit/runquery-timeout-quarantine.test.ts` — timeout contract at the mock level (KILL issued, connection destroyed not released, orphan rejection swallowed, ordinary errors/successes untouched).
- `tests/integration/runquery-timeout-quarantine.integration.test.ts` — against real MySQL: a 15s statement (both `execute()` and `CALL` shapes) settles at ~1.5s timeout, the server-side statement is confirmed killed, and the poisoned thread is never handed back out by the pool.