### PR TITLE
fix(ingestion): never retry a KILLed procedure call

### DIFF
--- a/frontend/lib/uploads/ingest-batch.ts
+++ b/frontend/lib/uploads/ingest-batch.ts
@@ -74,6 +74,7 @@ const RETRY_JITTER_MAX_MS = 1_000;
 const MYSQL_ERRNO_SERVER_GONE = 1927; // ER_SERVER_LOST — server closed the connection
 const MYSQL_ERRNO_TCP_LOST = 2013; // CR_SERVER_LOST — TCP connection lost during query
 const MYSQL_ERRNO_DEADLOCK = 1213; // ER_LOCK_DEADLOCK
+const MYSQL_ERRNO_QUERY_INTERRUPTED = 1317; // ER_QUERY_INTERRUPTED — statement was KILLed
 
 /**
  * Thrown when the caller's isAborted probe fires between sub-batches.
@@ -449,6 +450,7 @@ async function processSubBatch(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       const isTimeout = e.message?.includes('timed out');
+      const isInterrupted = e.code === 'ER_QUERY_INTERRUPTED' || e.errno === MYSQL_ERRNO_QUERY_INTERRUPTED;
       const isConnectionError =
         e.code === 'ECONNRESET' || e.code === 'PROTOCOL_CONNECTION_LOST' || e.errno === MYSQL_ERRNO_SERVER_GONE || e.errno === MYSQL_ERRNO_TCP_LOST;
       const isDeadlock = e.code === 'ER_LOCK_DEADLOCK' || e.errno === MYSQL_ERRNO_DEADLOCK;
@@ -462,6 +464,7 @@ async function processSubBatch(
         sqlMessage: e.sqlMessage,
         sql: e.sql?.substring(0, 200),
         isTimeout,
+        isInterrupted,
         isConnectionError,
         isDeadlock,
         isLockContention,
@@ -471,6 +474,12 @@ async function processSubBatch(
         subBatchID
       });
 
+      // A KILLed statement (ER_QUERY_INTERRUPTED) is a deliberate abort — an
+      // operator's KILL QUERY or the DB layer's timeout kill — never blindly
+      // re-run it. During the 2026-07-28 Harvard incident an operator KILL of a
+      // pathological 25-minute statement landed here as generic-retryable and
+      // simply started the same statement over.
+      if (isInterrupted) break;
       if (isTimeout && attempt >= TIMEOUT_GIVE_UP_AFTER_ATTEMPTS) break;
       if (isLockContention && attempt >= LOCK_GIVE_UP_AFTER_ATTEMPTS) break;
 

--- a/frontend/tests/integration/ingest-batch.test.ts
+++ b/frontend/tests/integration/ingest-batch.test.ts
@@ -559,4 +559,67 @@ describe('ingestBatch — integration', () => {
     console.log(`[abort-mid] unresolved coremeasurements rows=${unresolvedRows[0].count}`);
     expect(Number(unresolvedRows[0].count)).toBe(EXPECTED_ROW_COUNT);
   }, 60000);
+
+  // -------------------------------------------------------------------------
+  // 7. KILLed procedure call: ER_QUERY_INTERRUPTED is a deliberate abort
+  //
+  // During the 2026-07-28 Harvard incident, an operator KILL QUERY of a
+  // pathological 25-minute bulkingestionprocess call surfaced here as a
+  // generic-retryable error, and the retry loop immediately started the same
+  // statement over. An interrupted statement means someone (an operator, or the
+  // DB layer's timeout kill) deliberately stopped it — re-running it verbatim
+  // is never right.
+  //
+  // Expected outcome: exactly ONE procedure attempt (no retries, no backoff),
+  // the sub-batch's rows moved to unresolved coremeasurements, and ingestBatch
+  // returns normally.
+  // -------------------------------------------------------------------------
+
+  it('abandons a sub-batch after a single attempt when the procedure call is KILLed (ER_QUERY_INTERRUPTED)', async () => {
+    await stageFixtureRows();
+    expect(await countTemporaryRows()).toBe(EXPECTED_ROW_COUNT);
+
+    // Reject ONLY the procedure CALL with the exact error shape mysql2 raises
+    // for a KILL QUERY; every other statement passes through to the real DB.
+    const interruptError = Object.assign(new Error('Query execution was interrupted'), {
+      code: 'ER_QUERY_INTERRUPTED',
+      errno: 1317,
+      sqlState: '70100'
+    });
+    const realExecuteQuery = connectionManager.executeQuery.bind(connectionManager);
+    const executeQuerySpy = vi
+      .spyOn(connectionManager, 'executeQuery')
+      .mockImplementation(async (query: string, params?: unknown[], transactionId?: string) => {
+        if (query.includes('bulkingestionprocess')) {
+          console.log('[kill-interrupt] rejecting procedure CALL with ER_QUERY_INTERRUPTED');
+          throw interruptError;
+        }
+        return realExecuteQuery(query, params, transactionId);
+      });
+
+    try {
+      const result = await runIngestBatch();
+
+      const procedureAttempts = executeQuerySpy.mock.calls.filter(([query]) => typeof query === 'string' && query.includes('bulkingestionprocess')).length;
+      console.log(`[kill-interrupt] procedure CALL attempts=${procedureAttempts}`);
+      expect(procedureAttempts, 'a KILLed statement must never be re-run').toBe(1);
+
+      expect(result.subBatchResults).toHaveLength(1);
+      const subResult = result.subBatchResults[0];
+      expect(subResult.attemptsNeeded, 'gave up after the first interrupted attempt').toBe(1);
+      expect(subResult.batchFailedButHandled).toBe(true);
+      expect(subResult.rowCount, 'all staged rows moved to unresolved').toBe(EXPECTED_ROW_COUNT);
+
+      // temporarymeasurements drained; rows preserved as unresolved, not lost.
+      expect(await countTemporaryRows()).toBe(0);
+      const [unresolvedRows] = await connection.query<RowDataPacket[]>(
+        'SELECT COUNT(*) AS count FROM coremeasurements WHERE UploadFileID = ? AND StemGUID IS NULL',
+        [FILE_NAME]
+      );
+      console.log(`[kill-interrupt] unresolved coremeasurements rows=${unresolvedRows[0].count}`);
+      expect(Number(unresolvedRows[0].count)).toBe(EXPECTED_ROW_COUNT);
+    } finally {
+      executeQuerySpy.mockRestore();
+    }
+  }, 60000);
 });


### PR DESCRIPTION
## Summary

`processSubBatch` classified `ER_QUERY_INTERRUPTED` (errno 1317) as a generic-retryable error, so a deliberately KILLed `bulkingestionprocess` statement was immediately started over. During the 2026-07-28 Harvard incident, an operator `KILL QUERY` of a pathological 25-minute call simply triggered attempt 2 of 5 of the same statement.

An interrupted statement means someone stopped it on purpose — an operator's `KILL QUERY`, or the DB layer's timeout kill (#385). The retry loop now abandons the sub-batch after that single attempt, moving its rows to unresolved `coremeasurements` exactly like the timeout give-up path.

New integration test injects the exact mysql2 KILL error shape into the procedure CALL (all other statements pass through to the real DB) and pins: exactly one attempt, no backoff retries, all staged rows preserved as unresolved, `temporarymeasurements` drained.

Completes the incident's retry-hardening trio with #385 (timeout kill + pool quarantine) and #386 (collision join-order pin).