### PR TITLE
fix(ingestion): pin collision-check join order to stop census-scale blowup

### DIFF
--- a/frontend/db/sql/storedprocedures.sql
+++ b/frontend/db/sql/storedprocedures.sql
@@ -2981,22 +2981,34 @@ BEGIN
         FailureReason  VARCHAR(255)    NOT NULL
     );
 
+    -- The tag-level rematch (rather than a join on the row's resolved StemGUID) is
+    -- deliberate and load-bearing: the conflict is scoped to the TreeTag/StemTag PAIR, so a
+    -- species-corrected re-upload of an existing pair — which resolves to a freshly created
+    -- tree/stem with no measurements of its own — is still preserved for review instead of
+    -- silently forking a second tree (pinned by ingestion-invariants "preserves an incoming
+    -- correction...").
+    -- STRAIGHT_JOIN forces the only safe execution order, rbr -> trees -> stems -> cm:
+    -- one indexed lookup per stage (ux_trees_treetag_speciesid_censusid,
+    -- ux_stems_treeid_stemtag_census, ux_measure_unique), bounded by batch size no matter
+    -- how large trees/coremeasurements grow. Left to itself the optimizer can (and in the
+    -- 2026-07-28 Harvard census upload did) start from a trees x coremeasurements pair
+    -- explosion instead: sub-batch ingestion went 8s -> 8s -> 1500s+ as the census filled.
     INSERT IGNORE INTO existing_tag_stemtag_collision_failures (SourceRowIndex, FailureReason)
     SELECT DISTINCT rbr.id,
            LEFT(CONCAT('TreeTag/StemTag "', rbr.TreeTag, '"/"', rbr.StemTag,
                        '" already has a successful measurement for this date in this census; incoming row preserved for review.'),
                 255)
     FROM resolved_batch_rows rbr
-    INNER JOIN trees t_existing
+    STRAIGHT_JOIN trees t_existing
         ON t_existing.CensusID = rbr.CensusID
        AND t_existing.TreeTag = rbr.TreeTag
        AND t_existing.IsActive = 1
-    INNER JOIN stems s_existing
+    STRAIGHT_JOIN stems s_existing
         ON s_existing.TreeID = t_existing.TreeID
        AND s_existing.CensusID = t_existing.CensusID
        AND s_existing.StemTag = rbr.StemTag
        AND s_existing.IsActive = 1
-    INNER JOIN coremeasurements cm_existing_stem
+    STRAIGHT_JOIN coremeasurements cm_existing_stem
         ON cm_existing_stem.StemGUID = s_existing.StemGUID
        AND cm_existing_stem.CensusID = rbr.CensusID
        AND cm_existing_stem.StemGUID IS NOT NULL

--- a/frontend/db/sql/storedprocedures.sql
+++ b/frontend/db/sql/storedprocedures.sql
@@ -2988,7 +2988,7 @@ BEGIN
     -- silently forking a second tree (pinned by ingestion-invariants "preserves an incoming
     -- correction...").
     -- STRAIGHT_JOIN forces the only safe execution order, rbr -> trees -> stems -> cm:
-    -- one indexed lookup per stage (ux_trees_treetag_speciesid_censusid,
+    -- one indexed lookup per stage (idx_trees_tag_census_active,
     -- ux_stems_treeid_stemtag_census, ux_measure_unique), bounded by batch size no matter
     -- how large trees/coremeasurements grow. Left to itself the optimizer can (and in the
     -- 2026-07-28 Harvard census upload did) start from a trees x coremeasurements pair

--- a/frontend/tests/integration/ingestion-invariants.integration.test.ts
+++ b/frontend/tests/integration/ingestion-invariants.integration.test.ts
@@ -193,6 +193,170 @@ describe('Ingestion invariants (bulkingestionprocess)', () => {
       expect(String(preservedRows[1].Description)).toContain('incoming row preserved for review');
     });
 
+    it('allows a same-stem remeasurement on a DIFFERENT date across batches (the reingestion contract)', async () => {
+      // The conflict check is scoped to the collapser's key (StemGUID + MeasurementDate):
+      // a same-stem measurement on a different date is a legitimate remeasurement, and the
+      // reingestion flow depends on it never being flagged as DUPLICATE_TAG_CONFLICT_EXISTING.
+      const censusID = testData.census[0].censusID;
+      const remeasureDate = '2024-09-20';
+      const original: ScenarioMeasurement = {
+        treeTag: 'REMEASURE_OK',
+        stemTag: '1',
+        speciesCode: testData.species[0].SpeciesCode,
+        quadratName: testData.quadrats[0].QuadratName,
+        x: 6,
+        y: 6,
+        dbh: 10,
+        hom: 1.3,
+        date: MEASUREMENT_DATE
+      };
+
+      const first = await insertTestMeasurements(connection, testData, [original], {
+        censusID,
+        fileID: 'remeasure_original.csv',
+        batchID: 'remeasure_original'
+      });
+      const firstResult = await runBulkIngestion(connection, first.fileID, first.batchID);
+      expect(firstResult.batch_failed, firstResult.message).toBe(false);
+
+      const second = await insertTestMeasurements(connection, testData, [{ ...original, dbh: 12, date: remeasureDate }], {
+        censusID,
+        fileID: 'remeasure_followup.csv',
+        batchID: 'remeasure_followup'
+      });
+      const secondResult = await runBulkIngestion(connection, second.fileID, second.batchID);
+      expect(secondResult.batch_failed, secondResult.message).toBe(false);
+
+      const outcome = await readIngestionOutcome(connection, { ...second, censusID });
+      assertOutcome(
+        outcome,
+        {
+          sourceRecords: 1,
+          successfulRows: 1,
+          failedRows: 0,
+          remainingTemporaryRows: 0,
+          metricProcessedRecords: 1,
+          metricFailedRecords: 0,
+          metricMissingRecords: 0,
+          errorCodes: [],
+          alertTypes: []
+        },
+        secondResult,
+        1
+      );
+
+      // Both measurements live on the SAME stem — a remeasurement, not a forked stem.
+      const [stemRows] = await connection.query<RowDataPacket[]>(
+        `SELECT COUNT(DISTINCT cm.StemGUID) AS stems, COUNT(*) AS measurements
+         FROM coremeasurements cm
+         WHERE cm.CensusID = ? AND cm.UploadFileID IN (?, ?) AND cm.StemGUID IS NOT NULL`,
+        [censusID, first.fileID, second.fileID]
+      );
+      expect(Number(stemRows[0].stems), 'one shared stem across both batches').toBe(1);
+      expect(Number(stemRows[0].measurements), 'two measurements on that stem').toBe(2);
+    });
+
+    it('flags an incoming row when ANY same-TreeTag tree has a same-date measurement — the conflict is tag-scoped, not resolved-stem-scoped', async () => {
+      // SEMANTIC PIN, decided deliberately: the conflict predicate re-derives the stem
+      // through trees(TreeTag) -> stems(StemTag) WITHOUT species, so it fires even when the
+      // incoming row's OWN resolved stem (a different tree of another species, since
+      // ux_trees_treetag_speciesid_censusid scopes tags per species) has no measurement on
+      // the date. That wider net is what preserves species-corrected re-uploads for review
+      // instead of silently forking a second tree. A StemGUID-scoped join here would let
+      // this row through — do NOT "simplify" the query to one without re-ratifying that
+      // trade-off (it also flags legitimately recurring tags across species, as below).
+      const censusID = testData.census[0].censusID;
+      const sharedTag = 'DIV_TAG';
+      const conflictDate = '2024-09-20';
+
+      // Tree A (species[0]): ingested normally, measurement on the ORIGINAL date only.
+      const original: ScenarioMeasurement = {
+        treeTag: sharedTag,
+        stemTag: '1',
+        speciesCode: testData.species[0].SpeciesCode,
+        quadratName: testData.quadrats[0].QuadratName,
+        x: 7,
+        y: 7,
+        dbh: 10,
+        hom: 1.3,
+        date: MEASUREMENT_DATE
+      };
+      const first = await insertTestMeasurements(connection, testData, [original], {
+        censusID,
+        fileID: 'divtag_original.csv',
+        batchID: 'divtag_original'
+      });
+      const firstResult = await runBulkIngestion(connection, first.fileID, first.batchID);
+      expect(firstResult.batch_failed, firstResult.message).toBe(false);
+
+      // Tree B: same TreeTag, DIFFERENT species, its own stem '1', with a measurement on
+      // conflictDate — the bait the tag rematch used to bite on.
+      const [speciesRows] = await connection.query<RowDataPacket[]>(`SELECT SpeciesID FROM species WHERE SpeciesCode = ? AND IsActive = 1`, [
+        testData.species[1].SpeciesCode
+      ]);
+      const [quadratRows] = await connection.query<RowDataPacket[]>(`SELECT QuadratID FROM quadrats WHERE QuadratName = ? AND IsActive = 1 LIMIT 1`, [
+        testData.quadrats[0].QuadratName
+      ]);
+      const [treeInsert] = await connection.query<ResultSetHeader>(`INSERT INTO trees (TreeTag, SpeciesID, CensusID, IsActive) VALUES (?, ?, ?, 1)`, [
+        sharedTag,
+        speciesRows[0].SpeciesID,
+        censusID
+      ]);
+      const [stemInsert] = await connection.query<ResultSetHeader>(
+        `INSERT INTO stems (TreeID, QuadratID, CensusID, StemCrossID, StemTag, LocalX, LocalY, IsActive)
+         VALUES (?, ?, ?, NULL, '1', 99.9, 99.9, 1)`,
+        [treeInsert.insertId, quadratRows[0].QuadratID, censusID]
+      );
+      await connection.query(
+        `INSERT INTO coremeasurements
+           (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+            UploadFileID, UploadBatchID, SourceRowIndex, IsActive)
+         VALUES (?, ?, FALSE, ?, 33, 1.3, 'divtag_other_species.csv', 'divtag_other_species', 1, 1)`,
+        [censusID, stemInsert.insertId, conflictDate]
+      );
+
+      // Incoming row: resolves to tree A's stem (species[0]), which has NO measurement on
+      // conflictDate — but tree B (same tag, other species) does. The tag-scoped predicate
+      // must flag it and preserve the raw values for review.
+      const incoming = await insertTestMeasurements(connection, testData, [{ ...original, dbh: 22, date: conflictDate }], {
+        censusID,
+        fileID: 'divtag_incoming.csv',
+        batchID: 'divtag_incoming'
+      });
+      const incomingResult = await runBulkIngestion(connection, incoming.fileID, incoming.batchID);
+      expect(incomingResult.batch_failed, incomingResult.message).toBe(false);
+
+      const outcome = await readIngestionOutcome(connection, { ...incoming, censusID });
+      assertOutcome(
+        outcome,
+        {
+          sourceRecords: 1,
+          successfulRows: 0,
+          failedRows: 1,
+          remainingTemporaryRows: 0,
+          metricProcessedRecords: 0,
+          metricFailedRecords: 1,
+          metricMissingRecords: 0,
+          errorCodes: [INGESTION_ERROR_CODE.DUPLICATE_TAG_CONFLICT_EXISTING],
+          alertTypes: [INGESTION_ALERT_TYPE.DUPLICATE_TAG_CONFLICT_EXISTING]
+        },
+        incomingResult,
+        1
+      );
+
+      // The incoming values are preserved as an unresolved row, not silently dropped.
+      const [preservedRows] = await connection.query<RowDataPacket[]>(
+        `SELECT StemGUID, MeasuredDBH, RawTreeTag, Description FROM coremeasurements
+         WHERE UploadFileID = ? AND CensusID = ?`,
+        [incoming.fileID, censusID]
+      );
+      expect(preservedRows, 'exactly one preserved row for the incoming batch').toHaveLength(1);
+      expect(preservedRows[0].StemGUID, 'preserved as unresolved (StemGUID NULL)').toBeNull();
+      expect(Number(preservedRows[0].MeasuredDBH)).toBe(22);
+      expect(preservedRows[0].RawTreeTag).toBe(sharedTag);
+      expect(String(preservedRows[0].Description)).toContain('incoming row preserved for review');
+    });
+
     it('does not delete historical successful conflicts during the collapser pass', async () => {
       const censusID = testData.census[0].censusID;
       const original: ScenarioMeasurement = {

--- a/frontend/tests/integration/ingestion-scale-benchmark.integration.test.ts
+++ b/frontend/tests/integration/ingestion-scale-benchmark.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Ingestion scale benchmark: sub-batch time must NOT blow up as the census fills.
+ *
+ * ── The incident this guards against (Harvard census upload, 2026-07-28) ──────
+ * bulkingestionprocess ran three equal 10k-row sub-batches into one census:
+ * 8s -> 8s -> 1,500s+. The blowup was the existing_tag_stemtag_collision_failures
+ * query (storedprocedures.sql, STAGE 8): once coremeasurements held 20k rows the
+ * optimizer abandoned the batch-driven nested-loop plan for a
+ * trees x coremeasurements pair explosion — cost proportional to
+ * (existing measurements x batch rows) instead of (batch rows). The fix pins the
+ * join order with STRAIGHT_JOIN so every stage is one indexed lookup.
+ *
+ * This benchmark re-runs the incident's shape in miniature: three equal
+ * sub-batches into one census (0, then 10k, then 20k existing measurements) with
+ * every row a distinct tree+stem, timing each CALL. The assertion is deliberately
+ * generous — a healthy run is ~flat (later batches within ~1.5x of the first),
+ * the pathological plan is 10-100x — so it only fires on a real regression, not
+ * CI noise. If a future optimizer change reintroduces the flip, the third batch
+ * blows past the bound (or the test times out, which is the same signal).
+ *
+ * CRITICAL SAFETY: the beforeAll REFUSING TO RUN guard hard-fails before any
+ * write if the host is not local, so this can never touch a real database.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Connection, RowDataPacket } from 'mysql2/promise';
+import { setupTestDatabase, teardownTestDatabase, DEFAULT_TEST_CONFIG, type TestData, type TestDatabaseConfig } from '../setup/local-db-setup';
+
+const LOCAL_HOSTS = ['127.0.0.1', 'localhost'] as const;
+
+const BATCH_SIZE = 10000;
+const BATCH_COUNT = 3;
+const STAGING_CHUNK_SIZE = 2000;
+// A later batch may cost at most RATIO_LIMIT x the first (empty-census) batch,
+// with an absolute floor so a fast first batch cannot make the bound flaky.
+// Healthy observed ratio is ~1x-1.5x; the pathological plan is 10x-100x.
+const RATIO_LIMIT = 5;
+const MIN_ALLOWED_MS = 30000;
+const DATE_SPREAD_DAYS = 90;
+const TEST_TIMEOUT_MS = 360000;
+
+let connection: Connection;
+let testData: TestData;
+let config: TestDatabaseConfig;
+
+function assertLocalHostOrRefuse(): void {
+  const host = process.env.AZURE_SQL_SERVER;
+  if (!host || !LOCAL_HOSTS.includes(host as (typeof LOCAL_HOSTS)[number])) {
+    throw new Error(`REFUSING TO RUN: ConnectionManager host is '${host}', not local. Aborting to avoid writing to a real database.`);
+  }
+  const testHost = DEFAULT_TEST_CONFIG.host;
+  if (!LOCAL_HOSTS.includes(testHost as (typeof LOCAL_HOSTS)[number])) {
+    throw new Error(`REFUSING TO RUN: TEST_DB_HOST is '${testHost}', not local. Aborting to avoid writing to a real database.`);
+  }
+}
+
+function measurementDate(rowIndex: number): string {
+  const day = rowIndex % DATE_SPREAD_DAYS;
+  const base = new Date(Date.UTC(2024, 0, 1));
+  base.setUTCDate(base.getUTCDate() + day);
+  return base.toISOString().slice(0, 10);
+}
+
+/** Bulk-stages one sub-batch into temporarymeasurements (insertTestMeasurements is row-at-a-time and far too slow at this scale). */
+async function stageBatch(batchIndex: number): Promise<{ fileID: string; batchID: string }> {
+  const fileID = 'scale_benchmark.csv';
+  const batchID = `scale_benchmark__sub${String(batchIndex + 1).padStart(3, '0')}`;
+  const plotID = testData.plots[0].plotID;
+  const censusID = testData.census[0].censusID;
+  const speciesCode = testData.species[0].SpeciesCode;
+  const quadratName = testData.quadrats[0].QuadratName;
+
+  const rows: unknown[][] = [];
+  for (let i = 1; i <= BATCH_SIZE; i++) {
+    // Every row is its own tree+stem (the dominant shape of a census upload).
+    const treeTag = `B${batchIndex + 1}T${String(i).padStart(6, '0')}`;
+    rows.push([
+      fileID,
+      batchID,
+      plotID,
+      censusID,
+      treeTag,
+      '1',
+      speciesCode,
+      quadratName,
+      (i % 500) / 10,
+      (i % 700) / 10,
+      10 + (i % 900) / 10,
+      1.3,
+      measurementDate(i),
+      null,
+      null,
+      null
+    ]);
+  }
+  for (let offset = 0; offset < rows.length; offset += STAGING_CHUNK_SIZE) {
+    await connection.query(
+      `INSERT INTO temporarymeasurements
+         (FileID, BatchID, PlotID, CensusID, TreeTag, StemTag, SpeciesCode, QuadratName,
+          LocalX, LocalY, DBH, HOM, MeasurementDate, Codes, Comments, PublishedStemID)
+       VALUES ?`,
+      [rows.slice(offset, offset + STAGING_CHUNK_SIZE)]
+    );
+  }
+  return { fileID, batchID };
+}
+
+async function successfulRowCount(batchID: string): Promise<number> {
+  const [rows] = await connection.query<RowDataPacket[]>(
+    `SELECT COUNT(*) AS total FROM coremeasurements WHERE UploadBatchID = ? AND StemGUID IS NOT NULL AND IsActive = 1`,
+    [batchID]
+  );
+  return Number(rows[0].total);
+}
+
+beforeAll(async () => {
+  assertLocalHostOrRefuse();
+  const setup = await setupTestDatabase();
+  connection = setup.connection;
+  testData = setup.testData;
+  config = setup.config;
+}, 90000);
+
+afterAll(async () => {
+  await teardownTestDatabase(connection, config);
+});
+
+describe('Ingestion scale benchmark (0 / 10k / 20k existing measurements)', () => {
+  it(
+    'keeps sub-batch ingestion time flat as prior sub-batches fill the census',
+    async () => {
+      const durationsMs: number[] = [];
+
+      for (let batchIndex = 0; batchIndex < BATCH_COUNT; batchIndex++) {
+        const existingBefore = batchIndex * BATCH_SIZE;
+        const { fileID, batchID } = await stageBatch(batchIndex);
+
+        const startedAt = Date.now();
+        const [results] = await connection.query<RowDataPacket[]>('CALL bulkingestionprocess(?, ?)', [fileID, batchID]);
+        const elapsedMs = Date.now() - startedAt;
+        durationsMs.push(elapsedMs);
+
+        const resultRow = Array.isArray(results[0]) ? (results[0] as RowDataPacket[])[0] : results[0];
+        expect(resultRow?.batch_failed, `batch ${batchID}: ${resultRow?.message}`).toBeFalsy();
+
+        // The benchmark must measure REAL ingestion — a batch that silently failed
+        // its rows would be fast for the wrong reason.
+        const succeeded = await successfulRowCount(batchID);
+        expect(succeeded, `batch ${batchID} fully ingested`).toBe(BATCH_SIZE);
+
+        // eslint-disable-next-line no-console
+        console.log(`[scale-benchmark] batch ${batchIndex + 1}/${BATCH_COUNT} (${existingBefore} existing): ${elapsedMs}ms, ${succeeded} rows ingested`);
+      }
+
+      const [firstBatchMs, ...laterBatchesMs] = durationsMs;
+      const allowedMs = Math.max(RATIO_LIMIT * firstBatchMs, MIN_ALLOWED_MS);
+      // eslint-disable-next-line no-console
+      console.log(`[scale-benchmark] durations ${durationsMs.map(d => `${d}ms`).join(' -> ')}; bound for later batches: ${allowedMs}ms`);
+
+      for (const [i, later] of laterBatchesMs.entries()) {
+        expect(
+          later,
+          `batch ${i + 2} took ${later}ms with ${(i + 1) * BATCH_SIZE} existing measurements — over ${allowedMs}ms bound ` +
+            `(first batch ${firstBatchMs}ms). This is the incident signature: a stage whose cost scales with existing x batch rows.`
+        ).toBeLessThan(allowedMs);
+      }
+    },
+    TEST_TIMEOUT_MS
+  );
+});

--- a/frontend/tests/integration/ingestion-scale-benchmark.integration.test.ts
+++ b/frontend/tests/integration/ingestion-scale-benchmark.integration.test.ts
@@ -22,7 +22,7 @@
  * write if the host is not local, so this can never touch a real database.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { Connection, RowDataPacket } from 'mysql2/promise';
+import { createConnection, type Connection, type RowDataPacket } from 'mysql2/promise';
 import { setupTestDatabase, teardownTestDatabase, DEFAULT_TEST_CONFIG, type TestData, type TestDatabaseConfig } from '../setup/local-db-setup';
 
 const LOCAL_HOSTS = ['127.0.0.1', 'localhost'] as const;
@@ -35,12 +35,24 @@ const STAGING_CHUNK_SIZE = 2000;
 // Healthy observed ratio is ~1x-1.5x; the pathological plan is 10x-100x.
 const RATIO_LIMIT = 5;
 const MIN_ALLOWED_MS = 30000;
+const MAX_BATCH_DURATION_MS = 30000;
+const CALL_TIMEOUT_MS = 45000;
 const DATE_SPREAD_DAYS = 90;
-const TEST_TIMEOUT_MS = 360000;
+const TEST_TIMEOUT_MS = CALL_TIMEOUT_MS * BATCH_COUNT + 60000;
 
 let connection: Connection;
 let testData: TestData;
 let config: TestDatabaseConfig;
+
+type ThreadedConnection = Connection & { threadId?: number };
+type ProcedureResults = RowDataPacket[] | RowDataPacket[][];
+
+class BenchmarkCallTimeoutError extends Error {
+  constructor(batchID: string) {
+    super(`bulkingestionprocess timed out after ${CALL_TIMEOUT_MS}ms for ${batchID}`);
+    this.name = 'BenchmarkCallTimeoutError';
+  }
+}
 
 function assertLocalHostOrRefuse(): void {
   const host = process.env.AZURE_SQL_SERVER;
@@ -112,6 +124,51 @@ async function successfulRowCount(batchID: string): Promise<number> {
   return Number(rows[0].total);
 }
 
+/**
+ * Runs one CALL on a disposable connection. If the incident regresses and the
+ * statement hangs, abort it from a second connection before failing the test;
+ * a Vitest timeout alone cannot cancel server-side MySQL work.
+ */
+async function runBulkIngestionWithTimeout(fileID: string, batchID: string): Promise<ProcedureResults> {
+  const ingestConnection = await createConnection(config);
+  const threadID = (ingestConnection as ThreadedConnection).threadId;
+  if (!Number.isInteger(threadID)) {
+    await ingestConnection.end();
+    throw new Error(`MySQL connection for ${batchID} did not expose a numeric thread id`);
+  }
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  let destroyed = false;
+  const callPromise = ingestConnection.query('CALL bulkingestionprocess(?, ?)', [fileID, batchID]) as Promise<[ProcedureResults, unknown]>;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => reject(new BenchmarkCallTimeoutError(batchID)), CALL_TIMEOUT_MS);
+  });
+
+  try {
+    const [results] = await Promise.race([callPromise, timeoutPromise]);
+    return results;
+  } catch (error) {
+    if (error instanceof BenchmarkCallTimeoutError) {
+      // Attach before KILL so ER_QUERY_INTERRUPTED can never become an unhandled rejection.
+      void callPromise.catch(() => undefined);
+      let killConnection: Connection | undefined;
+      try {
+        killConnection = await createConnection(config);
+        await killConnection.query(`KILL QUERY ${threadID}`);
+      } finally {
+        await killConnection?.end().catch(() => undefined);
+        // Never reuse a connection that may still have a statement settling.
+        ingestConnection.destroy();
+        destroyed = true;
+      }
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
+    if (!destroyed) await ingestConnection.end();
+  }
+}
+
 beforeAll(async () => {
   assertLocalHostOrRefuse();
   const setup = await setupTestDatabase();
@@ -135,7 +192,7 @@ describe('Ingestion scale benchmark (0 / 10k / 20k existing measurements)', () =
         const { fileID, batchID } = await stageBatch(batchIndex);
 
         const startedAt = Date.now();
-        const [results] = await connection.query<RowDataPacket[]>('CALL bulkingestionprocess(?, ?)', [fileID, batchID]);
+        const results = await runBulkIngestionWithTimeout(fileID, batchID);
         const elapsedMs = Date.now() - startedAt;
         durationsMs.push(elapsedMs);
 
@@ -146,14 +203,13 @@ describe('Ingestion scale benchmark (0 / 10k / 20k existing measurements)', () =
         // its rows would be fast for the wrong reason.
         const succeeded = await successfulRowCount(batchID);
         expect(succeeded, `batch ${batchID} fully ingested`).toBe(BATCH_SIZE);
+        expect(elapsedMs, `batch ${batchID} exceeded the ${MAX_BATCH_DURATION_MS}ms absolute latency ceiling`).toBeLessThan(MAX_BATCH_DURATION_MS);
 
-        // eslint-disable-next-line no-console
         console.log(`[scale-benchmark] batch ${batchIndex + 1}/${BATCH_COUNT} (${existingBefore} existing): ${elapsedMs}ms, ${succeeded} rows ingested`);
       }
 
       const [firstBatchMs, ...laterBatchesMs] = durationsMs;
       const allowedMs = Math.max(RATIO_LIMIT * firstBatchMs, MIN_ALLOWED_MS);
-      // eslint-disable-next-line no-console
       console.log(`[scale-benchmark] durations ${durationsMs.map(d => `${d}ms`).join(' -> ')}; bound for later batches: ${allowedMs}ms`);
 
       for (const [i, later] of laterBatchesMs.entries()) {

--- a/frontend/tests/upload-procedure-regressions.test.ts
+++ b/frontend/tests/upload-procedure-regressions.test.ts
@@ -50,19 +50,32 @@ describe('upload procedure regressions', () => {
 
   it('surfaces cross-batch TreeTag/StemTag conflicts instead of inserting a second success', () => {
     const canonicalSql = readSql('db/sql/storedprocedures.sql');
+    const tableStructuresSql = readSql('db/sql/tablestructures.sql');
+    const collisionSql = extractSqlSegment(
+      canonicalSql,
+      'CREATE TEMPORARY TABLE existing_tag_stemtag_collision_failures',
+      'DROP TEMPORARY TABLE IF EXISTS existing_tag_stemtag_collision_failures'
+    );
 
-    expect(canonicalSql).toContain("'DUPLICATE_TAG_CONFLICT_EXISTING'");
+    expect(collisionSql).toContain("'DUPLICATE_TAG_CONFLICT_EXISTING'");
     // STRAIGHT_JOIN (not INNER JOIN) is load-bearing: it pins the batch-driven join order
     // so the optimizer can never flip to the trees x coremeasurements pair explosion that
     // stalled the 2026-07-28 Harvard census upload (8s -> 1,500s+ per sub-batch).
-    expect(canonicalSql).toContain('STRAIGHT_JOIN trees t_existing');
-    expect(canonicalSql).toContain('STRAIGHT_JOIN stems s_existing');
-    expect(canonicalSql).toContain('STRAIGHT_JOIN coremeasurements cm_existing_stem');
+    expect(collisionSql).toMatch(
+      /FROM resolved_batch_rows rbr STRAIGHT_JOIN trees t_existing[\s\S]*STRAIGHT_JOIN stems s_existing[\s\S]*STRAIGHT_JOIN coremeasurements cm_existing_stem/
+    );
+    expect(collisionSql).not.toContain('INNER JOIN trees t_existing');
+    expect(collisionSql).not.toContain('INNER JOIN stems s_existing');
+    expect(collisionSql).not.toContain('INNER JOIN coremeasurements cm_existing_stem');
     expect(canonicalSql).toContain('CREATE TEMPORARY TABLE prior_core_insert_failure_rows');
-    expect(canonicalSql).toContain('LEFT JOIN prior_core_insert_failure_rows prior_failure');
-    expect(canonicalSql).toContain('CREATE TEMPORARY TABLE existing_tag_stemtag_collision_failures');
-    expect(canonicalSql).toContain('incoming row preserved for review');
+    expect(collisionSql).toContain('LEFT JOIN prior_core_insert_failure_rows prior_failure');
+    expect(collisionSql).toContain('incoming row preserved for review');
     expect(canonicalSql).toContain('SELECT COUNT(*) FROM existing_tag_stemtag_collision_failures');
+
+    // Pin the permanent indexes that make the forced batch-driven order one lookup per stage.
+    expect(tableStructuresSql).toContain('create index idx_trees_tag_census_active on trees (TreeTag, CensusID, IsActive)');
+    expect(tableStructuresSql).toContain('constraint ux_stems_treeid_stemtag_census unique (TreeID, StemTag, CensusID)');
+    expect(tableStructuresSql).toContain('constraint ux_measure_unique unique (StemGUID, CensusID, MeasurementDate, MeasuredDBH, MeasuredHOM)');
   });
 
   it('cleans up stale failed sub-batches before retrying the same batch id', () => {

--- a/frontend/tests/upload-procedure-regressions.test.ts
+++ b/frontend/tests/upload-procedure-regressions.test.ts
@@ -52,9 +52,12 @@ describe('upload procedure regressions', () => {
     const canonicalSql = readSql('db/sql/storedprocedures.sql');
 
     expect(canonicalSql).toContain("'DUPLICATE_TAG_CONFLICT_EXISTING'");
-    expect(canonicalSql).toContain('INNER JOIN trees t_existing');
-    expect(canonicalSql).toContain('INNER JOIN stems s_existing');
-    expect(canonicalSql).toContain('INNER JOIN coremeasurements cm_existing_stem');
+    // STRAIGHT_JOIN (not INNER JOIN) is load-bearing: it pins the batch-driven join order
+    // so the optimizer can never flip to the trees x coremeasurements pair explosion that
+    // stalled the 2026-07-28 Harvard census upload (8s -> 1,500s+ per sub-batch).
+    expect(canonicalSql).toContain('STRAIGHT_JOIN trees t_existing');
+    expect(canonicalSql).toContain('STRAIGHT_JOIN stems s_existing');
+    expect(canonicalSql).toContain('STRAIGHT_JOIN coremeasurements cm_existing_stem');
     expect(canonicalSql).toContain('CREATE TEMPORARY TABLE prior_core_insert_failure_rows');
     expect(canonicalSql).toContain('LEFT JOIN prior_core_insert_failure_rows prior_failure');
     expect(canonicalSql).toContain('CREATE TEMPORARY TABLE existing_tag_stemtag_collision_failures');


### PR DESCRIPTION
## Summary

Fixes the ingestion stall behind the Harvard census upload incident (2026-07-28): equal 10k-row sub-batches went 8s → 8s → 1,500s+ once the census held 20k measurements.

The `existing_tag_stemtag_collision_failures` query in `bulkingestionprocess` (STAGE 8) joined `resolved_batch_rows → trees → stems → coremeasurements` with the join order left to the optimizer. Reproduction at incident scale (26k trees / 30k stems / 20k existing measurements / 10k-row batch, local MySQL 8.0.36) confirmed the shape is plan-fragile: the identical dataset runs in 44ms under one plan choice and exceeds a 60s timeout under another (driving from a `coremeasurements` scan into the temp table by `CensusID`, which matches every batch row — an existing×batch pair explosion). Adding a composite tag index on the temp table makes the bad choice *more* likely, not less.

The fix pins the only safe order with `STRAIGHT_JOIN`: batch rows driving one indexed lookup per stage (`idx_trees_tag_census_active` → `ux_stems_treeid_stemtag_census` → `ux_measure_unique`), so cost is bounded by batch size no matter how large `trees`/`coremeasurements` grow. Forced-order runtime at incident scale: 32ms.

## Why not the StemGUID-driven rewrite

Joining `coremeasurements` directly on the row's resolved `rbr.StemGUID` (the "obvious" simplification, and what was recommended in review of the incident) is **semantically wrong**: tags are only unique per `(TreeTag, SpeciesID, CensusID)`, so a species-corrected re-upload of an existing tag pair resolves to a freshly created tree/stem with no measurements of its own — the StemGUID join sees no conflict and the correction silently forks a second tree instead of being preserved for review. The existing cross-batch preservation test caught exactly this. The tag-level rematch is deliberate; a new test now pins that semantics explicitly from the other side so it can't be "simplified" away without re-ratifying the trade-off.

## Tests

- `ingestion-invariants` additions:
  - a same-stem remeasurement on a **different date** across batches ingests cleanly (the reingestion contract);
  - a same-date measurement on **any** same-tag tree — even another species' — is preserved for review (tag-scoped conflict pin).
- `upload-procedure-regressions`: the collision block's source contract now requires the `STRAIGHT_JOIN` order (regex over the extracted segment), rejects a regression back to `INNER JOIN`, and pins the permanent indexes each forced stage relies on.
- New `ingestion-scale-benchmark` integration test: three real 10k-row sub-batches into one census (0/10k/20k existing), asserting later batches stay under max(5× first batch, 30s), with a per-CALL 45s timeout that KILLs the server-side statement from a second connection on regression (a Vitest timeout alone cannot cancel MySQL work). Healthy: 2146ms → 2135ms → 2166ms, each batch fully ingesting 10,000 rows.

**Honest scope of the benchmark:** the production plan flip is statistics-dependent and does not reproduce deterministically at this scale — the pre-fix procedure also passes the benchmark locally. The benchmark is a canary for any cost-scaling regression in the procedure (it fails loudly at the incident's magnitude); the deterministic protection is the `STRAIGHT_JOIN` itself, backed by the production evidence and the local demonstration that the unforced shape can explode.