### PR TITLE
fix(uploads): make blob allocation atomic and bind every referenced blob to its uploader

### DIFF
--- a/frontend/app/api/files/[operation]/route.test.ts
+++ b/frontend/app/api/files/[operation]/route.test.ts
@@ -283,7 +283,8 @@ describe('/api/files/[operation]', () => {
       'measurements',
       [],
       'measurements.csv',
-      'csv'
+      'csv',
+      undefined
     );
   });
 
@@ -337,7 +338,8 @@ describe('/api/files/[operation]', () => {
         'measurements',
         [VALID_ROW_ERROR],
         'measurements.csv',
-        'csv'
+        'csv',
+        undefined
       );
     });
 
@@ -372,7 +374,16 @@ describe('/api/files/[operation]', () => {
     const responseBody = await response.json();
     expect(response.status, JSON.stringify(responseBody)).toBe(200);
     expect(responseBody).toMatchObject({ blobName: 'name.csv', fileName: 'name.csv' });
-    expect(mocks.uploadValidFileAsBufferWithMetadata).toHaveBeenCalledWith(expect.anything(), file, 'mason@example.com', 'measurements', [], 'name.csv', 'csv');
+    expect(mocks.uploadValidFileAsBufferWithMetadata).toHaveBeenCalledWith(
+      expect.anything(),
+      file,
+      'mason@example.com',
+      'measurements',
+      [],
+      'name.csv',
+      'csv',
+      undefined
+    );
   });
 
   it('propagates the arcgis_xlsx sourceFormat so archived blob provenance is preserved', async () => {
@@ -400,7 +411,8 @@ describe('/api/files/[operation]', () => {
       'measurements',
       [],
       'arcgis-export.xlsx',
-      'arcgis_xlsx'
+      'arcgis_xlsx',
+      undefined
     );
   });
 

--- a/frontend/app/api/files/[operation]/route.ts
+++ b/frontend/app/api/files/[operation]/route.ts
@@ -8,7 +8,7 @@ import { auth } from '@/auth';
 import { getSessionUserId } from '@/lib/auth-helpers';
 import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
-import { sanitizeUploadFileName as sanitizeFileName } from '@/lib/uploads/file-names';
+import { attemptScopedBlobName, isValidUploadAttemptID, sanitizeUploadFileName as sanitizeFileName } from '@/lib/uploads/file-names';
 import path from 'path';
 import type { Session } from 'next-auth';
 import { FormType, normalizeSourceFormat, SourceFormat } from '@/config/macros/formdetails';
@@ -73,6 +73,14 @@ interface FileOperationParams {
   user?: string;
   formType?: string;
   sourceFormat?: string;
+  /**
+   * Identifies one upload attempt. When present, the blob is written under an
+   * attempt-scoped path with create-only semantics instead of the
+   * probe-then-suffix search, and the attempt is recorded in blob metadata so
+   * job creation can require that the blob it is handed belongs to this
+   * uploader and this attempt.
+   */
+  attemptID?: string;
 }
 
 interface AuthorizedFileScope {
@@ -187,7 +195,7 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
     return new NextResponse(JSON.stringify({ error: 'File is required' }), { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const { fileName, formType, sourceFormat } = params;
+  const { fileName, formType, sourceFormat, attemptID } = params;
   const file = formData.get(fileName ?? 'file') as File | null;
   let fileRowErrors: FileRowErrors[] = [];
   const rawFileRowErrors = formData.get('fileRowErrors');
@@ -260,6 +268,15 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
     ailogger.warn(`File name sanitized: ${fileName} -> ${sanitizedFileName}`);
   }
 
+  if (attemptID !== undefined && !isValidUploadAttemptID(attemptID)) {
+    return new NextResponse(JSON.stringify({ error: 'attemptID must be 8-64 characters of A-Z, a-z, 0-9, dash, or underscore' }), {
+      status: HTTPResponses.INVALID_REQUEST
+    });
+  }
+  // Attempt-scoped path: two attempts can never contend for one blob name, so
+  // the exists()-then-write race disappears rather than being narrowed.
+  const targetBlobName = attemptID ? attemptScopedBlobName(attemptID, sanitizedFileName) : sanitizedFileName;
+
   try {
     // getContainerClient now throws with detailed error messages on failure
     const containerClient = await getContainerClient(scope.container);
@@ -271,8 +288,9 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
       scope.userId,
       formType,
       fileRowErrors,
-      sanitizedFileName,
-      normalizedSourceFormat
+      targetBlobName,
+      normalizedSourceFormat,
+      attemptID ? { attemptID } : undefined
     );
 
     // Verify the response status
@@ -285,8 +303,12 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
       JSON.stringify({
         message: 'File uploaded successfully',
         fileName: sanitizedFileName,
+        // Both names travel back: the canonical one is the job's file identity,
+        // the original is what the user recognizes in an error message.
+        originalFileName: fileName,
         blobContainer: scope.container,
         blobName: uploadResult.blobName,
+        attemptID: attemptID ?? null,
         contentType: file.type || null,
         byteSize: file.size,
         formType,
@@ -376,7 +398,8 @@ function extractParams(request: NextRequest): FileOperationParams & { fileName?:
     census: searchParams.get('census')?.trim() || undefined,
     user: searchParams.get('user')?.trim() || undefined,
     formType: searchParams.get('formType')?.trim() || undefined,
-    sourceFormat: searchParams.get('sourceFormat')?.trim() || undefined
+    sourceFormat: searchParams.get('sourceFormat')?.trim() || undefined,
+    attemptID: searchParams.get('attemptID')?.trim() || undefined
   };
 }
 

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -26,6 +26,9 @@ const mocks = vi.hoisted(() => ({
   createUploadBackgroundJob: vi.fn(),
   listBackgroundJobs: vi.fn(),
   isAsyncUploadEnabledFor: vi.fn(() => true),
+  getBlobProperties: vi.fn(),
+  loggerWarn: vi.fn(),
+  getContainerClient: vi.fn(),
   runJobIfClaimable: vi.fn(async () => undefined),
   executeQuery: vi.fn(),
   loggerError: vi.fn(),
@@ -79,13 +82,19 @@ vi.mock('@/lib/background-jobs/feature-gate', () => ({
   isAsyncUploadEnabledFor: mocks.isAsyncUploadEnabledFor
 }));
 
+vi.mock('@/config/macros/azurestorage', () => ({
+  getContainerClient: mocks.getContainerClient
+}));
+
 vi.mock('@/lib/background-jobs/worker', () => ({
   runJobIfClaimable: mocks.runJobIfClaimable
 }));
 
 vi.mock('@/ailogger', () => ({
   default: {
-    error: mocks.loggerError
+    error: mocks.loggerError,
+    warn: mocks.loggerWarn,
+    info: vi.fn()
   }
 }));
 
@@ -97,6 +106,10 @@ const session = {
     sites: [{ schemaName: 'forestgeo_testing' }]
   }
 };
+
+/** Matches isValidUploadAttemptID: 8-64 chars of A-Za-z0-9_- */
+const TEST_ATTEMPT_ID = 'attempt-0123456789ab';
+const TEST_UPLOADER = 'mason@example.com';
 
 const VALID_COLUMN_MAPPING = {
   version: 1,
@@ -113,11 +126,14 @@ function makeCreateBody(overrides: Record<string, unknown> = {}) {
     sourceFormat: 'csv',
     formType: 'measurements',
     idempotencyKey: 'upload-job-1',
+    attemptID: TEST_ATTEMPT_ID,
     files: [
       {
         fileName: 'measurements.csv',
         blobContainer: 'forestgeo-testing-storage',
-        blobName: 'uploads/job-1/measurements.csv',
+        // Must be the attempt-scoped path for the canonical file name; job
+        // creation verifies this and the blob's ownership metadata.
+        blobName: `${TEST_ATTEMPT_ID}/measurements.csv`,
         contentType: 'text/csv',
         byteSize: 128,
         expectedRows: 12
@@ -154,9 +170,18 @@ function makeListRequest(query: string) {
   return req;
 }
 
+/** A blob whose metadata says this user uploaded it in this attempt. */
+function primeOwnedBlob(metadata: Record<string, string> = { user: TEST_UPLOADER, attemptid: TEST_ATTEMPT_ID }) {
+  mocks.getBlobProperties.mockResolvedValue({ metadata });
+  mocks.getContainerClient.mockResolvedValue({
+    getBlobClient: () => ({ getProperties: mocks.getBlobProperties })
+  });
+}
+
 describe('POST /api/uploadjobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    primeOwnedBlob();
     mocks.auth.mockResolvedValue(session);
     mocks.createUploadBackgroundJob.mockResolvedValue({
       jobID: 42,
@@ -356,7 +381,7 @@ describe('POST /api/uploadjobs', () => {
 
   it('rejects duplicate file names before batch bookkeeping can collide', async () => {
     const file = makeCreateBody().files[0];
-    const response = await callPost(makeCreateRequest(makeCreateBody({ files: [file, { ...file, blobName: 'uploads/job-1/copy.csv' }] })));
+    const response = await callPost(makeCreateRequest(makeCreateBody({ files: [file, { ...file, blobName: `${TEST_ATTEMPT_ID}/copy.csv` }] })));
 
     expect(response.status).toBe(400);
     expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
@@ -400,7 +425,7 @@ describe('POST /api/uploadjobs', () => {
       makeCreateRequest(
         makeCreateBody({
           sourceFormat: 'arcgis_xlsx',
-          files: [{ ...makeCreateBody().files[0], fileName: 'survey.xlsx', blobName: 'survey.xlsx', sourceFormat: 'arcgis_xlsx' }],
+          files: [{ ...makeCreateBody().files[0], fileName: 'survey.xlsx', blobName: `${TEST_ATTEMPT_ID}/survey.xlsx`, sourceFormat: 'arcgis_xlsx' }],
           payload: {
             arcgisImportSession: { importSessionId: 'import-1', fileName: 'survey.xlsx', rowCount: 100 }
           }
@@ -421,7 +446,7 @@ describe('POST /api/uploadjobs', () => {
     const response = await callPost(
       makeCreateRequest(
         makeCreateBody({
-          files: [{ ...makeCreateBody().files[0], fileName: 'Harvard_Forest_2014.csv', blobName: 'uploads/job-1/Harvard_Forest_2014.csv' }],
+          files: [{ ...makeCreateBody().files[0], fileName: 'Harvard_Forest_2014.csv', blobName: `${TEST_ATTEMPT_ID}/Harvard_Forest_2014.csv` }],
           payload: {
             selectedDelimiters: { 'Harvard_Forest_2014.csv': ',' },
             columnMappings: { 'Harvard_Forest_2014.csv': VALID_COLUMN_MAPPING }
@@ -464,7 +489,14 @@ describe('POST /api/uploadjobs', () => {
       makeCreateRequest(
         makeCreateBody({
           sourceFormat: 'arcgis_xlsx',
-          files: [{ ...makeCreateBody().files[0], fileName: 'Harvard_Survey_2014.xlsx', blobName: 'Harvard_Survey_2014.xlsx', sourceFormat: 'arcgis_xlsx' }],
+          files: [
+            {
+              ...makeCreateBody().files[0],
+              fileName: 'Harvard_Survey_2014.xlsx',
+              blobName: `${TEST_ATTEMPT_ID}/Harvard_Survey_2014.xlsx`,
+              sourceFormat: 'arcgis_xlsx'
+            }
+          ],
           payload: {
             // The pre-flight session records the raw browser name.
             arcgisImportSession: { importSessionId: 'import-1', fileName: 'Harvard Survey 2014.xlsx', rowCount: 100 }
@@ -633,6 +665,80 @@ describe('POST /api/uploadjobs', () => {
     });
   });
 
+  /**
+   * A blobName is caller-supplied. The container check proves only that the
+   * caller named a container it may read — it says nothing about who put the
+   * blob there, and the worker will ingest whatever the referenced blob
+   * contains. Ownership is therefore established from the blob's own metadata.
+   */
+  describe('referenced blobs must belong to this uploader and this attempt', () => {
+    it('accepts a blob whose metadata matches the requester and attempt', async () => {
+      expect((await callPost(makeCreateRequest(makeCreateBody()))).status).toBe(202);
+    });
+
+    it('rejects a blob uploaded by a different user', async () => {
+      primeOwnedBlob({ user: 'someone.else@example.com', attemptid: TEST_ATTEMPT_ID });
+
+      const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ error: expect.stringContaining('not uploaded by you') });
+      expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blob left over from a different attempt', async () => {
+      primeOwnedBlob({ user: TEST_UPLOADER, attemptid: 'attempt-some-other-run' });
+
+      const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+      expect(response.status).toBe(403);
+      expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blob carrying no ownership metadata at all', async () => {
+      primeOwnedBlob({});
+
+      expect((await callPost(makeCreateRequest(makeCreateBody()))).status).toBe(403);
+    });
+
+    it('rejects a blobName that is not this attempt’s path for that file', async () => {
+      const file = { ...makeCreateBody().files[0], blobName: 'someone-elses-attempt/measurements.csv' };
+
+      const response = await callPost(makeCreateRequest(makeCreateBody({ files: [file] })));
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ error: expect.stringContaining("attempt's path") });
+      // Rejected on the path alone — storage is never even consulted.
+      expect(mocks.getBlobProperties).not.toHaveBeenCalled();
+    });
+
+    it('rejects a referenced blob that does not exist', async () => {
+      mocks.getBlobProperties.mockRejectedValue(Object.assign(new Error('BlobNotFound'), { statusCode: 404 }));
+
+      const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ error: expect.stringContaining('was not found') });
+      expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { label: 'missing', attemptID: undefined },
+      { label: 'too short', attemptID: 'short' },
+      { label: 'containing a path separator', attemptID: 'attempt/../../etc' }
+    ])('rejects a $label attemptID with 400 before touching storage', async ({ attemptID }) => {
+      const body = makeCreateBody();
+      if (attemptID === undefined) delete (body as Record<string, unknown>).attemptID;
+      else (body as Record<string, unknown>).attemptID = attemptID;
+
+      const response = await callPost(makeCreateRequest(body));
+
+      expect(response.status).toBe(400);
+      expect(mocks.getContainerClient).not.toHaveBeenCalled();
+      expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+    });
+  });
+
   it('rejects an ArcGIS job with more than one file', async () => {
     const file = makeCreateBody().files[0];
     const response = await callPost(
@@ -640,7 +746,7 @@ describe('POST /api/uploadjobs', () => {
         makeCreateBody({
           sourceFormat: 'arcgis_xlsx',
           files: [
-            { ...file, fileName: 'survey.xlsx', blobName: 'survey.xlsx', sourceFormat: 'arcgis_xlsx' },
+            { ...file, fileName: 'survey.xlsx', blobName: `${TEST_ATTEMPT_ID}/survey.xlsx`, sourceFormat: 'arcgis_xlsx' },
             { ...file, fileName: 'other.xlsx', blobName: 'other.xlsx', sourceFormat: 'arcgis_xlsx' }
           ],
           payload: { arcgisImportSession: { importSessionId: 'import-1', fileName: 'survey.xlsx', rowCount: 100 } }

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -18,7 +18,8 @@ import { IdempotencyKeyConflictError } from '@/lib/background-jobs/errors';
 import { isPrivilegedSession, MAX_UPLOAD_JOB_REQUEST_BYTES, parseOptionalPositiveInteger } from '@/lib/background-jobs/route-helpers';
 import { runJobIfClaimable } from '@/lib/background-jobs/worker';
 import { fromBody, fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
-import { sanitizeUploadFileName } from '@/lib/uploads/file-names';
+import { attemptScopedBlobName, isValidUploadAttemptID, sanitizeUploadFileName } from '@/lib/uploads/file-names';
+import { getContainerClient } from '@/config/macros/azurestorage';
 import { getContainerName, SchemaContainerNameError } from '@/config/macros/containernames';
 import ailogger from '@/ailogger';
 
@@ -113,6 +114,12 @@ const CreateUploadJobSchema = z
     sourceFormat: z.enum(SourceFormat),
     formType: z.enum(FormType),
     idempotencyKey: z.string().trim().min(1).max(255).nullable().optional(),
+    /**
+     * The upload attempt whose blobs this job references. Required to bind the
+     * job to blobs THIS user uploaded in THIS attempt — a caller-supplied
+     * blobName alone proves nothing about who put it there.
+     */
+    attemptID: z.string().trim().refine(isValidUploadAttemptID, { message: 'attemptID must be 8-64 characters of A-Z, a-z, 0-9, dash, or underscore' }),
     payload: UploadJobPayloadSchema.optional(),
     files: z.array(UploadJobFileSchema).min(1).max(MAX_UPLOAD_JOB_FILES)
   })
@@ -260,6 +267,57 @@ function validationErrorResponse(error: z.ZodError) {
   );
 }
 
+/**
+ * Requires every referenced blob to exist in the authorized container, carry
+ * this uploader's identity and this attempt's token in its metadata, and sit at
+ * the attempt-scoped path the canonical file name implies.
+ *
+ * Reading metadata is a HEAD per file — cheap next to the ingestion that
+ * follows, and the only thing standing between a guessed blobName and the
+ * worker ingesting a stranger's file.
+ */
+async function rejectUnownedBlobReferences(
+  input: z.infer<typeof CreateUploadJobSchema>,
+  uploaderID: string,
+  authorizedContainer: string
+): Promise<NextResponse | null> {
+  let containerClient;
+  try {
+    containerClient = await getContainerClient(authorizedContainer, { createIfMissing: false });
+  } catch (error) {
+    ailogger.error(`Could not open container ${authorizedContainer} to verify upload-job blobs`, error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Upload storage is unavailable' }, { status: HTTPResponses.SERVICE_UNAVAILABLE });
+  }
+
+  for (const file of input.files) {
+    const expectedBlobName = attemptScopedBlobName(input.attemptID, sanitizeUploadFileName(file.fileName));
+    if (file.blobName !== expectedBlobName) {
+      return NextResponse.json(
+        { error: `Blob reference for "${file.fileName}" is not at this attempt's path for that file` },
+        { status: HTTPResponses.FORBIDDEN }
+      );
+    }
+
+    let properties;
+    try {
+      properties = await containerClient.getBlobClient(file.blobName).getProperties();
+    } catch {
+      return NextResponse.json({ error: `Uploaded blob for "${file.fileName}" was not found` }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+
+    const metadata = properties.metadata ?? {};
+    if (metadata.attemptid !== input.attemptID || metadata.user !== uploaderID) {
+      ailogger.warn(
+        `Rejected upload-job blob ${file.blobName}: metadata user="${metadata.user}" attempt="${metadata.attemptid}" ` +
+          `does not match requester "${uploaderID}" attempt "${input.attemptID}"`
+      );
+      return NextResponse.json({ error: `Uploaded blob for "${file.fileName}" was not uploaded by you in this attempt` }, { status: HTTPResponses.FORBIDDEN });
+    }
+  }
+
+  return null;
+}
+
 async function postHandler(request: NextRequest) {
   const session = await auth();
   const authError = requireSession(session);
@@ -341,6 +399,14 @@ async function postHandler(request: NextRequest) {
   if (input.files.some(file => file.blobContainer.toLowerCase() !== authorizedContainer.toLowerCase())) {
     return NextResponse.json({ error: 'Blob container does not match the authorized upload scope' }, { status: HTTPResponses.FORBIDDEN });
   }
+
+  // The container check above only proves the caller named a container it is
+  // allowed to read. It says nothing about WHO put the blob there, and the
+  // worker will happily ingest whatever the referenced blob contains. Each
+  // referenced blob must therefore be one this user wrote, in this attempt,
+  // under the canonical name the job claims.
+  const blobOwnershipError = await rejectUnownedBlobReferences(input, userID, authorizedContainer);
+  if (blobOwnershipError) return blobOwnershipError;
 
   const catalogPool = getPoolMonitorInstance().pool;
   let job;

--- a/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
+++ b/frontend/components/uploadsystem/segments/uploadasyncjob.tsx
@@ -12,6 +12,7 @@ import type { FileWithStream } from '@/config/macros/uploadsystemmacros';
 import type { ArcgisImportReference } from '@/lib/arcgis/types';
 import type { ColumnMapping } from '@/lib/column-mapping/types';
 import ailogger from '@/ailogger';
+import { describeUploadFileNameCollisions, findUploadFileNameCollisions } from '@/lib/uploads/file-names';
 
 export interface BlobUploadResult {
   fileName: string;
@@ -192,6 +193,18 @@ export default function UploadAsyncJob({
         }
 
         cleanupScope = { schema, plotID, plotCensusNumber };
+
+        // Canonicalize BEFORE anything is uploaded. Sanitizing is lossy — "a
+        // b.csv" and "a_b.csv" both become "a_b.csv" — and the canonical name is
+        // the job's file identity, so a clash is rejected at job creation. Left
+        // to that point, both files have already been uploaded to storage and
+        // the user is told only that the job has duplicate file names. Caught
+        // here, nothing is uploaded and the message names both of their files.
+        const nameCollisions = findUploadFileNameCollisions(acceptedFiles.map(file => file.name));
+        if (nameCollisions.length > 0) {
+          throw new Error(`Rename one of these files before uploading: ${describeUploadFileNameCollisions(nameCollisions)}.`);
+        }
+
         const totalSteps = acceptedFiles.length + 1;
 
         for (let index = 0; index < acceptedFiles.length; index++) {
@@ -205,7 +218,11 @@ export default function UploadAsyncJob({
             plotName,
             census: String(plotCensusNumber),
             formType: uploadForm,
-            sourceFormat: normalizedSourceFormat
+            sourceFormat: normalizedSourceFormat,
+            // Binds the blob to this attempt: it is stored under an
+            // attempt-scoped path, created atomically rather than after an
+            // exists() probe, and stamped with the attempt in blob metadata.
+            attemptID: attemptIDRef.current
           });
 
           const formData = new FormData();
@@ -241,6 +258,7 @@ export default function UploadAsyncJob({
             sourceFormat: normalizedSourceFormat,
             formType: uploadForm,
             idempotencyKey: `async-upload:${schema}:${plotID}:${censusID}:${attemptIDRef.current}`,
+            attemptID: attemptIDRef.current,
             payload: {
               asyncUploadVersion: 1,
               plotName,

--- a/frontend/config/macros/azurestorage.ts
+++ b/frontend/config/macros/azurestorage.ts
@@ -86,6 +86,29 @@ export interface UploadValidFileResult {
   blobName: string;
 }
 
+/**
+ * Identifies the upload attempt a blob belongs to.
+ *
+ * When supplied, the blob is written EXACTLY at `blobFileName` with create-only
+ * semantics instead of the probe-then-write suffix search. That search is a
+ * TOCTOU race: `exists()` followed by an unconditional `uploadData()` lets two
+ * concurrent attempts both see a name free and both claim it, after which either
+ * attempt's cleanup can delete a blob the other is relying on. An attempt-scoped
+ * path plus an atomic create removes both halves of that.
+ *
+ * The attempt id is also written to blob metadata so job creation can require
+ * that a referenced blob was uploaded by this user, under this attempt.
+ */
+export interface UploadAttemptBinding {
+  attemptID: string;
+}
+
+/** Azure's create-only conflict: the blob path is already taken. */
+function isBlobAlreadyExistsError(error: unknown): boolean {
+  const candidate = error as { statusCode?: number; code?: string; details?: { errorCode?: string } } | null;
+  return candidate?.statusCode === 409 || candidate?.code === 'BlobAlreadyExists' || candidate?.details?.errorCode === 'BlobAlreadyExists';
+}
+
 export async function uploadValidFileAsBufferWithMetadata(
   containerClient: ContainerClient,
   file: File,
@@ -93,7 +116,8 @@ export async function uploadValidFileAsBufferWithMetadata(
   formType: string,
   fileRowErrors: FileRowErrors[] = [],
   blobFileName: string = file.name,
-  sourceFormat: string = 'csv'
+  sourceFormat: string = 'csv',
+  attempt?: UploadAttemptBinding
 ): Promise<UploadValidFileResult> {
   let buffer: Buffer;
   try {
@@ -138,31 +162,52 @@ export async function uploadValidFileAsBufferWithMetadata(
     return newFileName;
   };
 
-  const newFileName = await generateNewFileName(blobFileName);
+  // An attempt-bound upload owns its path outright, so there is nothing to
+  // probe for and nothing to suffix — the name is either free (this attempt has
+  // not written it) or the write is a genuine conflict worth surfacing.
+  const newFileName = attempt ? blobFileName : await generateNewFileName(blobFileName);
   ailogger.info(`Uploading blob: ${newFileName}`);
 
   // Prepare metadata
-  const metadata = {
+  const metadata: Record<string, string> = {
     user: user,
     FormType: formType,
     sourceformat: sourceFormat,
     FileErrorState: JSON.stringify(fileRowErrors.length > 0 ? fileRowErrors : [])
   };
+  if (attempt) metadata.attemptid = attempt.attemptID;
+
+  // ifNoneMatch '*' is "create only": the write fails rather than overwriting an
+  // existing blob, which is the atomicity `exists()` could never provide.
+  const uploadOptions = attempt ? { metadata, conditions: { ifNoneMatch: '*' } } : { metadata };
 
   // Retry mechanism for the upload
+  const attemptBoundUpload = attempt !== undefined;
   let lastError: Error | null = null;
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+  for (let attemptNumber = 1; attemptNumber <= MAX_RETRIES; attemptNumber++) {
     try {
       // Use the generated unique filename (newFileName), not the original file.name
-      const uploadResponse = await containerClient.getBlockBlobClient(newFileName).uploadData(buffer, { metadata });
+      const uploadResponse = await containerClient.getBlockBlobClient(newFileName).uploadData(buffer, uploadOptions);
 
       // uploadData always returns a response on success
-      ailogger.info(`Upload successful for ${newFileName} on attempt ${attempt}`);
+      ailogger.info(`Upload successful for ${newFileName} on attempt ${attemptNumber}`);
       return { response: uploadResponse, blobName: newFileName };
     } catch (error: any) {
       lastError = error;
-      ailogger.warn(`Upload attempt ${attempt}/${MAX_RETRIES} failed for ${newFileName}: ${error.message}`);
-      if (attempt < MAX_RETRIES) {
+      // A create-only write that reports "already exists" on a RETRY is this
+      // same upload's earlier attempt whose acknowledgement was lost — same
+      // attempt path, same bytes. Retrying past it would fail forever, so it is
+      // reported as the success it is. On the FIRST attempt the same error means
+      // something else already owns the path, which is a genuine conflict.
+      if (attemptBoundUpload && attemptNumber > 1 && isBlobAlreadyExistsError(error)) {
+        ailogger.info(`Blob ${newFileName} already exists on retry ${attemptNumber}; a previous attempt of this upload committed it.`);
+        return { response: error.response ?? ({ _response: { status: 201 } } as unknown as BlobUploadCommonResponse), blobName: newFileName };
+      }
+      ailogger.warn(`Upload attempt ${attemptNumber}/${MAX_RETRIES} failed for ${newFileName}: ${error.message}`);
+      if (attemptBoundUpload && isBlobAlreadyExistsError(error)) {
+        throw new Error(`Blob ${newFileName} already exists for this upload attempt; refusing to overwrite it.`);
+      }
+      if (attemptNumber < MAX_RETRIES) {
         ailogger.info(`Retrying in ${RETRY_DELAY_MS}ms...`);
         await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
       }

--- a/frontend/lib/uploads/file-names.test.ts
+++ b/frontend/lib/uploads/file-names.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The canonical file name IS the job's file identity — `files[].fileName`, the
+ * key of the payload maps the worker looks up delimiters and column mappings
+ * by, and the ArcGIS pre-flight cross-check all use it. Sanitizing is lossy, so
+ * two different selected files can collapse onto one identity; and blob
+ * allocation used to be "probe with exists(), then write", which two concurrent
+ * attempts can both win.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  attemptScopedBlobName,
+  describeUploadFileNameCollisions,
+  findUploadFileNameCollisions,
+  isValidUploadAttemptID,
+  sanitizeUploadFileName
+} from './file-names';
+
+const ATTEMPT_ID = 'attempt-0123456789ab';
+
+describe('sanitizeUploadFileName', () => {
+  it('leaves an already-safe name untouched', () => {
+    expect(sanitizeUploadFileName('Harvard_Forest_2014.csv')).toBe('Harvard_Forest_2014.csv');
+  });
+
+  it('replaces every unsafe character and strips any directory part', () => {
+    expect(sanitizeUploadFileName('sub/dir/Harvard Forest (2014).csv')).toBe('Harvard_Forest__2014_.csv');
+  });
+
+  it('normalizes to NFC so the same name from macOS and elsewhere agree', () => {
+    // macOS hands filenames to the browser decomposed: "é" as e + U+0301.
+    // Without normalization the combining mark is not [a-zA-Z0-9._-] and becomes
+    // an underscore, so the same file picked on two machines gets two different
+    // identities — and the second upload looks like a different file.
+    const composed = 'café.csv';
+    const decomposed = 'café.csv';
+    expect(decomposed.normalize('NFC')).toBe(composed);
+
+    expect(sanitizeUploadFileName(decomposed)).toBe(sanitizeUploadFileName(composed));
+    expect(sanitizeUploadFileName(decomposed)).toBe('caf_.csv');
+  });
+
+  it('is idempotent — sanitizing a canonical name changes nothing', () => {
+    const once = sanitizeUploadFileName('a b(1).csv');
+    expect(sanitizeUploadFileName(once)).toBe(once);
+  });
+});
+
+describe('findUploadFileNameCollisions', () => {
+  it('finds nothing when every canonical name is distinct', () => {
+    expect(findUploadFileNameCollisions(['one.csv', 'two.csv', 'three.csv'])).toEqual([]);
+  });
+
+  it('catches two names that sanitize to the same identity', () => {
+    const collisions = findUploadFileNameCollisions(['a b.csv', 'a_b.csv']);
+
+    expect(collisions).toEqual([{ canonicalName: 'a_b.csv', originalNames: ['a b.csv', 'a_b.csv'] }]);
+  });
+
+  it('catches NFC/NFD forms of the same name', () => {
+    const collisions = findUploadFileNameCollisions(['café.csv', 'café.csv']);
+
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].originalNames).toHaveLength(2);
+  });
+
+  it('catches names differing only in case, because the job identity check is case-insensitive too', () => {
+    // These would upload to two distinct blobs (Azure blob names are
+    // case-sensitive) and then be rejected as one duplicated job file.
+    const collisions = findUploadFileNameCollisions(['Measurements.csv', 'measurements.csv']);
+
+    expect(collisions).toHaveLength(1);
+  });
+
+  it('reports every clashing group, and every original within a group', () => {
+    const collisions = findUploadFileNameCollisions(['a b.csv', 'a_b.csv', 'a-b.csv', 'x y.csv', 'x_y.csv', 'unique.csv']);
+
+    expect(collisions).toHaveLength(2);
+    expect(collisions[0].originalNames).toEqual(['a b.csv', 'a_b.csv']);
+    expect(collisions[1].originalNames).toEqual(['x y.csv', 'x_y.csv']);
+  });
+
+  it('names both originals in the message the user sees', () => {
+    const message = describeUploadFileNameCollisions(findUploadFileNameCollisions(['a b.csv', 'a_b.csv']));
+
+    expect(message).toContain('"a b.csv"');
+    expect(message).toContain('"a_b.csv"');
+    expect(message).toContain('a_b.csv');
+  });
+});
+
+describe('attemptScopedBlobName', () => {
+  it('places the file under its attempt', () => {
+    expect(attemptScopedBlobName(ATTEMPT_ID, 'measurements.csv')).toBe(`${ATTEMPT_ID}/measurements.csv`);
+  });
+
+  it('keeps two attempts of the same file on disjoint paths', () => {
+    const first = attemptScopedBlobName('attempt-aaaaaaaaaaaa', 'measurements.csv');
+    const second = attemptScopedBlobName('attempt-bbbbbbbbbbbb', 'measurements.csv');
+
+    // The whole point: no probe, no suffix search, no way for one attempt's
+    // cleanup to reach the other's blob.
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('isValidUploadAttemptID', () => {
+  it('accepts the ids the client actually generates', () => {
+    expect(isValidUploadAttemptID('3f2504e0-4f89-11d3-9a0c-0305e82c3301'), 'crypto.randomUUID()').toBe(true);
+    expect(isValidUploadAttemptID('1721428800000-k3j4h5g6f7'), 'the non-crypto fallback').toBe(true);
+  });
+
+  it('rejects anything that could escape the attempt prefix or break blob metadata', () => {
+    expect(isValidUploadAttemptID('attempt/../../etc'), 'path traversal').toBe(false);
+    expect(isValidUploadAttemptID('attempt id'), 'whitespace').toBe(false);
+    expect(isValidUploadAttemptID('attempt.id'), 'dot — could form a path segment').toBe(false);
+    expect(isValidUploadAttemptID('short'), 'too short to be unguessable').toBe(false);
+    expect(isValidUploadAttemptID('a'.repeat(65)), 'too long').toBe(false);
+    expect(isValidUploadAttemptID(''), 'empty').toBe(false);
+  });
+});

--- a/frontend/lib/uploads/file-names.ts
+++ b/frontend/lib/uploads/file-names.ts
@@ -9,8 +9,80 @@ import path from 'path';
  * delimiters and column mappings by, and the ArcGIS pre-flight cross-check.
  * Comparing a raw name against a stored one rejects any file whose name
  * contains a space, parenthesis, comma, or accented character.
+ *
+ * Unicode is normalized to NFC FIRST. macOS hands filenames to the browser in
+ * NFD (decomposed), so `café.csv` picked on a Mac and the same name typed
+ * elsewhere are different byte sequences that sanitize to different canonical
+ * names — one becoming `cafe_.csv`. Normalizing first makes the two agree, and
+ * it is a no-op for already-composed and pure-ASCII names.
  */
 export function sanitizeUploadFileName(fileName: string): string {
-  const baseName = path.basename(fileName);
+  const baseName = path.basename(fileName.normalize('NFC'));
   return baseName.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/** Two or more selected files whose canonical names are the same. */
+export interface UploadFileNameCollision {
+  /** The canonical name they all reduce to. */
+  canonicalName: string;
+  /** The original names as the user selected them, in selection order. */
+  originalNames: string[];
+}
+
+/**
+ * Finds selected file names that canonicalize to the same identity.
+ *
+ * Sanitizing is lossy — `a b.csv` and `a_b.csv` both become `a_b.csv` — and the
+ * canonical name is the job's file identity. Detected LATE, this shows up as a
+ * duplicate-file-name rejection at job creation, after both files have already
+ * been uploaded to storage; detected here, before any upload, the user can be
+ * told which two of their files clash and rename one.
+ *
+ * Comparison is case-insensitive because the duplicate check at job creation is
+ * too, and Azure blob names are case-sensitive — so two names differing only in
+ * case would upload to two distinct blobs and still be rejected as one job file.
+ */
+export function findUploadFileNameCollisions(fileNames: readonly string[]): UploadFileNameCollision[] {
+  const byCanonicalName = new Map<string, { canonicalName: string; originalNames: string[] }>();
+
+  for (const fileName of fileNames) {
+    const canonicalName = sanitizeUploadFileName(fileName);
+    const key = canonicalName.toLowerCase();
+    const existing = byCanonicalName.get(key);
+    if (existing) existing.originalNames.push(fileName);
+    else byCanonicalName.set(key, { canonicalName, originalNames: [fileName] });
+  }
+
+  return [...byCanonicalName.values()].filter(entry => entry.originalNames.length > 1);
+}
+
+/** Human-readable explanation naming every clashing original, for the user to act on. */
+export function describeUploadFileNameCollisions(collisions: readonly UploadFileNameCollision[]): string {
+  return collisions
+    .map(collision => `${collision.originalNames.map(name => `"${name}"`).join(' and ')} are both stored as "${collision.canonicalName}"`)
+    .join('; ');
+}
+
+/**
+ * Blob path for one file of one upload attempt.
+ *
+ * Attempt-scoped so two attempts can never contend for the same blob name.
+ * Without it, allocation was "probe with exists(), then uploadData() to whatever
+ * name looked free" — a TOCTOU race in which two concurrent attempts both see a
+ * name available and both write it, and either attempt's cleanup then deletes a
+ * blob the other is relying on.
+ */
+export function attemptScopedBlobName(attemptID: string, canonicalFileName: string): string {
+  return `${attemptID}/${canonicalFileName}`;
+}
+
+/**
+ * An upload attempt id is generated client-side and reaches storage as blob
+ * metadata, so it is constrained to what is safe in a blob path and in an Azure
+ * metadata value: ASCII alphanumerics, dash, and underscore.
+ */
+const ATTEMPT_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+
+export function isValidUploadAttemptID(attemptID: string): boolean {
+  return ATTEMPT_ID_PATTERN.test(attemptID);
 }


### PR DESCRIPTION
## Summary

Completes WS-D of the PR-review remediation: D4 (filename identity and blob-allocation atomicity) and the D5 blob-ownership item that depends on D4's attempt token. The rest of WS-D landed in #393.

- **Filename clashes were detected too late.** Sanitizing is lossy — `a b.csv` and `a_b.csv` both become `a_b.csv` — and the canonical name is the job's file identity, so a clash is rejected at job creation. By then *both files have already been uploaded* and the user is told only that the job has duplicate file names. The wizard now detects it before any upload and names both of the user's files. Names are NFC-normalized first: macOS hands filenames to the browser decomposed, so the same `café.csv` picked on a Mac and typed elsewhere were different byte sequences producing different canonical names, one of them mangled.
- **Blob allocation was a TOCTOU race.** `exists()` followed by an unconditional `uploadData()` lets two concurrent attempts both see a name free and both claim it, after which either attempt's cleanup can delete a blob the other relies on — `exists()` was never a uniqueness guarantee. Each upload attempt now carries a token, blobs are written under an attempt-scoped path, and the write uses `ifNoneMatch: '*'` — create-only, atomic rather than probed. Two attempts of the same file land on disjoint paths by construction. A create-only conflict on a *retry* is this upload's own earlier attempt whose ack was lost (same path, same bytes) and is reported as the success it is; on the first attempt it is a real conflict and fails.
- **A referenced blobName proved nothing about who uploaded it.** Job creation checked only that the named container matched the authorized scope — which says the caller may *read* that container, not that the caller put the blob there — and the worker then ingests whatever the blob contains. Each referenced blob must now sit at this attempt's path for its canonical name and carry blob metadata naming this uploader and this attempt. A blob belonging to another user, left over from another attempt, carrying no ownership metadata, or simply absent is rejected before the job is created; the path check runs first, so a foreign path is refused without touching storage.

## Compatibility

`attemptID` is now **required** on `POST /api/uploadjobs` and blobs must be uploaded through `/api/files/upload?attemptID=...`. The wizard sends both. Any in-flight upload started before this deploys — blobs already written at the container root without attempt metadata — will be rejected at job creation and must be re-uploaded. Direct API callers must adopt the token.