### PR TITLE
fix(worker): make crash recovery sub-batch aware and surface unresolved outcomes

### DIFF
--- a/frontend/app/api/setupbulkprocedure/[fileID]/[batchID]/route.test.ts
+++ b/frontend/app/api/setupbulkprocedure/[fileID]/[batchID]/route.test.ts
@@ -224,7 +224,10 @@ describe('GET /api/setupbulkprocedure/[fileID]/[batchID]', () => {
         normalizedSql.includes('DELETE FROM forestgeo_testing.coremeasurements') &&
         normalizedSql.includes('StemGUID IS NULL') &&
         normalizedSql.includes('UploadFileID = ?') &&
-        normalizedSql.includes('NOT (UploadBatchID <=> ?)')
+        // Family-sparing exclusion: on a worker retry the batch ID is reused
+        // and completed sub-batches' proc-recorded failure rows live under
+        // suffixed IDs — a bare-ID exclusion would delete them permanently.
+        normalizedSql.includes('NOT (UploadBatchID <=> ? OR UploadBatchID LIKE ?')
       );
     });
 
@@ -259,7 +262,8 @@ describe('GET /api/setupbulkprocedure/[fileID]/[batchID]', () => {
         normalizedSql.includes('JOIN forestgeo_testing.temporarymeasurements tm') &&
         normalizedSql.includes('tm.FileID = ?') &&
         normalizedSql.includes('tm.BatchID = ?') &&
-        normalizedSql.includes('NOT (cm.UploadFileID <=> ? AND cm.UploadBatchID <=> ?)')
+        // Family-sparing (see the same-file cleanup test above).
+        normalizedSql.includes('NOT (cm.UploadFileID <=> ? AND (cm.UploadBatchID <=> ? OR cm.UploadBatchID LIKE ?')
       );
     });
 

--- a/frontend/app/api/uploadjobs/[jobId]/route.ts
+++ b/frontend/app/api/uploadjobs/[jobId]/route.ts
@@ -4,8 +4,11 @@ import { requireSession, getSessionUserId } from '@/lib/auth-helpers';
 import { HTTPResponses } from '@/config/macros';
 import { getPoolMonitorInstance } from '@/lib/db/poolmonitorsingleton';
 import { cancelBackgroundJob, getBackgroundJobWithDetails, requestBackgroundJobCancel } from '@/lib/background-jobs/repository';
+import { cleanupCancelledUnclaimedJobArtifacts } from '@/lib/background-jobs/worker';
 import { parseJobID, requireJobAccess } from '@/lib/background-jobs/route-helpers';
 import type { BackgroundJobWithDetails } from '@/lib/background-jobs/types';
+import ConnectionManager from '@/lib/db/connectionmanager';
+import ailogger from '@/ailogger';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
 
 export const runtime = 'nodejs';
@@ -104,6 +107,18 @@ async function postHandler(request: NextRequest, context: RouteContext) {
   // queued/waiting_retry jobs have no worker and are cancelled directly.
   const cancelled = await cancelBackgroundJob(catalogPool, parsedJobID, userID);
   if (cancelled) {
+    // A waiting_retry job's dead attempt may have left staged rows and parse
+    // rejects behind; with no worker to finalize this cancel, clean them here.
+    // Best-effort: the cancel itself is already durable, and the cleanup is
+    // idempotent hygiene — a failure here must not turn the cancel into a 500.
+    try {
+      await cleanupCancelledUnclaimedJobArtifacts(ConnectionManager.getInstance(), job);
+    } catch (cleanupError) {
+      ailogger.warn(
+        `[uploadjobs] Cancelled job ${parsedJobID} but artifact cleanup failed (residue remains until next attempt): ` +
+          `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+      );
+    }
     return NextResponse.json({ success: true }, { status: HTTPResponses.OK });
   }
 

--- a/frontend/lib/background-jobs/repository.ts
+++ b/frontend/lib/background-jobs/repository.ts
@@ -656,14 +656,21 @@ export async function markBackgroundJobWaitingRetryAsWorker(
   return job;
 }
 
-export async function markBackgroundJobCompleted(catalogPool: Pool, jobID: number, workerID: string): Promise<void> {
+export async function markBackgroundJobCompleted(
+  catalogPool: Pool,
+  jobID: number,
+  workerID: string,
+  outcome: { failedRows?: number; unresolvedRows?: number } = {}
+): Promise<void> {
+  const unresolvedRows = outcome.unresolvedRows ?? 0;
   await setBackgroundJobStatus(catalogPool, jobID, workerID, {
     status: 'completed',
     phase: 'completed',
     percentComplete: UPLOAD_JOB_PHASE_PROGRESS.completed,
+    ...(outcome.failedRows !== undefined ? { failedRows: outcome.failedRows } : {}),
     lastError: null,
     eventType: 'completed',
-    eventMessage: 'Upload job completed'
+    eventMessage: unresolvedRows > 0 ? `Upload job completed with ${unresolvedRows} row(s) preserved as unresolved failures for review` : 'Upload job completed'
   });
 }
 

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -44,7 +44,7 @@ import { commitArcgisImport } from '@/lib/uploads/arcgis-commit';
 import { collapseCensus } from '@/lib/uploads/collapse-census';
 import { detectDelimiter } from '@/lib/uploads/detect-delimiter';
 import { sanitizeUploadFileName } from '@/lib/uploads/file-names';
-import { ingestBatch, IngestBatchAbortedError } from '@/lib/uploads/ingest-batch';
+import { ingestBatch, IngestBatchAbortedError, type IngestBatchResult } from '@/lib/uploads/ingest-batch';
 import { deleteUnresolvedRowsForBatchFamily, recordInvalidRows } from '@/lib/uploads/record-invalid-rows';
 import { buildSubBatchPattern, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
 import { countStagedRows, MeasurementChunkResolutionError, stageMeasurementChunk } from '@/lib/uploads/stage-measurements';
@@ -139,6 +139,7 @@ export async function runJobIfClaimable(jobID: number, deps?: WorkerDeps): Promi
     cancelRequested: false,
     processedRows: 0,
     failedRows: 0,
+    unresolvedIngestRows: 0,
     lastPercent: 0,
     assignedBatches: new Map(),
     deferredInvalidRows: [],
@@ -170,7 +171,10 @@ export async function runJobIfClaimable(jobID: number, deps?: WorkerDeps): Promi
     await runPostIngestionPhases(ctx);
 
     await assertStillOwned(ctx);
-    await markBackgroundJobCompleted(catalogPool, jobID, workerID);
+    await markBackgroundJobCompleted(catalogPool, jobID, workerID, {
+      failedRows: ctx.failedRows,
+      unresolvedRows: ctx.unresolvedIngestRows
+    });
     completed = true;
   } catch (error) {
     await handleRunFailure(ctx, error);
@@ -229,6 +233,13 @@ interface WorkerRunContext {
   cancelRequested: boolean;
   processedRows: number;
   failedRows: number;
+  /**
+   * Rows the ingest phase preserved as unresolved failures (proc-recorded
+   * per-row failures + rows moved after exhausted/abandoned sub-batch
+   * attempts). Counted into failedRows too; tracked separately so job
+   * completion can say so instead of reading as a clean success.
+   */
+  unresolvedIngestRows: number;
   lastPercent: number;
   assignedBatches: Map<number, { file: BackgroundJobFileRecord; batchID: string }>;
   /** Parse rejects from zero-valid-row files, recorded after the last ingest (see runMeasurementsPipeline). */
@@ -359,7 +370,18 @@ function collectCancellationCleanupTargets(ctx: WorkerRunContext): Array<{ fileN
  */
 async function finalizeCancelledJob(ctx: WorkerRunContext): Promise<void> {
   for (const { fileName, batchID } of collectCancellationCleanupTargets(ctx)) {
-    if (await isBatchCompleted(ctx, fileName, batchID)) continue; // completed-batch guard: never clean
+    if (await isBatchCompleted(ctx, fileName, batchID)) {
+      // A family can LOOK completed (a metric completed, nothing processing,
+      // nothing staged) while a mid-batch abort left other sub-batches' rows
+      // parked as unresolved with no metric at all. Only skip when no such
+      // residue exists; otherwise fall through — cleanup preserves the
+      // completed members' rows and removes only the abandoned ones.
+      const abandonedSubBatchIDs = await findAbandonedUnresolvedSubBatchIDs(ctx, fileName, batchID);
+      if (abandonedSubBatchIDs.length === 0) continue;
+      ailogger.info(
+        `[UploadWorker] Cancelled family ${batchID} looks completed but holds unresolved rows from abandoned sub-batch(es) ${abandonedSubBatchIDs.join(', ')}; cleaning those`
+      );
+    }
     await cleanupBatchArtifacts(ctx, fileName, batchID);
   }
   await setBackgroundJobStatus(ctx.catalogPool, ctx.job.jobID, ctx.workerID, {
@@ -545,7 +567,7 @@ function getRecordPayload<T>(payload: Record<string, unknown> | null, key: strin
  * in flight: no family metric left in 'processing'/'failed', and no family rows
  * left staged.
  */
-async function isBatchCompleted(ctx: WorkerRunContext, fileName: string, batchID: string): Promise<boolean> {
+async function isBatchCompleted(ctx: BatchScopeContext, fileName: string, batchID: string): Promise<boolean> {
   const { schemaName, censusID } = ctx.job;
   const subBatchPattern = buildSubBatchPattern(batchID);
 
@@ -575,6 +597,93 @@ async function isBatchCompleted(ctx: WorkerRunContext, fileName: string, batchID
 }
 
 /**
+ * The slice of worker context the batch-hygiene helpers actually need. Lets
+ * the cancel API route (which has no running worker) reuse the same
+ * completed-family probe and sub-batch-aware cleanup as the worker itself.
+ */
+type BatchScopeContext = Pick<WorkerRunContext, 'connectionManager' | 'job'>;
+
+/**
+ * Cleanup for a job cancelled while UNCLAIMED (queued/waiting_retry): a prior
+ * failed attempt may have left staged temporarymeasurements rows and recorded
+ * parse rejects behind, and with no worker to finalize the cancel they would
+ * otherwise be orphaned forever. Applies the same completed-family guard and
+ * sub-batch-aware cleanup as the worker's own cancel finalization.
+ */
+export async function cleanupCancelledUnclaimedJobArtifacts(connectionManager: ConnectionManager, job: BackgroundJobWithDetails): Promise<void> {
+  const ctx: BatchScopeContext = { connectionManager, job };
+  for (const file of job.files) {
+    if (!file.batchID) continue;
+    if (await isBatchCompleted(ctx, file.fileName, file.batchID)) {
+      const abandonedSubBatchIDs = await findAbandonedUnresolvedSubBatchIDs(ctx, file.fileName, file.batchID);
+      if (abandonedSubBatchIDs.length === 0) continue;
+    }
+    await cleanupBatchArtifacts(ctx, file.fileName, file.batchID);
+  }
+}
+
+/**
+ * Batch/sub-batch IDs in the family whose uploadmetrics row is 'completed'.
+ * These sub-batches' StemGUID-NULL rows are the PROC's recorded failures — the
+ * idempotent re-run skips completed sub-batches and never regenerates them, so
+ * cleanup must preserve those rows (see deleteUnresolvedRowsForBatchFamily's
+ * precondition).
+ */
+async function getCompletedSubBatchIDs(ctx: BatchScopeContext, batchID: string): Promise<string[]> {
+  const { schemaName, censusID } = ctx.job;
+  const sql = safeFormatQuery(
+    schemaName,
+    `SELECT batchID FROM ??.uploadmetrics
+     WHERE censusID = ?
+       AND (batchID = ? OR batchID LIKE ? ${LIKE_ESCAPE_CLAUSE})
+       AND status = 'completed'`
+  );
+  const rows = await ctx.connectionManager.executeQuery(sql, [censusID, batchID, buildSubBatchPattern(batchID)]);
+  return Array.isArray(rows) ? rows.map((row: { batchID: string }) => String(row.batchID)) : [];
+}
+
+/** Per-row failures the procedure recorded across the batch family's metrics. */
+async function sumFamilyFailedRecords(ctx: BatchScopeContext, batchID: string): Promise<number> {
+  const { schemaName, censusID } = ctx.job;
+  const sql = safeFormatQuery(
+    schemaName,
+    `SELECT COALESCE(SUM(failedRecords), 0) AS failedTotal FROM ??.uploadmetrics
+     WHERE censusID = ?
+       AND (batchID = ? OR batchID LIKE ? ${LIKE_ESCAPE_CLAUSE})`
+  );
+  const rows = await ctx.connectionManager.executeQuery(sql, [censusID, batchID, buildSubBatchPattern(batchID)]);
+  return Number(rows?.[0]?.failedTotal ?? 0);
+}
+
+/**
+ * Sub-batch IDs that hold unresolved (StemGUID IS NULL) rows but have NO
+ * 'completed' uploadmetrics row. These are the residue of a dead or aborted
+ * attempt — e.g. a mid-batch cancel moved staged rows to unresolved without a
+ * metric ever completing. A family carrying such IDs can satisfy the
+ * completed-family probe (some metric completed, nothing processing, nothing
+ * staged) while still holding attempt residue that must be cleaned.
+ */
+async function findAbandonedUnresolvedSubBatchIDs(ctx: BatchScopeContext, fileName: string, batchID: string): Promise<string[]> {
+  const { schemaName, censusID } = ctx.job;
+  const sql = safeFormatQuery(
+    schemaName,
+    `SELECT DISTINCT cm.UploadBatchID AS batchID
+     FROM ??.coremeasurements cm
+     LEFT JOIN ??.uploadmetrics um
+       ON um.batchID = cm.UploadBatchID
+      AND um.censusID = cm.CensusID
+      AND um.status = 'completed'
+     WHERE cm.UploadFileID = ?
+       AND cm.CensusID = ?
+       AND cm.StemGUID IS NULL
+       AND cm.UploadBatchID LIKE ? ${LIKE_ESCAPE_CLAUSE}
+       AND um.batchID IS NULL`
+  );
+  const rows = await ctx.connectionManager.executeQuery(sql, [fileName, censusID, buildSubBatchPattern(batchID)]);
+  return Array.isArray(rows) ? rows.map((row: { batchID: string }) => String(row.batchID)) : [];
+}
+
+/**
  * Retry hygiene for a NON-completed batch: drops any temporarymeasurements
  * left by an interrupted attempt and the parse rejects it recorded, so the
  * re-run starts from a clean slate without accumulating duplicates.
@@ -582,8 +691,13 @@ async function isBatchCompleted(ctx: WorkerRunContext, fileName: string, batchID
  * Operates on the batch family for the same reason as the probe: an
  * interrupted split leaves rows under `__subNNN`, and deleting only the
  * unsuffixed ID would leave them staged to be ingested a second time.
+ *
+ * SUB-BATCH AWARE: within a mixed family (some sub-batches completed, others
+ * not), the completed members' StemGUID-NULL rows are the proc's recorded
+ * failures and MUST survive — the idempotent re-run skips those sub-batches
+ * and never regenerates them. Only non-completed members' rows are deleted.
  */
-async function cleanupBatchArtifacts(ctx: WorkerRunContext, fileName: string, batchID: string): Promise<void> {
+async function cleanupBatchArtifacts(ctx: BatchScopeContext, fileName: string, batchID: string): Promise<void> {
   const { schemaName, plotID, censusID } = ctx.job;
   const subBatchPattern = buildSubBatchPattern(batchID);
 
@@ -594,7 +708,8 @@ async function cleanupBatchArtifacts(ctx: WorkerRunContext, fileName: string, ba
        AND (BatchID = ? OR BatchID LIKE ? ${LIKE_ESCAPE_CLAUSE})`
   );
   await ctx.connectionManager.executeQuery(deleteTempSQL, [fileName, plotID, censusID, batchID, subBatchPattern]);
-  await deleteUnresolvedRowsForBatchFamily(ctx.connectionManager, schemaName, fileName, batchID, censusID);
+  const completedSubBatchIDs = await getCompletedSubBatchIDs(ctx, batchID);
+  await deleteUnresolvedRowsForBatchFamily(ctx.connectionManager, schemaName, fileName, batchID, censusID, undefined, completedSubBatchIDs);
 }
 
 // ---------------------------------------------------------------------------
@@ -751,10 +866,26 @@ async function runMeasurementsPipeline(ctx: WorkerRunContext): Promise<void> {
     await assertStillOwned(ctx);
     await transitionSessionState(ctx, UploadSessionState.UPLOADED);
 
+    let fileUnresolvedRows = 0;
     if (fileInsertedRows > 0) {
       await setProgress(ctx, 'ingestion', UPLOAD_JOB_PHASE_PROGRESS.ingestion, `Ingesting ${file.fileName}`);
       await transitionSessionState(ctx, UploadSessionState.PROCESSING);
-      await runIngestForBatch(ctx, file.fileName, batchID);
+      const ingestResult = await runIngestForBatch(ctx, file.fileName, batchID);
+      // Surface what the ingest actually did: rows the retry loop moved to
+      // unresolved after abandoning a sub-batch, plus per-row failures the
+      // procedure recorded in uploadmetrics. Without this a sub-batch that
+      // exhausted every attempt still finalized the job as a clean success.
+      const movedRows = ingestResult.subBatchResults.reduce((total, sub) => total + sub.rowCount, 0);
+      const procFailedRecords = await sumFamilyFailedRecords(ctx, batchID);
+      fileUnresolvedRows = movedRows + procFailedRecords;
+      if (fileUnresolvedRows > 0) {
+        ctx.failedRows += fileUnresolvedRows;
+        ctx.unresolvedIngestRows += fileUnresolvedRows;
+        ailogger.warn(
+          `[UploadWorker] ${file.fileName} (batch ${batchID}) ingested with ${fileUnresolvedRows} unresolved failure row(s): ` +
+            `${movedRows} moved after abandoned sub-batch attempt(s), ${procFailedRecords} recorded by bulkingestionprocess`
+        );
+      }
     }
 
     if (fileInvalidRows.length > 0 && fileInsertedRows > 0) {
@@ -801,11 +932,13 @@ async function runMeasurementsPipeline(ctx: WorkerRunContext): Promise<void> {
     await updateBackgroundJobFileStatus(ctx.catalogPool, job.jobID, ctx.workerID, file.jobFileID, {
       status: fileInsertedRows > 0 ? 'processed' : fileInvalidRows.length + fileDroppedRows > 0 ? 'failed' : 'skipped',
       processedRows: fileInsertedRows,
-      failedRows: fileInvalidRows.length + fileDroppedRows,
+      failedRows: fileInvalidRows.length + fileDroppedRows + fileUnresolvedRows,
       errorMessage:
         fileInsertedRows === 0 && fileInvalidRows.length + fileDroppedRows > 0
           ? `No rows could be staged: ${fileInvalidRows.length} row(s) rejected during parsing, ${fileDroppedRows} row(s) dropped during column resolution`
-          : null
+          : fileUnresolvedRows > 0
+            ? `${fileUnresolvedRows} row(s) preserved as unresolved failures during ingestion`
+            : null
     });
   }
 
@@ -830,9 +963,9 @@ async function runMeasurementsPipeline(ctx: WorkerRunContext): Promise<void> {
  * surfaces as IngestBatchAbortedError; route it through assertStillOwned so it
  * is finalized as a cancellation or lease loss rather than a generic failure.
  */
-async function runIngestForBatch(ctx: WorkerRunContext, fileName: string, batchID: string): Promise<void> {
+async function runIngestForBatch(ctx: WorkerRunContext, fileName: string, batchID: string): Promise<IngestBatchResult> {
   try {
-    await ingestBatch(ctx.connectionManager, {
+    return await ingestBatch(ctx.connectionManager, {
       schema: ctx.job.schemaName,
       fileID: fileName,
       batchID,

--- a/frontend/lib/uploads/ingest-batch.ts
+++ b/frontend/lib/uploads/ingest-batch.ts
@@ -28,7 +28,7 @@ import ailogger from '@/ailogger';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
 import { shouldRecoverFailedInitialCensus } from '@/lib/failedinitialcensusrecovery';
 import { moveTemporaryBatchToFailedMeasurements } from '@/lib/batchfailuretransfer';
-import { buildSubBatchID, discoverBatchFamily, highestSubBatchOrdinal } from '@/lib/uploads/batch-family';
+import { buildSubBatchID, buildSubBatchPattern, discoverBatchFamily, highestSubBatchOrdinal, LIKE_ESCAPE_CLAUSE } from '@/lib/uploads/batch-family';
 
 // Sub-batches of 10K rows keep transaction duration ~6.5s (benchmarked),
 // well under the 50s innodb_lock_wait_timeout on Azure MySQL.
@@ -270,16 +270,28 @@ async function cleanupMatchedUnresolvedIngestionFailuresForBatch(
   censusID: number,
   transactionID: string
 ): Promise<number> {
+  // Spare the CURRENT batch FAMILY (bare ID + its __subNNN members), not just
+  // the bare ID: on a worker retry the batch ID is reused, and the completed
+  // sub-batches' proc-recorded failure rows live under suffixed IDs — deleting
+  // them here would permanently destroy recorded failures the idempotent
+  // re-run never regenerates. Non-completed members' stale rows were already
+  // removed by the worker's sub-batch-aware cleanup before re-staging. A
+  // same-file re-upload under a NEW batch ID still cleans the old family
+  // (a different family never matches the new one's pattern).
   const sameFileDeleteSQL = safeFormatQuery(
     schema,
     `DELETE FROM ??.coremeasurements
      WHERE CensusID = ?
        AND StemGUID IS NULL
        AND UploadFileID = ?
-       AND NOT (UploadBatchID <=> ?)`
+       AND NOT (UploadBatchID <=> ? OR UploadBatchID LIKE ? ${LIKE_ESCAPE_CLAUSE})`
   );
 
-  const sameFileDeleteResult = await connectionManager.executeQuery(sameFileDeleteSQL, [censusID, fileID, batchID], transactionID);
+  const sameFileDeleteResult = await connectionManager.executeQuery(
+    sameFileDeleteSQL,
+    [censusID, fileID, batchID, buildSubBatchPattern(batchID)],
+    transactionID
+  );
   const sameFileDeletedRows = toCount(sameFileDeleteResult?.affectedRows);
 
   if (sameFileDeletedRows > 0) {
@@ -329,10 +341,14 @@ async function cleanupMatchedUnresolvedIngestionFailuresForBatch(
       AND tm.Comments <=> cm.RawComments
      WHERE cm.CensusID = ?
        AND cm.StemGUID IS NULL
-       AND NOT (cm.UploadFileID <=> ? AND cm.UploadBatchID <=> ?)`
+       AND NOT (cm.UploadFileID <=> ? AND (cm.UploadBatchID <=> ? OR cm.UploadBatchID LIKE ? ${LIKE_ESCAPE_CLAUSE}))`
   );
 
-  const deleteResult = await connectionManager.executeQuery(deleteSQL, [fileID, batchID, censusID, fileID, batchID], transactionID);
+  const deleteResult = await connectionManager.executeQuery(
+    deleteSQL,
+    [fileID, batchID, censusID, fileID, batchID, buildSubBatchPattern(batchID)],
+    transactionID
+  );
   const deletedRows = toCount(deleteResult?.affectedRows);
 
   if (deletedRows > 0) {
@@ -370,8 +386,17 @@ async function splitIntoSubBatches(
     // Continue past any sub-batch left by an interrupted prior attempt so a
     // resumed split cannot reuse an ordinal that already holds rows.
     const subBatchID = buildSubBatchID(originalBatchID, startOrdinal + i + 1);
+    // ORDER BY id pins sub-batch membership to staging order (= file order,
+    // since chunks insert sequentially). Without it the LIMIT takes rows in
+    // unspecified InnoDB scan order, and a crash-retry that re-stages and
+    // re-splits could partition rows differently than the dead attempt — the
+    // proc's idempotency skip would then silently delete never-ingested rows
+    // re-staged under an already-completed sub-batch ID.
     // LIMIT cannot be parameterized in mysql2 prepared statements, so inline the constant
-    const updateSQL = safeFormatQuery(schema, `UPDATE ??.temporarymeasurements SET BatchID = ? WHERE FileID = ? AND BatchID = ? LIMIT ${batchSize}`);
+    const updateSQL = safeFormatQuery(
+      schema,
+      `UPDATE ??.temporarymeasurements SET BatchID = ? WHERE FileID = ? AND BatchID = ? ORDER BY id LIMIT ${batchSize}`
+    );
     const updateResult = await connectionManager.executeQuery(updateSQL, [subBatchID, fileID, originalBatchID], transactionID);
     const affectedRows = toCount(updateResult?.affectedRows);
 

--- a/frontend/lib/uploads/record-invalid-rows.ts
+++ b/frontend/lib/uploads/record-invalid-rows.ts
@@ -144,14 +144,16 @@ export async function recordFailedMeasurementRows(
  * Called before retrying a crashed upload job to prevent duplicate failure rows
  * accumulating across retry attempts.
  *
- * PRECONDITION — never call this for a batch whose uploadmetrics row is
- * status='completed'. Under the same (UploadFileID, UploadBatchID), completed
- * batches hold BOTH the worker-recorded parse rejects AND the failure rows the
- * bulkingestionprocess stored procedure recorded during ingestion — all with
- * StemGUID NULL and indistinguishable here. Deleting them would permanently
- * destroy the procedure's recorded failures: the idempotent re-run of a
- * completed batch skips ingestion entirely and never regenerates them. Callers
- * must probe uploadmetrics first and skip completed batches.
+ * PRECONDITION — never delete rows belonging to a batch (or sub-batch) whose
+ * uploadmetrics row is status='completed'. Under the same
+ * (UploadFileID, UploadBatchID), completed batches hold BOTH the
+ * worker-recorded parse rejects AND the failure rows the bulkingestionprocess
+ * stored procedure recorded during ingestion — all with StemGUID NULL and
+ * indistinguishable here. Deleting them would permanently destroy the
+ * procedure's recorded failures: the idempotent re-run of a completed batch
+ * skips ingestion entirely and never regenerates them. Callers enforce this by
+ * passing the family's completed batch/sub-batch IDs as `preserveBatchIDs`
+ * (or by skipping fully-completed families outright).
  *
  * Scope is the whole batch FAMILY: rows recorded under the original BatchID AND
  * under any `<batchID>__subNNN` a prior split created. Cleaning only the
@@ -167,20 +169,23 @@ export async function deleteUnresolvedRowsForBatchFamily(
   fileID: string,
   batchID: string,
   censusID: number,
-  transactionID?: string
+  transactionID?: string,
+  preserveBatchIDs: string[] = []
 ): Promise<number> {
+  const preserveClause = preserveBatchIDs.length > 0 ? `AND UploadBatchID NOT IN (${preserveBatchIDs.map(() => '?').join(', ')})` : '';
   const deleteSQL = safeFormatQuery(
     schema,
     `DELETE FROM ??.coremeasurements
      WHERE UploadFileID = ?
        AND CensusID = ?
        AND StemGUID IS NULL
-       AND (UploadBatchID = ? OR UploadBatchID LIKE ? ${LIKE_ESCAPE_CLAUSE})`
+       AND (UploadBatchID = ? OR UploadBatchID LIKE ? ${LIKE_ESCAPE_CLAUSE})
+       ${preserveClause}`
   );
 
   const result: { affectedRows?: number } = await connectionManager.executeQuery(
     deleteSQL,
-    [fileID, censusID, batchID, buildSubBatchPattern(batchID)],
+    [fileID, censusID, batchID, buildSubBatchPattern(batchID), ...preserveBatchIDs],
     transactionID
   );
   return result?.affectedRows ?? 0;

--- a/frontend/tests/integration/upload-worker.test.ts
+++ b/frontend/tests/integration/upload-worker.test.ts
@@ -174,7 +174,7 @@ import {
   getBackgroundJob,
   getBackgroundJobWithDetails
 } from '@/lib/background-jobs/repository';
-import { runJobIfClaimable, SESSION_CONFLICT_RETRY_DELAY_SECONDS, type WorkerDeps } from '@/lib/background-jobs/worker';
+import { cleanupCancelledUnclaimedJobArtifacts, runJobIfClaimable, SESSION_CONFLICT_RETRY_DELAY_SECONDS, type WorkerDeps } from '@/lib/background-jobs/worker';
 import { UPLOAD_JOB_MAX_RETRIES, type BackgroundJobFileRecord } from '@/lib/background-jobs/types';
 import { createUploadSession, ensureUploadSessionsTable } from '@/config/uploadsessiontracker';
 import { FormType, SourceFormat, type FileRow } from '@/config/macros/formdetails';
@@ -1043,6 +1043,185 @@ describe('runJobIfClaimable — integration', () => {
       // No re-staging, and no extra uploadmetrics rows appeared.
       expect(await countFamilyTempRows(batchID)).toBe(0);
       expect(await fetchFamilyMetrics(batchID)).toEqual(familyMetricsBefore);
+    }, 180000);
+
+    /** StemGUID-NULL rows for one family batch ID, with identifying fields. */
+    async function fetchUnresolvedRowsForBatch(subBatchID: string): Promise<Array<{ tag: string; sourceRowIndex: number; description: string }>> {
+      const [rows] = await connection.query<RowDataPacket[]>(
+        `SELECT RawTreeTag, SourceRowIndex, Description FROM coremeasurements
+         WHERE UploadFileID = ? AND CensusID = ? AND UploadBatchID = ? AND StemGUID IS NULL
+         ORDER BY SourceRowIndex`,
+        [FILE1_NAME, censusID, subBatchID]
+      );
+      return rows.map(row => ({ tag: String(row.RawTreeTag), sourceRowIndex: Number(row.SourceRowIndex), description: String(row.Description) }));
+    }
+
+    it('recycled mid-family: the completed sub-batch keeps its proc-recorded failure rows through the retry', async () => {
+      // THE A1 DEFECT: retry cleanup deleted StemGUID-NULL rows for the WHOLE
+      // family, destroying failure rows the proc recorded for already-completed
+      // sub-batches — which the idempotent re-run then skips and never
+      // regenerates. Net silent loss of recorded failures.
+      const PRESERVED_FAILURE_TAG = 'W1PRESERVE';
+      const PRESERVED_FAILURE_INDEX = 424242; // positive = proc-keyed namespace
+      const PRESERVED_FAILURE_REASON = 'Planted proc-recorded failure: must survive family retry cleanup';
+
+      const jobID = await createSingleFileJob();
+      await runJobIfClaimable(jobID, healthyDeps());
+      const batchID = await batchIDForFile(jobID, FILE1_NAME);
+
+      const subBatchIDs = Object.keys(await fetchFamilyMetrics(batchID)).sort();
+      const [firstSubBatch, ...remainingSubBatches] = subBatchIDs;
+
+      // Plant a failure row AS IF bulkingestionprocess recorded it while
+      // completing the first sub-batch (StemGUID NULL, positive proc-style
+      // SourceRowIndex, under the COMPLETED sub-batch's ID).
+      await connection.query(
+        `INSERT INTO coremeasurements
+           (CensusID, StemGUID, MeasurementDate, UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, Description, IsActive)
+         VALUES (?, NULL, ?, ?, ?, ?, ?, ?, 1)`,
+        [censusID, MEASUREMENT_DATE, FILE1_NAME, firstSubBatch, PRESERVED_FAILURE_TAG, PRESERVED_FAILURE_INDEX, PRESERVED_FAILURE_REASON]
+      );
+
+      // Simulate the attempt dying after the first sub-batch: later sub-batch
+      // metrics gone, their ingested rows gone, their rows back in staging.
+      await connection.query(`DELETE FROM uploadmetrics WHERE batchID IN (?)`, [remainingSubBatches]);
+      await connection.query(
+        `DELETE cm FROM coremeasurements cm
+         JOIN stems s ON s.StemGUID = cm.StemGUID
+         JOIN trees t ON t.TreeID = s.TreeID
+         WHERE cm.UploadFileID = ? AND cm.CensusID = ? AND t.TreeTag IN ('W1003', 'W1004', 'W1005')`,
+        [FILE1_NAME, censusID]
+      );
+      await insertStagedTempRow(FILE1_NAME, remainingSubBatches[0], 'W1003', 'Q02', 30.1);
+      await requeueJob(jobID);
+
+      await runJobIfClaimable(jobID, healthyDeps());
+
+      const job = await getBackgroundJob(catalogPool, jobID);
+      const preservedRows = await fetchUnresolvedRowsForBatch(firstSubBatch);
+      console.log(`[a1-preserve] status=${job?.status} preservedRows=${JSON.stringify(preservedRows)}`);
+
+      expect(job!.status).toBe('completed');
+      // The planted failure row survived the retry byte-for-byte — the family
+      // cleanup excluded the completed sub-batch instead of wiping it.
+      const survivor = preservedRows.find(row => row.sourceRowIndex === PRESERVED_FAILURE_INDEX);
+      expect(survivor, `completed sub-batch ${firstSubBatch} lost its proc-recorded failure row`).toBeDefined();
+      expect(survivor!.tag).toBe(PRESERVED_FAILURE_TAG);
+      expect(survivor!.description).toBe(PRESERVED_FAILURE_REASON);
+      // And the resumed sub-batches still ingested to a clean, complete set.
+      expect(await countFamilyTempRows(batchID)).toBe(0);
+      expect(await fetchIngestedTags()).toHaveLength(FILE1_VALID_ROW_COUNT);
+    }, 180000);
+
+    it('assigns sub-batch membership in staging order (deterministic split canary)', async () => {
+      // A2: the split UPDATE now carries ORDER BY id, so sub-batch membership
+      // is pinned to staging order (= file order). Contiguous, ordered
+      // SourceRowIndex ranges per sub-batch are the observable consequence —
+      // an unordered LIMIT that ever returns could interleave them.
+      const jobID = await createSingleFileJob();
+      await runJobIfClaimable(jobID, healthyDeps());
+      const batchID = await batchIDForFile(jobID, FILE1_NAME);
+
+      const [rows] = await connection.query<RowDataPacket[]>(
+        `SELECT UploadBatchID, MIN(SourceRowIndex) AS minIdx, MAX(SourceRowIndex) AS maxIdx, COUNT(*) AS n
+         FROM coremeasurements
+         WHERE UploadFileID = ? AND CensusID = ? AND StemGUID IS NOT NULL
+         GROUP BY UploadBatchID ORDER BY UploadBatchID`,
+        [FILE1_NAME, censusID]
+      );
+      console.log(`[a2-split-order] ${JSON.stringify(rows)}`);
+      expect(rows.length).toBeGreaterThan(1);
+      let previousMax = -Infinity;
+      for (const row of rows) {
+        const minIdx = Number(row.minIdx);
+        const maxIdx = Number(row.maxIdx);
+        expect(maxIdx - minIdx + 1, `sub-batch ${row.UploadBatchID} rows must be contiguous in staging order`).toBe(Number(row.n));
+        expect(minIdx, `sub-batch ${row.UploadBatchID} must start after the previous sub-batch ends`).toBeGreaterThan(previousMax);
+        previousMax = maxIdx;
+      }
+      void batchID;
+    }, 180000);
+
+    it('surfaces exhausted-retry moved rows on the job record instead of finalizing as a clean success', async () => {
+      // A3: a sub-batch that exhausts every attempt moves its rows to
+      // unresolved coremeasurements; the job must NOT read as a clean success.
+      const jobID = await createSingleFileJob();
+
+      // Fail every CALL for the first sub-batch with a plain retryable error so
+      // the loop exhausts all attempts and moves that sub-batch's rows.
+      const FIRST_SUB_SUFFIX = '__sub001';
+      sharedState.onSchemaQuery = (query, params) => {
+        if (query.includes('bulkingestionprocess') && String(params?.[1] ?? '').endsWith(FIRST_SUB_SUFFIX)) {
+          throw new Error('Injected deterministic procedure failure for A3');
+        }
+      };
+      try {
+        await runJobIfClaimable(jobID, healthyDeps());
+      } finally {
+        sharedState.onSchemaQuery = null;
+      }
+
+      const job = await getBackgroundJob(catalogPool, jobID);
+      const jobDetails = await getBackgroundJobWithDetails(catalogPool, jobID);
+      const fileRecord = jobDetails!.files.find(file => file.fileName === FILE1_NAME)!;
+      const [events] = await catalogPool.query<RowDataPacket[]>(
+        `SELECT Message FROM catalog.background_job_events WHERE JobID = ? AND EventType = 'completed' ORDER BY EventID DESC LIMIT 1`,
+        [jobID]
+      );
+      console.log(`[a3-surface] status=${job?.status} jobFailedRows=${job?.failedRows} fileFailedRows=${fileRecord.failedRows} event=${events[0]?.Message}`);
+
+      expect(job!.status).toBe('completed');
+      // The two moved rows of sub001 (SPLIT_THRESHOLD_ROWS) count on the job
+      // and file records, on top of the fixture's parse reject.
+      expect(job!.failedRows).toBe(FILE1_REJECT_ROW_COUNT + SPLIT_THRESHOLD_ROWS);
+      expect(fileRecord.failedRows).toBe(FILE1_REJECT_ROW_COUNT + SPLIT_THRESHOLD_ROWS);
+      expect(String(events[0]?.Message)).toContain('unresolved');
+    }, 180000);
+
+    it('cancel-path cleanup preserves completed sub-batch failure rows and removes abandoned-sub residue', async () => {
+      // A4/A5 shared logic (cleanupCancelledUnclaimedJobArtifacts): a family
+      // that LOOKS completed can hide unresolved rows under sub-batch IDs that
+      // never earned a metric (mid-batch abort residue). Cleanup must remove
+      // exactly those while preserving completed sub-batches' failure rows —
+      // and must not touch a genuinely completed family at all.
+      const PRESERVED_TAG = 'W1KEEPME';
+      const ABANDONED_TAG = 'W1RESIDUE';
+
+      const jobID = await createSingleFileJob();
+      await runJobIfClaimable(jobID, healthyDeps());
+      const batchID = await batchIDForFile(jobID, FILE1_NAME);
+      const subBatchIDs = Object.keys(await fetchFamilyMetrics(batchID)).sort();
+      const [firstSubBatch, secondSubBatch] = subBatchIDs;
+      const jobDetails = await getBackgroundJobWithDetails(catalogPool, jobID);
+
+      // Genuinely completed family: cleanup is a no-op.
+      const rejectIDsBefore = await fetchRejectIDs(FILE1_NAME);
+      await cleanupCancelledUnclaimedJobArtifacts(ConnectionManager.getInstance(), jobDetails!);
+      expect(await fetchRejectIDs(FILE1_NAME), 'completed family must be untouched').toEqual(rejectIDsBefore);
+
+      // Now craft the A5 state: the second sub-batch's metric vanishes (as if
+      // it never completed) and it holds mid-abort unresolved residue, while
+      // the first (still completed) sub-batch holds a proc-recorded failure.
+      await connection.query(`DELETE FROM uploadmetrics WHERE batchID = ?`, [secondSubBatch]);
+      await connection.query(
+        `INSERT INTO coremeasurements
+           (CensusID, StemGUID, MeasurementDate, UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, Description, IsActive)
+         VALUES (?, NULL, ?, ?, ?, ?, 515151, 'proc-recorded failure on completed sub-batch', 1),
+                (?, NULL, ?, ?, ?, ?, 626262, 'mid-abort residue on abandoned sub-batch', 1)`,
+        [censusID, MEASUREMENT_DATE, FILE1_NAME, firstSubBatch, PRESERVED_TAG, censusID, MEASUREMENT_DATE, FILE1_NAME, secondSubBatch, ABANDONED_TAG]
+      );
+
+      await cleanupCancelledUnclaimedJobArtifacts(ConnectionManager.getInstance(), jobDetails!);
+
+      const firstRows = await fetchUnresolvedRowsForBatch(firstSubBatch);
+      const secondRows = await fetchUnresolvedRowsForBatch(secondSubBatch);
+      console.log(`[a4a5-cleanup] first=${JSON.stringify(firstRows)} second=${JSON.stringify(secondRows)}`);
+
+      expect(
+        firstRows.some(row => row.tag === PRESERVED_TAG),
+        'completed sub-batch failure row must survive cancel cleanup'
+      ).toBe(true);
+      expect(secondRows, 'abandoned sub-batch residue must be removed').toHaveLength(0);
     }, 180000);
   });
 });


### PR DESCRIPTION
## Summary

Implements WS-A of the PR-review remediation (the CRITICAL findings from the retrospective review of #381–#387). The Harvard acceptance's recycle test passed only because the file produced zero failure rows — with any real failures, a mid-family recycle silently destroyed data:

- **Family-granular cleanup destroyed completed sub-batches' failure rows.** The worker's retry cleanup deleted StemGUID-NULL rows for the entire batch family, but `bulkingestionprocess` completes per sub-batch: rows the proc recorded as failures under a completed sub-batch were deleted, and the idempotent re-run (which skips completed sub-batches) never regenerated them. The red-first test also flushed out **two more copies of the same defect** the review hadn't found: `ingestBatch`'s setup-time stale-row deletes (same-file and cross-file) excluded only the bare batch ID, wiping the reused family's suffixed rows on every worker retry. Cleanup is now sub-batch aware everywhere: completed members' rows are preserved, non-completed members' rows are cleaned.
- **Split partition was non-deterministic.** Sub-batch membership was assigned with `UPDATE … LIMIT` and no `ORDER BY`; a crash-retry that re-stages and re-splits relied on unspecified InnoDB scan order aligning with the dead attempt's partition. Now `ORDER BY id` pins membership to staging order (= file order).
- **`IngestBatchResult` was discarded — false-success jobs.** A sub-batch that exhausted all 5 attempts and moved 10k rows to unresolved still finalized `completed` with `failedRows: 0`. Moved rows and proc-recorded `failedRecords` now reach the job and file records, and the completion event says "completed with N row(s) preserved as unresolved failures".
- **Cancel paths leaked artifacts.** Cancelling a queued/`waiting_retry` job now cleans the dead attempt's staged rows and rejects (same sub-batch-aware primitive, best-effort from the route); the worker's cancel finalization detects families that *look* completed but hold unresolved residue under sub-batches that never earned a metric, and cleans exactly those.

Four new integration tests in `upload-worker.test.ts` pin all of it, including byte-for-byte survival of a completed sub-batch's proc-recorded failure row through a simulated recycle. Contract tests asserting the old bare-ID SQL shapes updated to require the family-sparing forms.