### PR TITLE
fix(tests): stop ctfs-export happy-path schema leak

### DIFF
--- a/frontend/tests/integration/ctfs-export.integration.test.ts
+++ b/frontend/tests/integration/ctfs-export.integration.test.ts
@@ -18,7 +18,7 @@
  * Prerequisites: docker compose up -d mysql
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import mysql from 'mysql2/promise';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -230,10 +230,36 @@ async function executeCtfsSql(ctfsConn: mysql.Connection, sql: string): Promise<
 // Test suites
 // ---------------------------------------------------------------------------
 
+// Every database created by this file, so the file-level afterAll can prove
+// each one was dropped. This tripwire exists because a teardown that passed
+// `connection.config.database` (undefined after `USE` — mysql2 never updates
+// it) silently executed DROP DATABASE `undefined` and leaked 26 schemas per
+// green run, bloating information_schema and slowing every later run.
+const createdDatabases: string[] = [];
+
+afterAll(async () => {
+  if (createdDatabases.length === 0) return;
+  const conn = await mysql.createConnection({
+    host: DEFAULT_TEST_CONFIG.host,
+    user: DEFAULT_TEST_CONFIG.user,
+    password: DEFAULT_TEST_CONFIG.password,
+    port: DEFAULT_TEST_CONFIG.port
+  });
+  try {
+    const [rows] = await conn.query<mysql.RowDataPacket[]>('SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME IN (?)', [createdDatabases]);
+    const leaked = rows.map(r => r.SCHEMA_NAME as string);
+    expect(leaked, `Databases leaked by this file (teardown failed to drop them): ${leaked.join(', ')}`).toEqual([]);
+  } finally {
+    await conn.end();
+  }
+});
+
 describe('ctfs-export E2E: library pipeline → CTFS DB', () => {
   let appConn: mysql.Connection;
   let ctfsConn: mysql.Connection;
   let appSchema: string;
+  let appDbName: string;
+  let ctfsDbName: string;
 
   // Each beforeEach builds two fresh databases with unique names so test
   // collisions are impossible even when vitest retries or reruns.
@@ -241,8 +267,9 @@ describe('ctfs-export E2E: library pipeline → CTFS DB', () => {
     // Schema names must match safeFormatQuery's forestgeo_/catalog allowlist —
     // selectMeasurements validates the schema through the project-wide helper.
     const stamp = `${process.pid}_${Date.now()}`;
-    const appDbName = `forestgeo_cte_app_${stamp}`;
-    const ctfsDbName = `forestgeo_cte_ctfs_${stamp}`;
+    appDbName = `forestgeo_cte_app_${stamp}`;
+    ctfsDbName = `forestgeo_cte_ctfs_${stamp}`;
+    createdDatabases.push(appDbName, ctfsDbName);
 
     const appCfg = { ...DEFAULT_TEST_CONFIG, database: appDbName };
     const ctfsCfg = { ...DEFAULT_TEST_CONFIG, database: ctfsDbName };
@@ -260,14 +287,14 @@ describe('ctfs-export E2E: library pipeline → CTFS DB', () => {
   afterEach(async () => {
     if (appConn) {
       try {
-        await teardownTestDatabase(appConn, { database: appConn.config.database as string });
+        await teardownTestDatabase(appConn, { database: appDbName });
       } catch {
         // best-effort cleanup
       }
     }
     if (ctfsConn) {
       try {
-        await teardownTestDatabase(ctfsConn, { database: ctfsConn.config.database as string });
+        await teardownTestDatabase(ctfsConn, { database: ctfsDbName });
       } catch {
         // best-effort cleanup
       }
@@ -615,11 +642,14 @@ describe('ctfs-export perf baseline', () => {
   let appConn: mysql.Connection;
   let ctfsConn: mysql.Connection;
   let appSchema: string;
+  let appDbName: string;
+  let ctfsDbName: string;
 
   beforeEach(async () => {
     const stamp = `${process.pid}_${Date.now()}`;
-    const appDbName = `forestgeo_perf_app_${stamp}`;
-    const ctfsDbName = `forestgeo_perf_ctfs_${stamp}`;
+    appDbName = `forestgeo_perf_app_${stamp}`;
+    ctfsDbName = `forestgeo_perf_ctfs_${stamp}`;
+    createdDatabases.push(appDbName, ctfsDbName);
 
     appConn = await createTestDatabase({ ...DEFAULT_TEST_CONFIG, database: appDbName });
     ctfsConn = await createTestDatabase({ ...DEFAULT_TEST_CONFIG, database: ctfsDbName });
@@ -633,14 +663,14 @@ describe('ctfs-export perf baseline', () => {
   afterEach(async () => {
     if (appConn) {
       try {
-        await teardownTestDatabase(appConn, { database: appConn.config.database as string });
+        await teardownTestDatabase(appConn, { database: appDbName });
       } catch {
         /* best-effort */
       }
     }
     if (ctfsConn) {
       try {
-        await teardownTestDatabase(ctfsConn, { database: ctfsConn.config.database as string });
+        await teardownTestDatabase(ctfsConn, { database: ctfsDbName });
       } catch {
         /* best-effort */
       }

--- a/frontend/tests/setup/local-db-setup.ts
+++ b/frontend/tests/setup/local-db-setup.ts
@@ -201,7 +201,11 @@ export async function createTestDatabase(config: TestDatabaseConfig = DEFAULT_TE
 
     await connection.query(`DROP DATABASE IF EXISTS \`${config.database}\``);
     await connection.query(`CREATE DATABASE \`${config.database}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci`);
-    await connection.query(`USE \`${config.database}\``);
+    // changeUser (not `USE`) so mysql2 records the database on
+    // connection.config.database — a plain USE query switches the session
+    // server-side but leaves config.database undefined, which let callers
+    // tear down against `undefined` and leak the real database.
+    await connection.changeUser({ database: config.database });
 
     log.debug(` Test database created: ${config.database}`);
 
@@ -763,6 +767,22 @@ export async function teardownTestDatabase(
   if (!connection) {
     log.warn('No connection to clean up');
     return;
+  }
+
+  // A missing name means DROP DATABASE IF EXISTS `undefined` — which succeeds,
+  // drops nothing, and leaks the real database. Close the connection so the
+  // throw itself doesn't leak, then fail loudly. The 'undefined' literal
+  // catches names built by string-interpolating an undefined value.
+  if (!config.database || config.database === 'undefined') {
+    try {
+      await connection.end();
+    } catch {
+      // connection may already be closed; the error below is the signal
+    }
+    throw new Error(
+      `teardownTestDatabase requires an explicit database name; received ${JSON.stringify(config.database)}. ` +
+        `Pass the name used at createTestDatabase time.`
+    );
   }
 
   try {


### PR DESCRIPTION
## Summary

`ctfs-export.integration.test.ts` leaked both of its per-test databases on every green run — 26 schemas per full-suite pass — because its `afterEach` hooks tore down with `connection.config.database`, which mysql2 leaves `undefined` after a `USE` query. Teardown therefore executed `DROP DATABASE IF EXISTS \`undefined\``, which succeeds, drops nothing, and is swallowed by the best-effort catch. On long-lived local MySQL instances the orphans compound (measured >2,000 leaked databases / ~70k tables), progressively bloating `information_schema` and slowing every subsequent run.

Changes:
- **Bug**: both suites now record their generated database names and pass them explicitly to `teardownTestDatabase`.
- **Root affordance**: `createTestDatabase` switches schemas via `changeUser({ database })` instead of a `USE` query, so `connection.config.database` is recorded truthfully for any future caller of the old idiom.
- **Loud failure**: `teardownTestDatabase` now throws when called without a database name (after closing the connection) instead of silently dropping nothing.
- **Tripwire**: a file-level `afterAll` asserts every database created by this file is gone, and names the leaked schemas when it fails (red-proofed by mutation: a deliberately wrong teardown name fails the file with the leaked schema named).

Measured on a clean local MySQL: unmodified dev leaks exactly 26 schemas per full integration run; with this branch the identical run is green (116/116 files, 982 passed) with **zero** schemas leaked, wall-clock within 4% of baseline.

Note: this fixes the leak, but local evidence says the leak is unlikely to be the cause of the 35-minute CI integration timeouts (CI uses a fresh MySQL service container per run, and a clean-server local run of unmodified dev completes green in ~6 minutes). The CI stall is a separate open investigation.