### PR TITLE
fix(ingestion): harden bounded census-replacement deletes and close their coverage gaps

### DIFF
--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './route';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { insertIngestionFailureRows } from '@/config/measurementerrors';
-import { resetTemporaryMeasurementsSourceFormatColumnCacheForTests, TEMP_MEASUREMENT_INSERT_BATCH_SIZE } from '@/lib/ingestion/temporary-measurements';
+import {
+  CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE,
+  resetTemporaryMeasurementsSourceFormatColumnCacheForTests,
+  TEMP_MEASUREMENT_INSERT_BATCH_SIZE
+} from '@/lib/ingestion/temporary-measurements';
 import { SourceFormat } from '@/config/macros/formdetails';
 import { headerSignature } from '@/lib/column-mapping/mapping';
 import type { ColumnMapping } from '@/lib/column-mapping/types';
@@ -13,6 +17,14 @@ import {
   QUADRAT_OVERLAP_ACKNOWLEDGMENT_STATEMENT,
   validateQuadratCollectionDetailed
 } from '@/lib/provisioning/quadrat-collection-validation';
+
+/**
+ * Matches the chunk LIMIT only when it terminates the whole statement — i.e. it
+ * bounds the DELETE itself rather than an inner subquery.
+ */
+function outerLimitPattern(): RegExp {
+  return new RegExp(`LIMIT\\s+${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE}\\s*$`);
+}
 
 const { getCookieMock, authMock, handleUpsertMock } = vi.hoisted(() => ({
   getCookieMock: vi.fn(),
@@ -401,8 +413,11 @@ describe('sqlpacketload measurement scope validation', () => {
     // Both arms NULL-safe: a bare `NOT (col LIKE ?)` yields NULL for the
     // nullable UploadBatchID, which would spare every CTFS-migrated row.
     expect(deleteCmCall).toContain('(UploadBatchID IS NULL OR UploadBatchID NOT LIKE ?');
-    // Bounded so one statement never locks a whole 100k-row census.
-    expect(deleteCmCall).toContain('LIMIT');
+    // Bounded so one statement never runs long enough to be KILLed mid-delete.
+    // Pinned to the END of the statement: a bare toContain('LIMIT') also passes
+    // when the LIMIT sits inside a subquery, where it bounds the wrong thing and
+    // leaves the outer DELETE unbounded.
+    expect(deleteCmCall).toMatch(outerLimitPattern());
     // Census replacement, not filename replacement.
     expect(deleteCmCall).not.toContain('UploadFileID');
     // And never a batch id list sourced from metrics.
@@ -413,8 +428,13 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(deleteValidationErrorsCall).toContain('WHERE cm.CensusID = ?');
     expect(deleteValidationErrorsCall).not.toContain('cm.UploadFileID');
     // Single-table DELETE over a subquery: MySQL rejects LIMIT on a
-    // multi-table DELETE ... JOIN, and this delete must stay bounded too.
-    expect(deleteValidationErrorsCall).toContain('LIMIT');
+    // multi-table DELETE ... JOIN, and this delete must stay bounded too. The
+    // LIMIT has to bound the OUTER delete — inside the IN-subquery it would cap
+    // the victim list instead and the delete itself would stay unbounded.
+    expect(deleteValidationErrorsCall).toMatch(outerLimitPattern());
+    expect(deleteValidationErrorsCall!.indexOf('LIMIT'), 'LIMIT must follow the subquery, not sit inside it').toBeGreaterThan(
+      deleteValidationErrorsCall!.lastIndexOf(')')
+    );
 
     const deleteMetricsCall = executedSql.find((sql: string) => sql.includes('DELETE FROM `forestgeo_testing`.uploadmetrics'));
     expect(deleteMetricsCall).toBeDefined();

--- a/frontend/lib/ingestion/temporary-measurements.test.ts
+++ b/frontend/lib/ingestion/temporary-measurements.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
-import { findDroppedMeasurementCandidates, isUnsignedIntFieldInvalid, MYSQL_UNSIGNED_INT_MAX, parseUnsignedIntField } from './temporary-measurements';
+import {
+  CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE,
+  cleanupPreviousFileUploads,
+  findDroppedMeasurementCandidates,
+  isUnsignedIntFieldInvalid,
+  MYSQL_UNSIGNED_INT_MAX,
+  parseUnsignedIntField
+} from './temporary-measurements';
 import type ConnectionManager from '@/lib/db/connectionmanager';
 import type { FileRow } from '@/config/macros/formdetails';
+
+vi.mock('@/ailogger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
 
 describe('parseUnsignedIntField', () => {
   it('parses positive integers within the MySQL unsigned range', () => {
@@ -95,5 +104,100 @@ describe('isUnsignedIntFieldInvalid', () => {
     expect(isUnsignedIntFieldInvalid(0)).toBe(true);
     expect(isUnsignedIntFieldInvalid(-1)).toBe(true);
     expect(isUnsignedIntFieldInvalid(12.3)).toBe(true);
+  });
+});
+
+describe('cleanupPreviousFileUploads bounded-delete loop control', () => {
+  const TEST_SCHEMA = 'forestgeo_testing';
+  const TEST_FILE_NAME = 'replacement.csv';
+  const TEST_BATCH_ID = 'incoming-batch-0001';
+  const TEST_PLOT_ID = 22;
+  const TEST_CENSUS_ID = 32;
+  const TEST_TRANSACTION_ID = 'tx-test';
+
+  const CM_DELETE_MARKER = 'DELETE FROM `forestgeo_testing`.coremeasurements';
+  const NOTHING_DELETED = { affectedRows: 0 };
+
+  /**
+   * Drives the coremeasurements delete with a scripted sequence of server
+   * results and lets every other statement report an empty window, so each
+   * assertion is about the loop's reaction to ONE result shape.
+   */
+  function makeConnectionManager(coreMeasurementResults: unknown[]) {
+    const remaining = [...coreMeasurementResults];
+    const executeQuery = vi.fn(async (sql: string) => {
+      if (!String(sql).includes(CM_DELETE_MARKER)) return NOTHING_DELETED;
+      if (remaining.length === 0) {
+        throw new Error('bounded delete loop asked for more windows than the test scripted — it did not terminate');
+      }
+      return remaining.shift();
+    });
+    return { connectionManager: { executeQuery } as unknown as ConnectionManager, executeQuery };
+  }
+
+  function runCleanup(connectionManager: ConnectionManager) {
+    return cleanupPreviousFileUploads(connectionManager, TEST_SCHEMA, TEST_FILE_NAME, TEST_BATCH_ID, TEST_PLOT_ID, TEST_CENSUS_ID, TEST_TRANSACTION_ID);
+  }
+
+  function countCoreMeasurementDeletes(executeQuery: ReturnType<typeof vi.fn>): number {
+    return executeQuery.mock.calls.filter(call => String(call[0]).includes(CM_DELETE_MARKER)).length;
+  }
+
+  it('keeps requesting windows while the server keeps filling the limit, then stops on the first short window', async () => {
+    const { connectionManager, executeQuery } = makeConnectionManager([
+      { affectedRows: CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE },
+      { affectedRows: CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE },
+      { affectedRows: CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE - 1 }
+    ]);
+
+    const deleted = await runCleanup(connectionManager);
+
+    expect(deleted, 'returned total must be the sum of every window, not just the last').toBe(
+      CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE * 2 + (CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE - 1)
+    );
+    expect(countCoreMeasurementDeletes(executeQuery)).toBe(3);
+  });
+
+  it('stops after one window when the very first window is short', async () => {
+    const { connectionManager, executeQuery } = makeConnectionManager([{ affectedRows: 1 }]);
+
+    expect(await runCleanup(connectionManager)).toBe(1);
+    expect(countCoreMeasurementDeletes(executeQuery)).toBe(1);
+  });
+
+  it('rejects a missing affectedRows instead of silently reporting an empty census', async () => {
+    // Pre-fix this coerced to 0: the loop exited after one window and the caller
+    // was told the census had been fully replaced when nothing had been read.
+    const { connectionManager } = makeConnectionManager([{}]);
+
+    await expect(runCleanup(connectionManager)).rejects.toThrow(/could not read a row count/i);
+  });
+
+  it('rejects a non-numeric affectedRows instead of looping forever on NaN', async () => {
+    // `Number('many')` is NaN and `NaN < CHUNK_SIZE` is false, so the pre-fix
+    // loop re-issued the same DELETE without end. The scripted mock throws a
+    // distinguishable error if a second window is requested.
+    const { connectionManager } = makeConnectionManager([{ affectedRows: 'many' }]);
+
+    await expect(runCleanup(connectionManager)).rejects.toThrow(/could not read a row count/i);
+  });
+
+  it('rejects a negative affectedRows', async () => {
+    const { connectionManager } = makeConnectionManager([{ affectedRows: -1 }]);
+
+    await expect(runCleanup(connectionManager)).rejects.toThrow(/could not read a row count/i);
+  });
+
+  it('rejects a fractional affectedRows', async () => {
+    const { connectionManager } = makeConnectionManager([{ affectedRows: 1.5 }]);
+
+    await expect(runCleanup(connectionManager)).rejects.toThrow(/could not read a row count/i);
+  });
+
+  it('accepts an exactly-zero window as a legitimate empty result', async () => {
+    const { connectionManager, executeQuery } = makeConnectionManager([{ affectedRows: 0 }]);
+
+    expect(await runCleanup(connectionManager)).toBe(0);
+    expect(countCoreMeasurementDeletes(executeQuery)).toBe(1);
   });
 });

--- a/frontend/lib/ingestion/temporary-measurements.ts
+++ b/frontend/lib/ingestion/temporary-measurements.ts
@@ -241,10 +241,19 @@ export async function cleanupStaleMeasurementBatchesForFile(
 }
 
 /**
- * Rows removed per statement by the census-replacement deletes. A single
- * unbounded DELETE over a large census (Harvard: 106,227 rows) locks the whole
- * row set in one statement and can exceed innodb_lock_wait_timeout, failing the
- * staging chunk that owns the transaction and re-running on every retry.
+ * Rows removed per statement by the census-replacement deletes.
+ *
+ * What chunking DOES bound: per-statement execution time and per-statement
+ * rollback size. A single unbounded DELETE over a large census (Harvard: 116,227
+ * rows) runs as one statement that can outlive the 660s JS-side KILL in
+ * lib/db/primitives.ts, and a KILL mid-statement forces the server to roll back
+ * everything that one statement had removed.
+ *
+ * What chunking does NOT bound: the lock footprint at commit. Every chunk runs
+ * inside the SAME caller-owned transaction, so InnoDB holds every row lock this
+ * loop takes until that transaction commits — the total is identical to the
+ * unbounded DELETE. Do not treat lock contention against a concurrent writer as
+ * mitigated by this constant.
  */
 export const CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE = 5000;
 
@@ -263,6 +272,26 @@ function buildNotIncomingFamilyPredicate(column: string): string {
 }
 
 /**
+ * The loop below terminates ONLY on the row count the server reports, so an
+ * unreadable count is not a value to paper over with a default. Coercing a
+ * missing `affectedRows` to 0 stops the loop after one window and silently
+ * leaves the rest of the census in place; coercing an unparseable one to NaN
+ * makes `deleted < CHUNK_SIZE` permanently false and the loop never ends.
+ * Both are failures the caller must see.
+ */
+function requireAffectedRows(result: unknown, deleteSQL: string): number {
+  const affectedRows = (result as { affectedRows?: unknown })?.affectedRows;
+  const parsed = Number(affectedRows);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `Bounded delete could not read a row count from the server: affectedRows=${JSON.stringify(affectedRows)} ` +
+        `is not a non-negative integer. Statement: ${deleteSQL.replace(/\s+/g, ' ').trim().slice(0, 200)}`
+    );
+  }
+  return parsed;
+}
+
+/**
  * Runs a `DELETE ... LIMIT n` until it stops filling the limit, returning the
  * total rows removed. The statement is re-issued verbatim: each pass deletes a
  * fresh window because the previous window's rows no longer match.
@@ -271,7 +300,7 @@ async function deleteInBoundedChunks(connectionManager: ConnectionManager, delet
   let totalDeleted = 0;
   for (;;) {
     const result = await connectionManager.executeQuery(deleteSQL, params, transactionID);
-    const deleted = Number((result as { affectedRows?: number })?.affectedRows ?? 0);
+    const deleted = requireAffectedRows(result, deleteSQL);
     totalDeleted += deleted;
     if (deleted < CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE) return totalDeleted;
   }

--- a/frontend/tests/integration/clean-reupload-census-replacement.test.ts
+++ b/frontend/tests/integration/clean-reupload-census-replacement.test.ts
@@ -39,13 +39,16 @@ if (!['localhost', '127.0.0.1', '::1'].includes(TEST_DB_HOST)) {
 const sharedState = vi.hoisted(() => ({
   connection: null as import('mysql2/promise').Connection | null,
   activeTransactionID: null as string | null,
-  counter: 0
+  counter: 0,
+  /** Every statement the code under test issued, so chunk-loop iteration counts are observable. */
+  statements: [] as string[]
 }));
 
 vi.mock('@/lib/db/connectionmanager', () => {
   const manager = {
     executeQuery: async (sql: string, params?: unknown[]) => {
       if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      sharedState.statements.push(sql);
       const [rows] = await sharedState.connection.query(sql, params ?? []);
       return rows;
     },
@@ -100,6 +103,21 @@ const ORPHAN_FILE = 'harvard2014b.TXT';
 const LEGACY_MIGRATED_FILE = 'ctfs-migration';
 
 const CONTROL_FILE = 'control.csv';
+
+/** NULL-UploadBatchID legacy rows seeded into each CONTROL census. */
+const CONTROL_NULL_BATCH_ROW_COUNT = 2;
+
+/** NULL-UploadBatchID legacy rows seeded into the TARGET census. */
+const TARGET_NULL_BATCH_ROW_COUNT = 3;
+
+/**
+ * Rows the incoming upload has already written for itself before a re-entrant
+ * cleanup call: some under the bare batch id, some under split children.
+ */
+const INCOMING_OWN_PARKED_ROWS = 2;
+const INCOMING_OWN_SUB_BATCH = `${INCOMING_BATCH}__sub001`;
+const INCOMING_OWN_SUB_BATCH_PARKED_ROWS = 3;
+const INCOMING_OWN_INGESTED_SUB_BATCH = `${INCOMING_BATCH}__sub002`;
 
 describe('CLEAN_REUPLOAD census replacement — integration', () => {
   let connection: Connection;
@@ -287,7 +305,7 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     await seedParkedRows(PRIOR_FILE_DIFFERENT_NAME, PRIOR_BATCH_DIFFERENT_NAME, targetCensusID, 2);
 
     // Legacy CTFS-migrated rows with a NULL UploadBatchID.
-    await seedNullBatchRows(LEGACY_MIGRATED_FILE, targetCensusID, 3);
+    await seedNullBatchRows(LEGACY_MIGRATED_FILE, targetCensusID, TARGET_NULL_BATCH_ROW_COUNT);
 
     // The incoming upload's own metric row — must SURVIVE (it is the new upload).
     await seedMetric(INCOMING_FILE, INCOMING_BATCH, plotID, targetCensusID, 'processing');
@@ -296,10 +314,16 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     await seedMetric(CONTROL_FILE, 'control1-batch', plotID, samePlotOtherCensusID);
     await seedParkedRows(CONTROL_FILE, 'control1-batch', samePlotOtherCensusID, 3);
     await seedParkedRows(CONTROL_FILE, 'control1-orphan__sub001', samePlotOtherCensusID, 2);
+    // NULL-batch legacy rows OUTSIDE the target census. The NULL-safety fix
+    // makes a NULL UploadBatchID "belongs to no incoming family" — which is only
+    // half the contract. The census predicate still has to keep that from
+    // reaching another census's legacy rows.
+    await seedNullBatchRows(LEGACY_MIGRATED_FILE, samePlotOtherCensusID, CONTROL_NULL_BATCH_ROW_COUNT);
 
     // --- CONTROL 2: different plot and census ---
     await seedMetric(CONTROL_FILE, 'control2-batch', otherPlotID, otherPlotCensusID);
     await seedParkedRows(CONTROL_FILE, 'control2-batch', otherPlotCensusID, 3);
+    await seedNullBatchRows(LEGACY_MIGRATED_FILE, otherPlotCensusID, CONTROL_NULL_BATCH_ROW_COUNT);
 
     return { control1: await scopeDigest(samePlotOtherCensusID), control2: await scopeDigest(otherPlotCensusID) };
   }
@@ -321,6 +345,7 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     await connection.query(`DELETE FROM trees`);
     await connection.query(`DELETE FROM uploadmetrics`);
     rowIndexCounter = 0;
+    sharedState.statements.length = 0;
   });
 
   // -------------------------------------------------------------------------
@@ -334,7 +359,7 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     const beforeParked = await countRows(targetCensusID, 'parked');
     const beforeIngested = await countRows(targetCensusID, 'ingested');
     console.log(`[target] before: total=${before} parked=${beforeParked} ingested=${beforeIngested}`);
-    expect(before).toBe(3 + 1 + ORPHAN_SUB_BATCHES.length * 4 + 2 + 3); // 17
+    expect(before).toBe(3 + 1 + ORPHAN_SUB_BATCHES.length * 4 + 2 + TARGET_NULL_BATCH_ROW_COUNT); // 17
 
     await runCleanReupload();
 
@@ -373,7 +398,7 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
       targetCensusID
     ]);
     console.log(`[null-batch] before: ${before[0].count} row(s) with UploadBatchID IS NULL`);
-    expect(Number(before[0].count)).toBe(3);
+    expect(Number(before[0].count)).toBe(TARGET_NULL_BATCH_ROW_COUNT);
 
     await runCleanReupload();
 
@@ -382,6 +407,73 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     ]);
     console.log(`[null-batch] after: ${after[0].count}`);
     expect(Number(after[0].count)).toBe(0);
+  }, 120000);
+
+  /**
+   * The other half of the NULL-batch contract. A NULL UploadBatchID matches no
+   * incoming family, so the family predicate alone would happily delete every
+   * legacy row in the database — only the census/plot scope stops it. Without a
+   * control-census NULL row, a regression that widened the scope would still
+   * pass every assertion above.
+   */
+  it('leaves NULL-UploadBatchID rows in OTHER censuses untouched', async () => {
+    await seedFixture();
+
+    async function countNullBatchRows(censusID: number): Promise<number> {
+      const [rows] = await connection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM coremeasurements WHERE CensusID = ? AND UploadBatchID IS NULL`, [
+        censusID
+      ]);
+      return Number(rows[0].count);
+    }
+
+    expect(await countNullBatchRows(samePlotOtherCensusID)).toBe(CONTROL_NULL_BATCH_ROW_COUNT);
+    expect(await countNullBatchRows(otherPlotCensusID)).toBe(CONTROL_NULL_BATCH_ROW_COUNT);
+
+    await runCleanReupload();
+
+    const survivingSamePlot = await countNullBatchRows(samePlotOtherCensusID);
+    const survivingOtherPlot = await countNullBatchRows(otherPlotCensusID);
+    console.log(`[null-batch controls] samePlotOtherCensus=${survivingSamePlot} otherPlotCensus=${survivingOtherPlot}`);
+    expect(survivingSamePlot).toBe(CONTROL_NULL_BATCH_ROW_COUNT);
+    expect(survivingOtherPlot).toBe(CONTROL_NULL_BATCH_ROW_COUNT);
+    // And the target's own NULL rows are still gone — the scope narrowed, it did not stop working.
+    expect(await countNullBatchRows(targetCensusID)).toBe(0);
+  }, 120000);
+
+  /**
+   * The "spare the incoming family" arm of the delete predicate exists for the
+   * RE-ENTRANT case: this upload already split into `batch__subNNN` and wrote
+   * rows of its own, and cleanup runs again (a chunk retry, a worker recycle).
+   * Deleting those rows would destroy the in-flight upload's own work. Until
+   * this test, the arm was pinned only by textual SQL assertions — no DB row
+   * ever exercised it.
+   */
+  it('spares coremeasurements already written under the INCOMING batch family', async () => {
+    await seedFixture();
+
+    await seedParkedRows(INCOMING_FILE, INCOMING_BATCH, targetCensusID, INCOMING_OWN_PARKED_ROWS);
+    await seedParkedRows(INCOMING_FILE, INCOMING_OWN_SUB_BATCH, targetCensusID, INCOMING_OWN_SUB_BATCH_PARKED_ROWS);
+    const incomingIngestedID = await seedIngestedRow(INCOMING_FILE, INCOMING_OWN_INGESTED_SUB_BATCH, targetCensusID, plotID, 'INCOMING-INGESTED');
+    await seedErrorLink(incomingIngestedID);
+
+    const expectedSurvivors = INCOMING_OWN_PARKED_ROWS + INCOMING_OWN_SUB_BATCH_PARKED_ROWS + 1;
+
+    await runCleanReupload();
+
+    const [survivors] = await connection.query<RowDataPacket[]>(
+      `SELECT UploadBatchID, COUNT(*) AS count FROM coremeasurements WHERE CensusID = ? GROUP BY UploadBatchID ORDER BY UploadBatchID`,
+      [targetCensusID]
+    );
+    console.log(`[incoming-family] survivors: ${JSON.stringify(survivors)}`);
+
+    expect(survivors.map(row => [String(row.UploadBatchID), Number(row.count)])).toEqual([
+      [INCOMING_BATCH, INCOMING_OWN_PARKED_ROWS],
+      [INCOMING_OWN_SUB_BATCH, INCOMING_OWN_SUB_BATCH_PARKED_ROWS],
+      [INCOMING_OWN_INGESTED_SUB_BATCH, 1]
+    ]);
+    expect(await countRows(targetCensusID, 'all')).toBe(expectedSurvivors);
+    // The incoming row's error link rides along with the row it belongs to.
+    expect(await errorLinkCount(targetCensusID)).toBe(1);
   }, 120000);
 
   /**
@@ -409,6 +501,56 @@ describe('CLEAN_REUPLOAD census replacement — integration', () => {
     const surviving = await countRows(targetCensusID, 'all');
     console.log(`[chunked-delete] seeded=${overOneChunk} chunk=${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE} surviving=${surviving}`);
     expect(surviving).toBe(0);
+  }, 180000);
+
+  /**
+   * The coremeasurements delete and the error-link delete are different SQL
+   * shapes: the latter is a single-table DELETE over an IN-subquery, and its
+   * LIMIT bounds the outer delete while the subquery re-evaluates every pass.
+   * Only exercising the coremeasurements arm past one window leaves that shape's
+   * loop — the one that could re-select the same victims forever, or stop early —
+   * entirely unproven.
+   */
+  it('drives the error-link delete past one window too (the IN-subquery arm)', async () => {
+    const overOneChunk = CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE + 137;
+    await connection.query(`SET SESSION cte_max_recursion_depth = ?`, [overOneChunk + 1]);
+    await connection.query(
+      `INSERT INTO coremeasurements (CensusID, StemGUID, IsValidated, MeasurementDate, MeasuredDBH, MeasuredHOM,
+         UploadFileID, UploadBatchID, RawTreeTag, SourceRowIndex, IsActive)
+       WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < ?)
+       SELECT ?, NULL, FALSE, '2024-03-15', 1.0, 1.0, ?, 'bulk-prior-batch', CONCAT('E', n), n, 1 FROM seq`,
+      [overOneChunk, targetCensusID, PRIOR_FILE_WITH_METRICS]
+    );
+
+    await connection.query(
+      `INSERT INTO measurement_errors (ErrorSource, ErrorCode, ErrorMessage) VALUES ('ingestion','SQL_EXCEPTION','Ingestion SQL exception')
+       ON DUPLICATE KEY UPDATE ErrorID = LAST_INSERT_ID(ErrorID)`
+    );
+    const [errRows] = await connection.query<RowDataPacket[]>(
+      `SELECT ErrorID FROM measurement_errors WHERE ErrorSource='ingestion' AND ErrorCode='SQL_EXCEPTION' LIMIT 1`
+    );
+    await connection.query(
+      `INSERT INTO measurement_error_log (MeasurementID, ErrorID, IsResolved, CreatedAt)
+       SELECT CoreMeasurementID, ?, FALSE, NOW() FROM coremeasurements WHERE CensusID = ?`,
+      [errRows[0].ErrorID, targetCensusID]
+    );
+    expect(await errorLinkCount(targetCensusID)).toBe(overOneChunk);
+
+    sharedState.statements.length = 0;
+    await runCleanReupload();
+
+    const errorLinkDeleteStatements = sharedState.statements.filter(sql => /DELETE\s+FROM\s+`[^`]+`\.measurement_error_log/.test(sql));
+    // 5137 links = one full 5000-row window plus a short 137-row window that
+    // ends the loop. A single statement would mean the loop gave up early and
+    // left 137 links behind; more than two would mean it re-selected victims.
+    const expectedWindows = Math.ceil(overOneChunk / CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE);
+    console.log(
+      `[error-link chunking] seeded=${overOneChunk} chunk=${CENSUS_REPLACEMENT_DELETE_CHUNK_SIZE} ` +
+        `statements=${errorLinkDeleteStatements.length} expected=${expectedWindows}`
+    );
+    expect(errorLinkDeleteStatements.length).toBe(expectedWindows);
+    expect(await errorLinkCount(targetCensusID)).toBe(0);
+    expect(await countRows(targetCensusID, 'all')).toBe(0);
   }, 180000);
 
   it('removes prior rows under a DIFFERENT UploadFileID (census replacement, not filename replacement)', async () => {


### PR DESCRIPTION
## Summary

WS-F of the PR-review remediation (findings from the retrospective review of #381–#387).

- **`deleteInBoundedChunks` trusted whatever the server reported as `affectedRows`.** The loop terminates on that number alone, so a missing count coerced to `0` and stopped after one window — telling the caller a census had been fully replaced when only the first 5,000 rows were read — and an unparseable one coerced to `NaN`, making `deleted < CHUNK_SIZE` permanently false so the same `DELETE` re-issued forever. The count must now be a non-negative integer or the statement fails with the offending value in the message.
- **Corrected the chunking rationale.** Every chunk runs inside the caller's transaction, so InnoDB holds every lock the loop takes until commit — the footprint is identical to the unbounded `DELETE`. Chunking bounds per-statement execution time (against the 660s KILL) and statement rollback size, not lock contention. The Harvard figure was 116,227 rows, not 106,227.
- **Three arms of `cleanupPreviousFileUploads` had no row-level coverage.** The "spare the incoming batch family" predicate — the re-entrant case it exists for — was pinned only by textual SQL assertions, so dropping it would have deleted the in-flight upload's own rows with every test green. NULL-`UploadBatchID` rows were seeded into the target census only, leaving the census scope (the sole thing stopping a NULL-batch delete from reaching every legacy row in the database) untested. And the chunk loop was exercised only through the `coremeasurements` arm, never the error-link delete's different shape — a single-table `DELETE` over an `IN`-subquery that re-evaluates each pass.
- **Pinned the chunk `LIMIT` to the end of the statement** in the route contract test. `toContain('LIMIT')` passes just as happily when the `LIMIT` sits inside the subquery, where it caps the victim list and leaves the `DELETE` unbounded.