### PR TITLE
fix(async-upload): fail-closed rollout gate, unblock the sweeper, and honour cancellation mid-file

### DIFF
--- a/frontend/lib/background-jobs/feature-gate.test.ts
+++ b/frontend/lib/background-jobs/feature-gate.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The async-upload rollout gate decides who can reach a worker that stages,
+ * ingests, and replaces census data. An empty user/schema allow-list used to
+ * mean "everyone, everywhere" the moment ASYNC_UPLOAD_ENABLED flipped to true —
+ * so a misconfiguration and a full rollout were indistinguishable states, while
+ * the stated rollout was "one schema, one user".
+ *
+ * These tests pin the asymmetry that fixes it: users and schemas fail CLOSED
+ * (empty = nobody, `*` opens up on purpose), forms stay fail-OPEN because that
+ * list picks WHICH forms may go async for an already-permitted operator rather
+ * than bounding the blast radius.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isAsyncUploadEnabledFor } from './feature-gate';
+
+/** The only value that opens a fail-closed list. */
+const WILDCARD = '*';
+
+const ENV_KEYS = ['ASYNC_UPLOAD_ENABLED', 'ASYNC_UPLOAD_ALLOWED_USERS', 'ASYNC_UPLOAD_ALLOWED_SCHEMAS', 'ASYNC_UPLOAD_ALLOWED_FORMS'] as const;
+
+const ROLLOUT_SCHEMA = 'forestgeo_harvard';
+const ROLLOUT_USER = 'rollout.user@forestgeo.test';
+const OTHER_SCHEMA = 'forestgeo_serc';
+const OTHER_USER = 'someone.else@forestgeo.test';
+const FORM_TYPE = 'measurements';
+const OTHER_FORM_TYPE = 'species';
+
+const originalEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+/** The single-schema, single-user rollout the feature is supposed to be in. */
+function configureRollout(overrides: Partial<Record<(typeof ENV_KEYS)[number], string>> = {}) {
+  const config = {
+    ASYNC_UPLOAD_ENABLED: 'true',
+    ASYNC_UPLOAD_ALLOWED_USERS: ROLLOUT_USER,
+    ASYNC_UPLOAD_ALLOWED_SCHEMAS: ROLLOUT_SCHEMA,
+    ...overrides
+  } as Record<string, string>;
+  for (const key of ENV_KEYS) {
+    if (key in config) process.env[key] = config[key];
+    else delete process.env[key];
+  }
+}
+
+function askFor(overrides: { schema?: string | null; formType?: string | null; userIds?: string[] } = {}) {
+  return isAsyncUploadEnabledFor({ schema: ROLLOUT_SCHEMA, formType: FORM_TYPE, userIds: [ROLLOUT_USER], ...overrides });
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) originalEnv[key] = process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+describe('isAsyncUploadEnabledFor', () => {
+  it('is off entirely unless ASYNC_UPLOAD_ENABLED is exactly "true"', () => {
+    configureRollout({ ASYNC_UPLOAD_ENABLED: 'false' });
+    expect(askFor()).toBe(false);
+
+    configureRollout({ ASYNC_UPLOAD_ENABLED: 'TRUE' });
+    expect(askFor(), 'the flag is compared literally; only lowercase "true" enables').toBe(false);
+  });
+
+  it('allows the configured rollout user on the configured rollout schema', () => {
+    configureRollout();
+    expect(askFor()).toBe(true);
+  });
+
+  describe('user allow-list fails closed', () => {
+    it('denies everyone when the list is unset', () => {
+      configureRollout();
+      delete process.env.ASYNC_UPLOAD_ALLOWED_USERS;
+      expect(askFor()).toBe(false);
+    });
+
+    it('denies everyone when the list is empty or only separators', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_USERS: '' });
+      expect(askFor()).toBe(false);
+
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_USERS: ' , , ' });
+      expect(askFor()).toBe(false);
+    });
+
+    it('denies a user who is not on the list', () => {
+      configureRollout();
+      expect(askFor({ userIds: [OTHER_USER] })).toBe(false);
+    });
+
+    it('denies a request that carries no user at all', () => {
+      configureRollout();
+      expect(askFor({ userIds: [] })).toBe(false);
+      expect(askFor({ userIds: undefined })).toBe(false);
+    });
+
+    it('opens up only on an explicit wildcard', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_USERS: WILDCARD });
+      expect(askFor({ userIds: [OTHER_USER] })).toBe(true);
+    });
+
+    it('matches case-insensitively and ignores surrounding whitespace', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_USERS: `  ${ROLLOUT_USER.toUpperCase()}  , ${OTHER_USER}` });
+      expect(askFor({ userIds: [` ${ROLLOUT_USER} `] })).toBe(true);
+    });
+
+    it('allows a request whose ANY identity is listed', () => {
+      configureRollout();
+      expect(askFor({ userIds: [OTHER_USER, ROLLOUT_USER] })).toBe(true);
+    });
+  });
+
+  describe('schema allow-list fails closed', () => {
+    it('denies every schema when the list is unset or empty', () => {
+      configureRollout();
+      delete process.env.ASYNC_UPLOAD_ALLOWED_SCHEMAS;
+      expect(askFor()).toBe(false);
+
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_SCHEMAS: '' });
+      expect(askFor()).toBe(false);
+    });
+
+    it('denies a schema that is not on the list', () => {
+      configureRollout();
+      expect(askFor({ schema: OTHER_SCHEMA })).toBe(false);
+    });
+
+    it('denies a request with no schema', () => {
+      configureRollout();
+      expect(askFor({ schema: null })).toBe(false);
+      expect(askFor({ schema: undefined })).toBe(false);
+    });
+
+    it('opens up only on an explicit wildcard', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_SCHEMAS: WILDCARD });
+      expect(askFor({ schema: OTHER_SCHEMA })).toBe(true);
+    });
+  });
+
+  describe('form allow-list stays fail-open', () => {
+    it('permits any form when the list is unset — it is not the blast-radius control', () => {
+      configureRollout();
+      expect(askFor({ formType: OTHER_FORM_TYPE })).toBe(true);
+      expect(askFor({ formType: null })).toBe(true);
+    });
+
+    it('restricts to the named forms once the list is populated', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_FORMS: FORM_TYPE });
+      expect(askFor({ formType: FORM_TYPE })).toBe(true);
+      expect(askFor({ formType: OTHER_FORM_TYPE })).toBe(false);
+      expect(askFor({ formType: null }), 'a populated list cannot be satisfied by an absent form type').toBe(false);
+    });
+
+    it('honours a wildcard in the form list', () => {
+      configureRollout({ ASYNC_UPLOAD_ALLOWED_FORMS: WILDCARD });
+      expect(askFor({ formType: OTHER_FORM_TYPE })).toBe(true);
+    });
+  });
+
+  it('requires every dimension to pass, not any of them', () => {
+    configureRollout({ ASYNC_UPLOAD_ALLOWED_FORMS: FORM_TYPE });
+    expect(askFor({ schema: OTHER_SCHEMA })).toBe(false);
+    expect(askFor({ userIds: [OTHER_USER] })).toBe(false);
+    expect(askFor({ formType: OTHER_FORM_TYPE })).toBe(false);
+    expect(askFor()).toBe(true);
+  });
+});

--- a/frontend/lib/background-jobs/feature-gate.ts
+++ b/frontend/lib/background-jobs/feature-gate.ts
@@ -1,3 +1,22 @@
+/**
+ * Rollout gate for the async upload worker.
+ *
+ * The allow-lists are NOT symmetric, and deliberately so:
+ *
+ *   - `ASYNC_UPLOAD_ALLOWED_USERS` / `ASYNC_UPLOAD_ALLOWED_SCHEMAS` are
+ *     fail-CLOSED. An unset or empty list means NOBODY / NOWHERE. Opening the
+ *     feature up to everyone requires writing `*` on purpose. The stated rollout
+ *     is "one schema, one user", and an empty list previously meant "everyone,
+ *     everywhere" the moment ASYNC_UPLOAD_ENABLED flipped to true — a
+ *     misconfiguration and a full rollout were the same state.
+ *   - `ASYNC_UPLOAD_ALLOWED_FORMS` is fail-OPEN and stays that way. It selects
+ *     WHICH upload forms may go async once a user/schema is already permitted;
+ *     it is not the blast-radius control. Making it fail-closed would silently
+ *     disable the feature for a correctly-allow-listed operator.
+ */
+
+const WILDCARD = '*';
+
 function parseAllowList(raw: string | undefined): string[] {
   return (raw ?? '')
     .split(',')
@@ -5,20 +24,36 @@ function parseAllowList(raw: string | undefined): string[] {
     .filter(Boolean);
 }
 
-function allows(raw: string | undefined, value: string | undefined | null): boolean {
+function matches(entries: string[], value: string | undefined | null): boolean {
+  if (entries.includes(WILDCARD)) return true;
+  if (!value) return false;
+  return entries.includes(value.trim().toLowerCase());
+}
+
+/** Empty list = nobody. Only an explicit `*` opens it up. */
+function allowsWhenListed(raw: string | undefined, value: string | undefined | null): boolean {
+  const entries = parseAllowList(raw);
+  if (entries.length === 0) return false;
+  return matches(entries, value);
+}
+
+/** Empty list = no restriction on this dimension. */
+function allowsUnlessRestricted(raw: string | undefined, value: string | undefined | null): boolean {
   const entries = parseAllowList(raw);
   if (entries.length === 0) return true;
-  if (!value) return false;
-  const normalized = value.toLowerCase();
-  return entries.includes('*') || entries.includes(normalized);
+  return matches(entries, value);
 }
 
 export function isAsyncUploadEnabledFor({ schema, formType, userIds }: { schema?: string | null; formType?: string | null; userIds?: string[] }): boolean {
   if (process.env.ASYNC_UPLOAD_ENABLED !== 'true') return false;
 
-  const userAllowed = parseAllowList(process.env.ASYNC_UPLOAD_ALLOWED_USERS);
+  const allowedUsers = parseAllowList(process.env.ASYNC_UPLOAD_ALLOWED_USERS);
   const matchesUser =
-    userAllowed.length === 0 || userAllowed.includes('*') || (userIds ?? []).some(userID => userAllowed.includes(userID.trim().toLowerCase()));
+    allowedUsers.length > 0 && (allowedUsers.includes(WILDCARD) || (userIds ?? []).some(userID => allowedUsers.includes(userID.trim().toLowerCase())));
 
-  return allows(process.env.ASYNC_UPLOAD_ALLOWED_SCHEMAS, schema) && allows(process.env.ASYNC_UPLOAD_ALLOWED_FORMS, formType) && matchesUser;
+  return (
+    allowsWhenListed(process.env.ASYNC_UPLOAD_ALLOWED_SCHEMAS, schema) &&
+    allowsUnlessRestricted(process.env.ASYNC_UPLOAD_ALLOWED_FORMS, formType) &&
+    matchesUser
+  );
 }

--- a/frontend/lib/background-jobs/sweeper.ts
+++ b/frontend/lib/background-jobs/sweeper.ts
@@ -26,8 +26,22 @@ import { runJobIfClaimable, STALE_LEASE_THRESHOLD_MS } from './worker';
 /** Interval between sweeper passes. */
 export const SWEEP_INTERVAL_MS = 60_000;
 
-/** Maximum number of runnable jobs dispatched per pass. */
+/** Maximum number of runnable jobs a single pass will look at. */
 export const SWEEP_DISPATCH_LIMIT = 5;
+
+/**
+ * Hard ceiling on jobs EXECUTING concurrently in this process.
+ *
+ * A pass no longer waits for the jobs it hands off, so without a cap each tick
+ * would launch up to SWEEP_DISPATCH_LIMIT more of them every minute — unbounded
+ * growth against a 15-connection pool and a 12-transaction cap. Two is
+ * deliberately conservative: it lets a small job proceed alongside a
+ * census-scale one without letting census-scale ingestions pile up.
+ *
+ * A pass hands off only the capacity that is actually free, so raising this is
+ * the single place to widen execution concurrency.
+ */
+export const MAX_CONCURRENT_JOB_EXECUTIONS = 2;
 
 const MS_PER_SECOND = 1_000;
 const STALE_LEASE_THRESHOLD_SECONDS = STALE_LEASE_THRESHOLD_MS / MS_PER_SECOND;
@@ -62,6 +76,27 @@ interface SweeperSentinelValue {
 
 type SweeperGlobal = typeof globalThis & { [SWEEPER_SENTINEL]?: SweeperSentinelValue };
 
+/**
+ * Jobs currently executing, tracked across sweeper passes. Lives on globalThis
+ * for the same reason the interval does: dev-mode HMR re-evaluates this module,
+ * and a per-module set would let the concurrency cap be bypassed by a reload.
+ */
+const ACTIVE_DISPATCHES_SENTINEL = Symbol.for('forestgeo.uploadJobActiveDispatches');
+type DispatchGlobal = typeof globalThis & { [ACTIVE_DISPATCHES_SENTINEL]?: Set<Promise<void>> };
+
+function activeDispatches(): Set<Promise<void>> {
+  const dispatchGlobal = globalThis as DispatchGlobal;
+  if (!dispatchGlobal[ACTIVE_DISPATCHES_SENTINEL]) {
+    dispatchGlobal[ACTIVE_DISPATCHES_SENTINEL] = new Set<Promise<void>>();
+  }
+  return dispatchGlobal[ACTIVE_DISPATCHES_SENTINEL];
+}
+
+/** Jobs this process is currently executing. Exposed for diagnostics and tests. */
+export function activeJobExecutionCount(): number {
+  return activeDispatches().size;
+}
+
 // ---------------------------------------------------------------------------
 // Sweep pass
 // ---------------------------------------------------------------------------
@@ -77,14 +112,32 @@ const defaultSweepDeps: SweepDeps = {
 export interface SweepResult {
   /** Stale running jobs this pass moved to waiting_retry or failed. */
   reclaimed: number[];
-  /** Runnable jobs this pass successfully handed to dispatch. */
+  /**
+   * Runnable jobs this pass STARTED. The pass does not wait for them, so this
+   * says "execution began", not "execution finished" — a job listed here may
+   * still be running when the next pass begins.
+   */
   dispatched: number[];
+  /** Runnable jobs this pass found but could not start: every execution slot was full. */
+  deferredForCapacity: number[];
 }
 
 /**
- * One sweeper pass: reclaim stale leases, then dispatch runnable jobs. The
- * reclaim runs first so a job orphaned by a dead worker becomes runnable and
- * is re-dispatched within the SAME pass.
+ * One sweeper pass: reclaim stale leases, then start runnable jobs. The reclaim
+ * runs first so a job orphaned by a dead worker becomes runnable and is started
+ * within the SAME pass.
+ *
+ * The pass does NOT await the jobs it starts. It used to: `await deps.dispatch`
+ * ran a job to completion inside the pass, so one census-scale ingestion held
+ * the pass open for hours, the in-flight guard skipped every tick behind it, and
+ * stale-lease reclaim for every OTHER orphaned job was deferred for exactly as
+ * long. Reclaim is the sweeper's recovery mechanism, and it was the thing being
+ * starved.
+ *
+ * Decoupling means concurrency has to be bounded explicitly, which is what
+ * MAX_CONCURRENT_JOB_EXECUTIONS and the shared active-dispatch set do: a pass
+ * hands off only the free capacity and always completes its reclaim scan, even
+ * when no capacity is free at all.
  *
  * Per-job errors are logged and skipped; a query failure (e.g. the catalog is
  * unreachable) rejects the whole pass and is handled by the interval wrapper.
@@ -92,6 +145,7 @@ export interface SweepResult {
 export async function sweepOnce(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepResult> {
   const reclaimed: number[] = [];
   const dispatched: number[] = [];
+  const deferredForCapacity: number[] = [];
 
   const staleJobs = await findStaleRunningJobs(catalogPool, STALE_LEASE_THRESHOLD_SECONDS);
   for (const stale of staleJobs) {
@@ -114,19 +168,43 @@ export async function sweepOnce(catalogPool: Pool, deps: SweepDeps = defaultSwee
   }
 
   const runnableJobIDs = await findRunnableJobIDs(catalogPool, SWEEP_DISPATCH_LIMIT);
+  const active = activeDispatches();
+
   for (const jobID of runnableJobIDs) {
-    try {
-      await deps.dispatch(jobID);
-      dispatched.push(jobID);
-    } catch (error) {
-      ailogger.warn('upload.sweeper.dispatch_failed', {
-        jobID,
-        errorMessage: error instanceof Error ? error.message : String(error)
-      });
+    if (active.size >= MAX_CONCURRENT_JOB_EXECUTIONS) {
+      deferredForCapacity.push(jobID);
+      continue;
     }
+
+    // The .finally callback closes over `dispatch`, which is bound by the time
+    // it can run (it is asynchronous), so the set always deletes the exact
+    // promise it stored.
+    const dispatch: Promise<void> = Promise.resolve()
+      .then(() => deps.dispatch(jobID))
+      .catch(error => {
+        ailogger.warn('upload.sweeper.dispatch_failed', {
+          jobID,
+          errorMessage: error instanceof Error ? error.message : String(error)
+        });
+      })
+      .finally(() => {
+        active.delete(dispatch);
+      });
+    active.add(dispatch);
+    dispatched.push(jobID);
   }
 
-  return { reclaimed, dispatched };
+  if (deferredForCapacity.length > 0) {
+    // Never silent: a job waiting on capacity looks identical to a job the
+    // sweeper failed to see.
+    ailogger.info('upload.sweeper.deferred_for_capacity', {
+      deferredJobIDs: deferredForCapacity,
+      activeExecutions: active.size,
+      maxConcurrentExecutions: MAX_CONCURRENT_JOB_EXECUTIONS
+    });
+  }
+
+  return { reclaimed, dispatched, deferredForCapacity };
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +223,12 @@ export type SweepTickOutcome = { status: 'completed'; result: SweepResult } | { 
  * One interval tick: skips when a previous pass hasn't resolved yet (in-flight
  * guard), otherwise runs a sweep pass. Never throws — a failed pass must not
  * kill the interval — so callers read the outcome instead of catching.
+ *
+ * A failure is REPORTED, not logged, here. The two callers need different
+ * severities for the same event (a routine tick failing is a warning; the
+ * startup pass failing means deploy recovery did not happen), and logging both
+ * here and at the caller produced two events for one failure. Each caller emits
+ * exactly one.
  */
 export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepTickOutcome> {
   const sweeperGlobal = globalThis as SweeperGlobal;
@@ -158,9 +242,7 @@ export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultS
     return { status: 'completed', result: await sweepOnce(catalogPool, deps) };
   } catch (error: unknown) {
     // A failed pass must never kill the interval — the next tick retries.
-    const failure = error instanceof Error ? error : new Error(String(error));
-    ailogger.warn('upload.sweeper.pass_failed', { errorMessage: failure.message });
-    return { status: 'failed', error: failure };
+    return { status: 'failed', error: error instanceof Error ? error : new Error(String(error)) };
   } finally {
     const afterSentinel = (globalThis as SweeperGlobal)[SWEEPER_SENTINEL];
     if (afterSentinel) afterSentinel.inFlight = false;
@@ -172,16 +254,20 @@ export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultS
  * no-op (globalThis sentinel). The interval is unref()d so it never keeps the
  * process alive on its own.
  *
- * Within one process, jobs run sequentially: the in-flight guard in
- * runSweepTick ensures concurrent interval ticks (e.g. a long ingestion
- * spanning multiple minute boundaries) do not stack.
+ * Passes never stack: the in-flight guard in runSweepTick skips a tick while a
+ * previous pass is still resolving. Job EXECUTIONS are bounded separately, by
+ * MAX_CONCURRENT_JOB_EXECUTIONS, because a pass no longer waits for them.
  */
 export function startUploadJobSweeper(catalogPool: Pool): void {
   const sweeperGlobal = globalThis as SweeperGlobal;
   if (sweeperGlobal[SWEEPER_SENTINEL]) return;
 
   const interval = setInterval(() => {
-    void runSweepTick(catalogPool);
+    void runSweepTick(catalogPool).then(outcome => {
+      if (outcome.status === 'failed') {
+        ailogger.warn('upload.sweeper.pass_failed', { errorMessage: outcome.error.message });
+      }
+    });
   }, SWEEP_INTERVAL_MS);
   interval.unref?.();
   sweeperGlobal[SWEEPER_SENTINEL] = { interval, inFlight: false, shutdownInstalled: false };
@@ -201,6 +287,14 @@ export function stopUploadJobSweeper(): void {
  * the same globalThis sentinel as the interval, so only one set of listeners is
  * ever registered per process lifetime. An in-flight sweep pass is allowed to
  * finish naturally; the interval is cleared immediately so no new pass starts.
+ *
+ * Jobs still EXECUTING at shutdown are deliberately abandoned rather than
+ * awaited. Awaiting a census-scale ingestion would hold the process open past
+ * any platform shutdown grace period, and abandonment is already the case the
+ * recovery machinery is built for: the job's lease heartbeat stops, the next
+ * process's startup sweep reclaims it as a stale lease, and its batch-family
+ * crash recovery resumes the work. Waiting would buy nothing that reclaim does
+ * not already provide.
  *
  * Must be called AFTER startUploadJobSweeper (so the sentinel exists to host
  * the shutdownInstalled flag). If no sentinel is present, the handlers are

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -788,6 +788,16 @@ async function runMeasurementsPipeline(ctx: WorkerRunContext): Promise<void> {
     // census replacement and the changelog tracking row still happen.
     const chunkCount = Math.max(1, Math.ceil(rawRows.length / chunkRows));
     for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++) {
+      // Cancellation takes effect BETWEEN chunks, not only between files. A
+      // census-scale file stages over ~22 chunks, and probing only at the file
+      // boundary meant a cancel requested at chunk 2 still staged all 22 —
+      // minutes of work the user had already asked to stop, plus the rows to
+      // clean up afterwards. The heartbeat tick refreshes ctx.cancelRequested
+      // in the background, so the first chunk boundary after the request is
+      // enough; assertStillOwned re-reads the catalog to close the gap when the
+      // flag is not set yet.
+      if (chunkIndex > 0) await assertStillOwned(ctx);
+
       const chunk = rawRows.slice(chunkIndex * chunkRows, (chunkIndex + 1) * chunkRows);
 
       // The worker owns one transaction per chunk: begin/commit per chunk,

--- a/frontend/tests/integration/upload-sweeper.test.ts
+++ b/frontend/tests/integration/upload-sweeper.test.ts
@@ -14,9 +14,19 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import mysql, { type Pool } from 'mysql2/promise';
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
 import { createUploadBackgroundJob, getBackgroundJob, getBackgroundJobWithDetails } from '@/lib/background-jobs/repository';
-import { runSweepTick, startUploadJobSweeper, stopUploadJobSweeper, sweepOnce, SWEEP_DISPATCH_LIMIT, type SweepDeps } from '@/lib/background-jobs/sweeper';
+import {
+  activeJobExecutionCount,
+  MAX_CONCURRENT_JOB_EXECUTIONS,
+  runSweepTick,
+  startUploadJobSweeper,
+  stopUploadJobSweeper,
+  sweepOnce,
+  SWEEP_DISPATCH_LIMIT,
+  type SweepDeps
+} from '@/lib/background-jobs/sweeper';
 import type { CreateUploadJobInput } from '@/lib/background-jobs/types';
 import { UPLOAD_JOB_MAX_RETRIES } from '@/lib/background-jobs/types';
+import ailogger from '@/ailogger';
 
 // ---------------------------------------------------------------------------
 // Safety guard — this suite DELETEs from the shared `catalog` schema and must
@@ -60,6 +70,13 @@ const FUTURE_DUE_OFFSET_SECONDS = 3600;
 /** Must match the sentinel key in lib/background-jobs/sweeper.ts. */
 const SWEEPER_SENTINEL = Symbol.for('forestgeo.uploadJobSweeper');
 
+const DISPATCH_DRAIN_TIMEOUT_MS = 5000;
+/** Must match the sweeper pool created in beforeAll. */
+const SWEEPER_POOL_CONNECTION_LIMIT = 5;
+/** Long enough for a tick to reach its first catalog query and park there. */
+const IN_FLIGHT_SETTLE_MS = 50;
+const DISPATCH_DRAIN_POLL_MS = 5;
+
 // ---------------------------------------------------------------------------
 // Pool lifecycle and row cleanup
 // ---------------------------------------------------------------------------
@@ -90,10 +107,24 @@ beforeEach(async () => {
   console.log('[upload-sweeper] catalog rows cleared');
 });
 
-afterEach(() => {
+afterEach(async () => {
   // Never leak a live interval between tests.
   stopUploadJobSweeper();
+  // The active-dispatch set is process-global: a job still "running" here would
+  // consume capacity in the next test and make it fail for the wrong reason.
+  await waitForIdleDispatches();
 });
+
+/** Polls until no job execution is outstanding, or fails loudly. */
+async function waitForIdleDispatches(): Promise<void> {
+  const deadline = Date.now() + DISPATCH_DRAIN_TIMEOUT_MS;
+  while (activeJobExecutionCount() > 0) {
+    if (Date.now() > deadline) {
+      throw new Error(`${activeJobExecutionCount()} job execution(s) still active after ${DISPATCH_DRAIN_TIMEOUT_MS}ms — a test left a dispatch unresolved.`);
+    }
+    await new Promise(resolve => setTimeout(resolve, DISPATCH_DRAIN_POLL_MS));
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -262,7 +293,7 @@ describe('sweepOnce — runnable-job dispatch', () => {
     expect(calls).toContain(jobID);
   });
 
-  it('continues dispatching after a per-job dispatch failure and still resolves', async () => {
+  it('keeps starting jobs after one of them fails, and frees that job’s slot', async () => {
     const failingID = await seedQueuedJob('dispatch-fails.csv');
     const healthyID = await seedQueuedJob('dispatch-succeeds.csv');
     const { deps, calls } = makeDispatchStub([failingID]);
@@ -270,9 +301,130 @@ describe('sweepOnce — runnable-job dispatch', () => {
     const result = await sweepOnce(pool, deps);
     console.log(`[resilience] dispatched=[${result.dispatched.join(', ')}] stub calls=[${calls.join(', ')}]`);
 
-    // The failing job was attempted but is NOT reported as dispatched.
+    // The pass no longer waits for jobs, so `dispatched` means STARTED. Both
+    // started; the failure surfaces asynchronously and must not abort the pass.
     expect(calls).toEqual([failingID, healthyID]);
-    expect(result.dispatched).toEqual([healthyID]);
+    expect(result.dispatched).toEqual([failingID, healthyID]);
+
+    // A failed job must not hold its execution slot forever.
+    await waitForIdleDispatches();
+    expect(activeJobExecutionCount()).toBe(0);
+  });
+});
+
+/**
+ * The head-of-line blocking fix. `await deps.dispatch(jobID)` ran a job to
+ * completion INSIDE the pass, so one census-scale ingestion held the pass open
+ * for hours: the in-flight guard skipped every tick behind it, and stale-lease
+ * reclaim for every OTHER orphaned job was deferred for exactly that long.
+ * Reclaim is the recovery mechanism, and it was the thing being starved.
+ */
+describe('sweepOnce — dispatch is decoupled from job completion', () => {
+  /** A dispatch stub whose jobs only finish when the test says so. */
+  function makeHeldDispatchStub(): { deps: SweepDeps; started: number[]; release: () => void } {
+    const started: number[] = [];
+    const releasers: Array<() => void> = [];
+    const deps: SweepDeps = {
+      dispatch: vi.fn(
+        (jobID: number) =>
+          new Promise<void>(resolve => {
+            started.push(jobID);
+            releasers.push(resolve);
+          })
+      )
+    };
+    return { deps, started, release: () => releasers.splice(0).forEach(resolve => resolve()) };
+  }
+
+  it('returns while the job it started is still running', async () => {
+    await seedQueuedJob('long-running.csv');
+    const { deps, started, release } = makeHeldDispatchStub();
+
+    // Pre-fix this await never resolves until the job does.
+    const result = await sweepOnce(pool, deps);
+    console.log(`[decoupled] pass returned with ${started.length} job(s) still executing`);
+
+    expect(result.dispatched).toHaveLength(1);
+    expect(activeJobExecutionCount()).toBe(1);
+
+    release();
+    await waitForIdleDispatches();
+  });
+
+  it('keeps reclaiming stale leases across later passes while a job is still executing', async () => {
+    await seedQueuedJob('holds-a-slot.csv');
+    const { deps, release } = makeHeldDispatchStub();
+    await sweepOnce(pool, deps);
+    expect(activeJobExecutionCount()).toBe(1);
+
+    // A DIFFERENT job is orphaned while the first is mid-flight. Pre-fix, no
+    // pass could even start until the long job finished, so this sat unreclaimed.
+    const orphanedID = await seedRunningJob('orphaned-meanwhile.csv', STALE_HEARTBEAT_AGE_SECONDS, 0);
+
+    const secondPass = await sweepOnce(pool, deps);
+    console.log(`[decoupled] second pass reclaimed=[${secondPass.reclaimed.join(', ')}] while ${activeJobExecutionCount()} job(s) executing`);
+
+    expect(secondPass.reclaimed).toContain(orphanedID);
+    expect(await getBackgroundJob(pool, orphanedID).then(job => job?.status)).toBe('waiting_retry');
+
+    release();
+    await waitForIdleDispatches();
+  });
+
+  it('never exceeds the concurrency cap, and defers the rest with a reason', async () => {
+    const seededIDs: number[] = [];
+    for (let i = 0; i < MAX_CONCURRENT_JOB_EXECUTIONS + 2; i++) {
+      seededIDs.push(await seedQueuedJob(`capacity-${i}.csv`));
+    }
+    const { deps, started, release } = makeHeldDispatchStub();
+
+    const firstPass = await sweepOnce(pool, deps);
+    console.log(
+      `[capacity] cap=${MAX_CONCURRENT_JOB_EXECUTIONS} started=[${firstPass.dispatched.join(', ')}] deferred=[${firstPass.deferredForCapacity.join(', ')}]`
+    );
+
+    expect(firstPass.dispatched).toHaveLength(MAX_CONCURRENT_JOB_EXECUTIONS);
+    expect(activeJobExecutionCount()).toBe(MAX_CONCURRENT_JOB_EXECUTIONS);
+    expect(firstPass.deferredForCapacity.length).toBeGreaterThan(0);
+    expect(firstPass.dispatched.concat(firstPass.deferredForCapacity)).toEqual(seededIDs.slice(0, SWEEP_DISPATCH_LIMIT));
+
+    // A second pass with every slot still full starts NOTHING new — the whole
+    // point of the cap — but still completes.
+    const secondPass = await sweepOnce(pool, deps);
+    expect(secondPass.dispatched).toHaveLength(0);
+    expect(started).toHaveLength(MAX_CONCURRENT_JOB_EXECUTIONS);
+    expect(activeJobExecutionCount()).toBe(MAX_CONCURRENT_JOB_EXECUTIONS);
+
+    // Slots free up as jobs finish, and the next pass uses exactly that capacity.
+    release();
+    await waitForIdleDispatches();
+    const thirdPass = await sweepOnce(pool, deps);
+    console.log(`[capacity] after drain, third pass started=[${thirdPass.dispatched.join(', ')}]`);
+    expect(thirdPass.dispatched.length).toBeGreaterThan(0);
+    expect(thirdPass.dispatched.length).toBeLessThanOrEqual(MAX_CONCURRENT_JOB_EXECUTIONS);
+
+    release();
+    await waitForIdleDispatches();
+  });
+
+  it('still reclaims stale leases when every execution slot is full', async () => {
+    for (let i = 0; i < MAX_CONCURRENT_JOB_EXECUTIONS; i++) {
+      await seedQueuedJob(`filler-${i}.csv`);
+    }
+    const { deps, release } = makeHeldDispatchStub();
+    await sweepOnce(pool, deps);
+    expect(activeJobExecutionCount()).toBe(MAX_CONCURRENT_JOB_EXECUTIONS);
+
+    const orphanedID = await seedRunningJob('orphan-at-capacity.csv', STALE_HEARTBEAT_AGE_SECONDS, 0);
+
+    const result = await sweepOnce(pool, deps);
+    console.log(`[capacity] at full capacity: reclaimed=[${result.reclaimed.join(', ')}] started=[${result.dispatched.join(', ')}]`);
+
+    expect(result.reclaimed, 'reclaim must not be gated on execution capacity').toContain(orphanedID);
+    expect(result.dispatched).toHaveLength(0);
+
+    release();
+    await waitForIdleDispatches();
   });
 });
 
@@ -318,7 +470,11 @@ describe('startUploadJobSweeper / stopUploadJobSweeper — sentinel lifecycle', 
 // ---------------------------------------------------------------------------
 
 describe('sweepOnce — dispatch limit', () => {
-  it(`dispatches exactly SWEEP_DISPATCH_LIMIT jobs per pass; a second pass picks up the remainder`, async () => {
+  // Two limits, two jobs: SWEEP_DISPATCH_LIMIT bounds how many runnable jobs a
+  // pass LOOKS AT; MAX_CONCURRENT_JOB_EXECUTIONS bounds how many it STARTS.
+  // Before dispatch was decoupled these were the same number by accident,
+  // because a pass ran its jobs to completion one after another.
+  it(`considers at most SWEEP_DISPATCH_LIMIT jobs and starts at most MAX_CONCURRENT_JOB_EXECUTIONS of them`, async () => {
     const totalJobs = SWEEP_DISPATCH_LIMIT + 1;
     const jobIDs: number[] = [];
     for (let i = 0; i < totalJobs; i++) {
@@ -331,11 +487,16 @@ describe('sweepOnce — dispatch limit', () => {
     const result1 = await sweepOnce(pool, deps1);
     console.log(`[dispatch-limit] pass 1: dispatched=[${result1.dispatched.join(', ')}] stub calls=[${calls1.join(', ')}]`);
 
-    expect(result1.dispatched).toHaveLength(SWEEP_DISPATCH_LIMIT);
-    // Lowest JobIDs dispatched first (ORDER BY JobID).
-    expect(result1.dispatched).toEqual(jobIDs.slice(0, SWEEP_DISPATCH_LIMIT));
-    // The job beyond the limit was not touched.
+    // The pass looked at SWEEP_DISPATCH_LIMIT jobs — started what capacity
+    // allowed, deferred the rest — and never reached past the query limit.
+    expect(result1.dispatched.concat(result1.deferredForCapacity)).toEqual(jobIDs.slice(0, SWEEP_DISPATCH_LIMIT));
+    expect(result1.dispatched).toHaveLength(MAX_CONCURRENT_JOB_EXECUTIONS);
+    // The job beyond the query limit was not even considered.
     expect(result1.dispatched).not.toContain(remainderID);
+    expect(result1.deferredForCapacity).not.toContain(remainderID);
+
+    // The started jobs finish, freeing their slots for the next pass.
+    await waitForIdleDispatches();
 
     // Advance the first SWEEP_DISPATCH_LIMIT jobs out of 'queued' so the
     // second pass sees only the remainder. The stub never mutates DB status, so
@@ -351,6 +512,7 @@ describe('sweepOnce — dispatch limit', () => {
     // Only the remainder is queued now.
     expect(result2.dispatched).toEqual([remainderID]);
     expect(calls2).toEqual([remainderID]);
+    await waitForIdleDispatches();
   });
 });
 
@@ -360,70 +522,50 @@ describe('sweepOnce — dispatch limit', () => {
 
 describe('runSweepTick — in-flight guard', () => {
   it('skips a concurrent tick while the first pass is still awaiting', async () => {
-    // Use a deferred dispatch so the first tick stays in-flight while the
-    // second tick is invoked.
-    let resolveFirstDispatch!: () => void;
-    const firstDispatchBlocked = new Promise<void>(resolve => {
-      resolveFirstDispatch = resolve;
-    });
-
-    const dispatchCalls: number[] = [];
-    const blockingDeps: SweepDeps = {
-      dispatch: vi.fn(async (jobID: number) => {
-        dispatchCalls.push(jobID);
-        await firstDispatchBlocked;
-      })
-    };
-
+    // The guard now protects against a slow PASS, not a slow job: sweepOnce no
+    // longer waits for the jobs it starts, so a blocked dispatch would not keep
+    // a tick in flight. What can still hold a pass open is its own catalog
+    // queries, so this saturates the sweeper's pool and lets the first tick
+    // block acquiring a connection — the real shape of a slow pass.
     const jobID = await seedQueuedJob('in-flight-guard.csv');
     console.log(`[in-flight] seeded jobID=${jobID}`);
+
+    const heldConnections = [];
+    for (let i = 0; i < SWEEPER_POOL_CONNECTION_LIMIT; i++) {
+      heldConnections.push(await pool.getConnection());
+    }
+    console.log(`[in-flight] holding all ${heldConnections.length} pooled connections`);
 
     // Start the sweeper so the sentinel exists and runSweepTick can read inFlight.
     startUploadJobSweeper(pool);
     const sweeperGlobal = globalThis as SweeperGlobal;
 
-    // Kick off tick 1 — does NOT await yet; it sets inFlight=true and then
-    // waits inside blockingDeps.dispatch.
-    const tick1Promise = runSweepTick(pool, blockingDeps);
+    const { deps: blockedDeps, calls: blockedCalls } = makeDispatchStub();
+    // Tick 1 sets inFlight=true, then stalls on its first catalog query.
+    const tick1Promise = runSweepTick(pool, blockedDeps);
+    await new Promise<void>(resolve => setTimeout(resolve, IN_FLIGHT_SETTLE_MS));
 
-    // Yield to let tick 1 reach its first await (the sweepOnce DB queries).
-    // A short real delay is unavoidable here — the alternative is to instrument
-    // sweepOnce, which adds production complexity for a test concern.
-    await new Promise<void>(resolve => setTimeout(resolve, 50));
-
-    // At this point inFlight should be true because tick 1 hasn't resolved yet.
     const inFlightDuringFirstTick = sweeperGlobal[SWEEPER_SENTINEL]?.inFlight ?? false;
     console.log(`[in-flight] inFlight during tick 1: ${inFlightDuringFirstTick}`);
+    expect(inFlightDuringFirstTick).toBe(true);
 
-    // Tick 2 should be skipped because inFlight=true.
-    const skippingDeps: SweepDeps = {
-      dispatch: vi.fn(async (jobID: number) => {
-        dispatchCalls.push(jobID);
-      })
-    };
+    const { deps: skippingDeps } = makeDispatchStub();
     const skippedOutcome = await runSweepTick(pool, skippingDeps);
-    console.log(`[in-flight] after tick 2: outcome=${skippedOutcome.status} dispatchCalls=[${dispatchCalls.join(', ')}]`);
+    console.log(`[in-flight] tick 2 outcome=${skippedOutcome.status}`);
 
-    // tick 2 must NOT have dispatched anything — the skip guard fired.
     expect(skippingDeps.dispatch).not.toHaveBeenCalled();
     // A skip and a failure are different events: the startup caller escalates
     // one and not the other, so they must be distinguishable.
     expect(skippedOutcome).toEqual({ status: 'skipped_in_flight' });
 
-    // Unblock tick 1 and let it finish.
-    resolveFirstDispatch();
+    // Release the pool and let tick 1 finish.
+    heldConnections.forEach(connection => connection.release());
     await tick1Promise;
-    console.log(`[in-flight] after tick 1 resolves: inFlight=${sweeperGlobal[SWEEPER_SENTINEL]?.inFlight}`);
+    console.log(`[in-flight] tick 1 done: calls=[${blockedCalls.join(', ')}] inFlight=${sweeperGlobal[SWEEPER_SENTINEL]?.inFlight}`);
 
-    // inFlight resets to false after the pass completes.
     expect(sweeperGlobal[SWEEPER_SENTINEL]?.inFlight).toBe(false);
-
-    // A third tick now runs freely.
-    const { deps: deps3, calls: calls3 } = makeDispatchStub();
-    const freeOutcome = await runSweepTick(pool, deps3);
-    console.log(`[in-flight] tick 3 (free): outcome=${freeOutcome.status} calls=[${calls3.join(', ')}]`);
-    expect(deps3.dispatch).toHaveBeenCalled();
-    expect(freeOutcome.status).toBe('completed');
+    expect(blockedCalls).toContain(jobID);
+    await waitForIdleDispatches();
   });
 });
 
@@ -455,5 +597,36 @@ describe('runSweepTick — failure reporting', () => {
 
     expect(outcome.status).toBe('failed');
     expect(outcome.status === 'failed' && outcome.error.message).toBe(failure.message);
+  });
+
+  it('logs nothing itself, so one failed pass produces exactly one event', async () => {
+    // A failed startup sweep used to emit BOTH upload.sweeper.pass_failed (warn,
+    // from here) and upload.sweeper.startup_failed (error, from
+    // instrumentation-node) — two events, one failure, two different severities
+    // for the same thing. runSweepTick now reports and lets each caller emit its
+    // own single canonical event: the interval warns, the startup path errors.
+    const failure = new Error('catalog unreachable');
+    const deadPool = {
+      query: async () => {
+        throw failure;
+      },
+      execute: async () => {
+        throw failure;
+      }
+    } as unknown as Pool;
+    const warnSpy = vi.spyOn(ailogger, 'warn');
+    const errorSpy = vi.spyOn(ailogger, 'error');
+
+    try {
+      const outcome = await runSweepTick(deadPool, makeDispatchStub().deps);
+      expect(outcome.status).toBe('failed');
+
+      const failureEvents = [...warnSpy.mock.calls, ...errorSpy.mock.calls].filter(([event]) => typeof event === 'string' && event.includes('sweeper'));
+      console.log(`[single-event] sweeper events emitted by runSweepTick: ${JSON.stringify(failureEvents.map(([event]) => event))}`);
+      expect(failureEvents).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/frontend/tests/integration/upload-worker.test.ts
+++ b/frontend/tests/integration/upload-worker.test.ts
@@ -198,6 +198,10 @@ const MEASUREMENT_DATE = '2024-03-15';
 
 // File 1: 5 valid rows + 1 parse reject (missing required quadrat).
 const FILE1_VALID_ROW_COUNT = 5;
+/** One row per staging chunk, so a single fixture file spans several chunk boundaries. */
+const CANCEL_PROBE_CHUNK_ROWS = 1;
+/** Matches the bulk staging INSERT, not the many other temporarymeasurements statements. */
+const TEMPORARY_MEASUREMENTS_INSERT = /INSERT\s+(?:IGNORE\s+)?INTO\s+`?\w*`?\.?`?temporarymeasurements`?\s*\(/i;
 const FILE1_REJECT_ROW_COUNT = 1;
 const FILE1_CSV = [
   CSV_HEADER,
@@ -605,6 +609,54 @@ describe('runJobIfClaimable — integration', () => {
     const sessionStates = await fetchWorkerSessionStates(jobID);
     console.log(`[cancel] worker session states: ${JSON.stringify(sessionStates)}`);
     expect(sessionStates).toEqual(['failed']);
+  }, 180000);
+
+  /**
+   * Cancellation has to take effect BETWEEN CHUNKS, not only between files.
+   * A census-scale file stages over ~22 chunks; probing only at the file
+   * boundary meant a cancel requested during chunk 2 still staged all 22 —
+   * minutes of work the user had already asked to stop, and rows that then had
+   * to be cleaned up.
+   */
+  it('stops staging at the next chunk boundary when cancellation arrives mid-file', async () => {
+    const originalChunkRows = process.env.BACKGROUND_UPLOAD_CHUNK_ROWS;
+    // One row per chunk, so FILE1's rows span several chunk boundaries.
+    process.env.BACKGROUND_UPLOAD_CHUNK_ROWS = String(CANCEL_PROBE_CHUNK_ROWS);
+
+    const jobID = await createTwoFileJob();
+    let stagingInserts = 0;
+
+    sharedState.onSchemaQuery = async (query: string) => {
+      if (!TEMPORARY_MEASUREMENTS_INSERT.test(query)) return;
+      stagingInserts += 1;
+      if (stagingInserts === 1) {
+        // The user cancels while chunk 1 is still being written.
+        await catalogPool.query(`UPDATE catalog.background_jobs SET Status = 'cancel_requested' WHERE JobID = ? AND Status = 'running'`, [jobID]);
+        console.log('[cancel-mid-file] cancel_requested set during the first staging chunk');
+      }
+    };
+
+    try {
+      await runJobIfClaimable(jobID, healthyDeps());
+    } finally {
+      sharedState.onSchemaQuery = null;
+      if (originalChunkRows === undefined) delete process.env.BACKGROUND_UPLOAD_CHUNK_ROWS;
+      else process.env.BACKGROUND_UPLOAD_CHUNK_ROWS = originalChunkRows;
+    }
+
+    const job = await getBackgroundJob(catalogPool, jobID);
+    console.log(`[cancel-mid-file] status=${job?.status} stagingInserts=${stagingInserts} (file has ${FILE1_VALID_ROW_COUNT + FILE1_REJECT_ROW_COUNT} rows)`);
+
+    expect(job!.status).toBe('cancelled');
+    // The decisive assertion: staging stopped at the first chunk boundary
+    // instead of running the file out. Without the between-chunk probe this is
+    // one insert per row.
+    expect(stagingInserts, 'the chunk after the cancellation must never be staged').toBe(1);
+
+    // Nothing is left behind, and file 2 was never started.
+    expect(await countTempRows()).toBe(0);
+    expect(await fetchIngestedIDs(FILE1_NAME)).toHaveLength(0);
+    expect(await fetchIngestedIDs(FILE2_NAME)).toHaveLength(0);
   }, 180000);
 
   it('cancel during a retry attempt also cleans prior-attempt batches the attempt never reached', async () => {


### PR DESCRIPTION
## Summary

WS-E of the PR-review remediation (findings from the retrospective review of #381).

- **The rollout gate failed open.** An unset or empty `ASYNC_UPLOAD_ALLOWED_USERS` / `ASYNC_UPLOAD_ALLOWED_SCHEMAS` meant *everyone, everywhere* the moment `ASYNC_UPLOAD_ENABLED` flipped to `true` — so a misconfiguration and a full rollout were indistinguishable states, while the stated rollout is "one schema, one user". Both now deny by default and require an explicit `*` to open up. `ASYNC_UPLOAD_ALLOWED_FORMS` deliberately stays fail-open: it picks *which* forms may go async for an already-permitted operator, so making it fail-closed would silently disable the feature for a correctly allow-listed user.
- **One long job blocked every sweeper pass.** `sweepOnce` awaited `deps.dispatch`, running a job to completion *inside* the pass. A census-scale ingestion held the pass open for hours, the in-flight guard skipped every tick behind it, and stale-lease reclaim for every *other* orphaned job was deferred for exactly that long — starving the sweeper's own recovery mechanism. A pass now starts jobs and returns, with concurrency bounded explicitly rather than by the accident of serial execution: `MAX_CONCURRENT_JOB_EXECUTIONS` caps how many run at once, an HMR-safe shared set tracks them and removes each on settle, and a pass hands off only free capacity (deferrals are logged, never silent). Reclaim always runs, including at full capacity. `SWEEP_DISPATCH_LIMIT` and the execution cap are now distinct limits. Shutdown abandons executing jobs deliberately — awaiting a census-scale ingestion would outlast any platform grace period, and abandonment is exactly what the lease/reclaim/crash-recovery machinery already handles.
- **Cancellation only took effect between files.** A census-scale file stages over ~22 chunks, so a cancel requested during chunk 2 still staged all 22 — minutes of work the user had already asked to stop, plus all those rows to clean up. The chunk loop now probes at each boundary.
- **A failed startup sweep logged twice.** `runSweepTick` emitted `upload.sweeper.pass_failed` *and* instrumentation emitted `upload.sweeper.startup_failed` — two events at two severities for one failure. `runSweepTick` now reports the outcome and each caller emits its own single canonical event.

## Deployment note

Any environment currently running with `ASYNC_UPLOAD_ENABLED=true` and an empty user or schema allow-list is relying on the old fail-open behaviour: the feature will be **off** until both lists are populated.