### PR TITLE
test(provisioning): prove the provision → upload → teardown lifecycle, and fix the teardown it exposed

### DIFF
--- a/frontend/app/api/diagnostics/streaming-timeout/route.ts
+++ b/frontend/app/api/diagnostics/streaming-timeout/route.ts
@@ -7,6 +7,10 @@ export const runtime = 'nodejs';
 
 // Temporary diagnostic route for validating long-lived streamed requests on
 // non-production hosts without exercising the validation SQL path itself.
+// The heartbeat stream is the mechanism under test: it is what carries a
+// request past Azure App Service's ~240s load-balancer idle timeout, which no
+// app setting can raise. maxDuration is advisory only (Next.js records it in
+// the build manifest; only Vercel enforces it) and just documents the ceiling.
 export const maxDuration = 960;
 
 const DEFAULT_DURATION_SECONDS = 12 * 60;

--- a/frontend/app/api/setupbulkcollapser/[censusID]/route.ts
+++ b/frontend/app/api/setupbulkcollapser/[censusID]/route.ts
@@ -11,7 +11,12 @@ import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz'
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
 
-// Next.js route segment config: allow up to 5 minutes for large censuses
+// Advisory only — see setupbulkprocedure. Next.js records maxDuration in the
+// build manifest but only Vercel enforces it; on Azure App Service the real
+// ceiling is the load balancer's fixed ~240s idle timeout. Note that
+// COLLAPSER_TIMEOUT_MS (5 min) therefore outlives what this non-streaming
+// request can survive on the deployed site: the collapse keeps running
+// server-side after the client has already been handed a 504.
 export const maxDuration = 300;
 
 // Phase-3: user→schema membership via guard; requireUploadSessionOwnership retains plot/census token ownership.

--- a/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkfailure/[fileID]/[batchID]/route.ts
@@ -10,6 +10,11 @@ import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz'
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
+
+// Advisory only — see setupbulkprocedure for the full explanation. Next.js
+// records maxDuration in the build manifest but only Vercel enforces it; on
+// Azure App Service this non-streaming route is cut off with a 504 at the
+// load balancer's fixed ~240s idle timeout regardless of the value here.
 export const maxDuration = 900;
 
 // FAILURE PROCESS -- IF A BATCH EXCEEDS ALLOWED ATTEMPTS, MOVE IT TO FAILED & MOVE ON

--- a/frontend/app/api/setupbulkprocedure/[fileID]/[batchID]/route.ts
+++ b/frontend/app/api/setupbulkprocedure/[fileID]/[batchID]/route.ts
@@ -11,6 +11,15 @@ import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz'
 // Force Node.js runtime for database and Azure SDK compatibility
 // mysql2 and @azure/storage-* are not compatible with Edge Runtime
 export const runtime = 'nodejs';
+
+// ADVISORY ONLY on Azure. Next.js merely records maxDuration in the build
+// manifest; Vercel is what enforces it, and we self-host. The real ceiling is
+// Azure App Service's ~240s load-balancer idle timeout, which is fixed at the
+// hardware layer and cannot be raised by any app setting. A non-streaming
+// response that takes longer is severed with a 504 no matter what this says —
+// exactly the 2026-07-27 Harvard incident, where a 106k-row ingest died at 240s
+// while this file claimed a 15-minute budget. Anything that can outrun 240s
+// belongs on the background-jobs path (app/api/uploadjobs), not this request.
 export const maxDuration = 900;
 
 // Non-standard nginx status code for "client closed request"; preserved from

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -23,6 +23,13 @@ import { requireSession } from '@/lib/auth-helpers';
 import { assertSchemaAccess } from '@/lib/authz';
 import { isColumnMappingShape } from '@/lib/column-mapping/mapping';
 import { MeasurementChunkResolutionError, stageMeasurementChunk } from '@/lib/uploads/stage-measurements';
+import {
+  type FixedDataProcessingResult,
+  normalizeOptionalString,
+  normalizeRequiredString,
+  upsertAttributeRows,
+  upsertSpeciesRows
+} from '@/lib/uploads/reference-data-writers';
 
 /**
  * Generate idempotency key for a batch of data
@@ -67,21 +74,6 @@ function buildMeasurementScopeErrorResponse(status: HTTPResponses, message: stri
     }),
     { status }
   );
-}
-
-interface FixedDataProcessingResult {
-  insertedCount: number;
-  updatedCount: number;
-  skippedCount: number;
-  // Quadrat uploads only: bounded overlap reports plus complete layout signatures explicitly
-  // acknowledged as field measurements and recorded in the file changelog.
-  acknowledgedOverlapSummaries?: QuadratOverlapSummary[];
-}
-
-function normalizeOptionalString(value: unknown): string | null {
-  if (value === undefined || value === null) return null;
-  const normalized = String(value).trim();
-  return normalized === '' ? null : normalized;
 }
 
 function authenticatedSessionIdentity(sessionUser: unknown): string {
@@ -143,46 +135,6 @@ async function insertQuadratOverlapAcknowledgmentEvent(
   );
 }
 
-function normalizeRequiredString(value: unknown): string {
-  return String(value ?? '').trim();
-}
-
-function findDuplicateSpeciesCodes(rows: FileRow[]): string[] {
-  const seen = new Set<string>();
-  const duplicates = new Set<string>();
-
-  for (const row of rows) {
-    const speciesCode = normalizeOptionalString(row.spcode)?.toLowerCase();
-    if (!speciesCode) continue;
-    if (seen.has(speciesCode)) {
-      duplicates.add(speciesCode);
-      continue;
-    }
-    seen.add(speciesCode);
-  }
-
-  return Array.from(duplicates).sort();
-}
-
-/** Shared cap for every user-facing list of blocked values / validation issues below, so a
- *  single bad file (hundreds of blocked names, hundreds of failed rows) cannot produce an
- *  unbounded run-on error message. */
-const MAX_LISTED_ISSUES = 20;
-
-/** Joins `items` with `separator`, truncating at `maxItems` and appending an "...and N more"
- *  tail instead of listing everything. Shared by every truncated-list message in this file so
- *  there is one truncation style, not one per caller. */
-function truncateAndJoin(items: string[], separator: string, maxItems: number = MAX_LISTED_ISSUES): string {
-  const truncatedItems = items.slice(0, maxItems);
-  const remainingCount = items.length - truncatedItems.length;
-  return truncatedItems.join(separator) + (remainingCount > 0 ? `${separator}...and ${remainingCount} more` : '');
-}
-
-function formatBlockedCleanReuploadValues(values: string[], maxValues: number = MAX_LISTED_ISSUES): string {
-  const uniqueValues = Array.from(new Set(values.map(value => String(value ?? '').trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
-  return truncateAndJoin(uniqueValues, ', ', maxValues);
-}
-
 function isSupportedUploadMode(value: unknown): value is UploadMode {
   return value === UploadMode.CLEAN_REUPLOAD || value === UploadMode.REVISIONS;
 }
@@ -212,212 +164,6 @@ function isRetryableUploadError(error: unknown): boolean {
 
 function getUploadRetryDelayMs(attemptNumber: number): number {
   return Math.min(1000 * Math.pow(2, attemptNumber - 1), 10000);
-}
-
-async function upsertAttributeRows(
-  connectionManager: ConnectionManager,
-  schema: string,
-  rows: FileRow[],
-  uploadMode: UploadMode,
-  transactionID: string
-): Promise<FixedDataProcessingResult> {
-  let insertedCount = 0;
-  let updatedCount = 0;
-  let skippedCount = 0;
-
-  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
-    const deleteSQL = format(`DELETE FROM ??.attributes WHERE IsActive = 1`, [schema]);
-    await connectionManager.executeQuery(deleteSQL, [], transactionID);
-  }
-
-  for (const row of rows) {
-    const code = normalizeRequiredString(row.code || row.codes);
-    if (!code) {
-      skippedCount += 1;
-      continue;
-    }
-
-    const description = normalizeOptionalString(row.description || row.comments);
-    const status = normalizeOptionalString(row.status);
-
-    if (uploadMode === UploadMode.REVISIONS) {
-      const existingSQL = format(`SELECT Code FROM ??.attributes WHERE LOWER(Code) = LOWER(?) AND IsActive = 1 LIMIT 1`, [schema]);
-      const existingRows = await connectionManager.executeQuery(existingSQL, [code], transactionID);
-
-      if (existingRows.length > 0) {
-        const existingCode = existingRows[0].Code;
-        const updateSQL = format(`UPDATE ??.attributes SET Code = ?, Description = ?, Status = ?, DeletedAt = NULL WHERE Code = ? AND IsActive = 1`, [schema]);
-        await connectionManager.executeQuery(updateSQL, [code, description, status, existingCode], transactionID);
-        updatedCount += 1;
-        continue;
-      }
-    }
-
-    const insertSQL = format(`INSERT INTO ??.attributes (Code, Description, Status, IsActive, DeletedAt) VALUES (?, ?, ?, 1, NULL)`, [schema]);
-    await connectionManager.executeQuery(insertSQL, [code, description, status], transactionID);
-    insertedCount += 1;
-  }
-
-  return { insertedCount, updatedCount, skippedCount };
-}
-
-async function upsertSpeciesRows(
-  connectionManager: ConnectionManager,
-  schema: string,
-  rows: FileRow[],
-  uploadMode: UploadMode,
-  transactionID: string
-): Promise<FixedDataProcessingResult> {
-  let insertedCount = 0;
-  let updatedCount = 0;
-  let skippedCount = 0;
-
-  const duplicateSpeciesCodes = findDuplicateSpeciesCodes(rows);
-  if (duplicateSpeciesCodes.length > 0) {
-    throw new Error(`Species upload contains duplicate SpeciesCode values: ${duplicateSpeciesCodes.join(', ')}`);
-  }
-
-  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
-    // CLEAN_REUPLOAD deletes every active species row before re-inserting the file.
-    // That DELETE is only safe when no live records depend on those SpeciesIDs yet.
-    // trees and specieslimits both reference species via ON DELETE CASCADE, so
-    // including the same SpeciesCode in the upload does NOT preserve downstream data:
-    // the delete would still remove the dependent rows before the replacement
-    // SpeciesID exists. Block the mode entirely once any active species row is in use.
-    const blockingSpeciesSQL = format(
-      `SELECT DISTINCT s.SpeciesCode
-       FROM ??.species s
-       WHERE s.IsActive = 1
-         AND s.SpeciesCode IS NOT NULL
-         AND (
-           EXISTS (
-             SELECT 1
-             FROM ??.trees t
-             WHERE t.SpeciesID = s.SpeciesID
-           )
-           OR EXISTS (
-             SELECT 1
-             FROM ??.specieslimits sl
-             WHERE sl.SpeciesID = s.SpeciesID
-           )
-         )
-       ORDER BY s.SpeciesCode`,
-      [schema, schema, schema]
-    );
-    const blockingSpeciesRows = await connectionManager.executeQuery(blockingSpeciesSQL, [], transactionID);
-    const blockingCodes = Array.isArray(blockingSpeciesRows) ? blockingSpeciesRows.map((row: any) => String(row.SpeciesCode ?? '').trim()).filter(Boolean) : [];
-
-    if (blockingCodes.length > 0) {
-      throw new Error(
-        `Clean re-upload refused: active species rows are already referenced by trees or species limits ` +
-          `for the following SpeciesCode value(s): ${formatBlockedCleanReuploadValues(blockingCodes)}. ` +
-          `Deleting species would cascade-delete dependent records even if the same codes appear in the upload. ` +
-          `Use Revisions Upload instead.`
-      );
-    }
-
-    const deleteSQL = format(`DELETE FROM ??.species WHERE IsActive = 1`, [schema]);
-    await connectionManager.executeQuery(deleteSQL, [], transactionID);
-  }
-
-  for (const row of rows) {
-    const speciesCode = normalizeRequiredString(row.spcode);
-    if (!speciesCode) {
-      skippedCount += 1;
-      continue;
-    }
-
-    let familyID: number | undefined;
-    if (normalizeOptionalString(row.family)) {
-      familyID = (
-        await handleUpsert<FamilyResult>(connectionManager, schema, 'family', { Family: normalizeOptionalString(row.family)! }, 'FamilyID', transactionID)
-      ).id;
-    }
-
-    let genusID: number | undefined;
-    if (normalizeOptionalString(row.genus)) {
-      const genusPayload: Partial<GenusResult> = {
-        Genus: normalizeOptionalString(row.genus)!
-      };
-      if (familyID) {
-        genusPayload.FamilyID = familyID;
-      }
-      genusID = (await handleUpsert<GenusResult>(connectionManager, schema, 'genus', genusPayload, 'GenusID', transactionID)).id;
-    }
-
-    const speciesPayload = {
-      GenusID: genusID ?? null,
-      SpeciesName: normalizeOptionalString(row.species),
-      SubspeciesName: normalizeOptionalString(row.subspecies),
-      IDLevel: normalizeOptionalString(row.idlevel),
-      SpeciesAuthority: normalizeOptionalString(row.authority),
-      SubspeciesAuthority: normalizeOptionalString(row.subauthority)
-    };
-
-    if (uploadMode === UploadMode.REVISIONS) {
-      const existingSQL = format(`SELECT SpeciesID FROM ??.species WHERE LOWER(SpeciesCode) = LOWER(?) AND IsActive = 1 ORDER BY SpeciesID`, [schema]);
-      const existingRows = await connectionManager.executeQuery(existingSQL, [speciesCode], transactionID);
-
-      if (existingRows.length > 1) {
-        throw new Error(`Duplicate active species rows already exist for SpeciesCode "${speciesCode}". Remove the duplicates before uploading revisions.`);
-      }
-
-      if (existingRows.length > 0) {
-        // REVISIONS source-of-truth semantics: every column that the species upload
-        // CSV format can carry is overwritten unconditionally. Fields the row omits
-        // are normalized to NULL by normalizeOptionalString and so wipe whatever was
-        // previously in the database. This is intentional -- the user explicitly
-        // chose Option (a) ("Replace the whole row") when this behavior was
-        // confirmed. If the CSV format ever grows new columns, add them here to
-        // keep the overwrite semantics complete.
-        const updateSQL = format(
-          `UPDATE ??.species
-           SET SpeciesCode = ?, GenusID = ?, SpeciesName = ?, SubspeciesName = ?, IDLevel = ?, SpeciesAuthority = ?, SubspeciesAuthority = ?, DeletedAt = NULL
-           WHERE SpeciesID = ?`,
-          [schema]
-        );
-        await connectionManager.executeQuery(
-          updateSQL,
-          [
-            speciesCode,
-            speciesPayload.GenusID,
-            speciesPayload.SpeciesName,
-            speciesPayload.SubspeciesName,
-            speciesPayload.IDLevel,
-            speciesPayload.SpeciesAuthority,
-            speciesPayload.SubspeciesAuthority,
-            existingRows[0].SpeciesID
-          ],
-          transactionID
-        );
-        updatedCount += 1;
-        continue;
-      }
-    }
-
-    const insertSQL = format(
-      `INSERT INTO ??.species
-       (GenusID, SpeciesCode, SpeciesName, SubspeciesName, IDLevel, SpeciesAuthority, SubspeciesAuthority, IsActive, DeletedAt)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 1, NULL)`,
-      [schema]
-    );
-    await connectionManager.executeQuery(
-      insertSQL,
-      [
-        speciesPayload.GenusID,
-        speciesCode,
-        speciesPayload.SpeciesName,
-        speciesPayload.SubspeciesName,
-        speciesPayload.IDLevel,
-        speciesPayload.SpeciesAuthority,
-        speciesPayload.SubspeciesAuthority
-      ],
-      transactionID
-    );
-    insertedCount += 1;
-  }
-
-  return { insertedCount, updatedCount, skippedCount };
 }
 
 async function upsertPersonnelRows(

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -32,7 +32,8 @@ const mocks = vi.hoisted(() => ({
   runJobIfClaimable: vi.fn(async () => undefined),
   executeQuery: vi.fn(),
   loggerError: vi.fn(),
-  IdempotencyKeyConflictError: class IdempotencyKeyConflictError extends Error {}
+  IdempotencyKeyConflictError: class IdempotencyKeyConflictError extends Error {},
+  BackgroundJobScopeUnavailableError: class BackgroundJobScopeUnavailableError extends Error {}
 }));
 
 vi.mock('@/auth', () => ({
@@ -70,7 +71,8 @@ vi.mock('@/lib/background-jobs/repository', () => ({
 }));
 
 vi.mock('@/lib/background-jobs/errors', () => ({
-  IdempotencyKeyConflictError: mocks.IdempotencyKeyConflictError
+  IdempotencyKeyConflictError: mocks.IdempotencyKeyConflictError,
+  BackgroundJobScopeUnavailableError: mocks.BackgroundJobScopeUnavailableError
 }));
 
 vi.mock('@/config/macros/containernames', () => ({
@@ -398,6 +400,14 @@ describe('POST /api/uploadjobs', () => {
 
   it('returns 409 when an idempotency key belongs to a different request', async () => {
     mocks.createUploadBackgroundJob.mockRejectedValueOnce(new mocks.IdempotencyKeyConflictError('conflict'));
+    const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+    expect(response.status).toBe(409);
+    expect(mocks.runJobIfClaimable).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when teardown removes the site before the job can be created', async () => {
+    mocks.createUploadBackgroundJob.mockRejectedValueOnce(new mocks.BackgroundJobScopeUnavailableError('site disappeared'));
     const response = await callPost(makeCreateRequest(makeCreateBody()));
 
     expect(response.status).toBe(409);

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -14,7 +14,7 @@ import { SUPPORTED_DELIMITERS } from '@/lib/uploads/detect-delimiter';
 import { isAsyncUploadEnabledFor } from '@/lib/background-jobs/feature-gate';
 import { isAllowedAsyncPipeline } from '@/lib/background-jobs/types';
 import { createUploadBackgroundJob, listBackgroundJobs } from '@/lib/background-jobs/repository';
-import { IdempotencyKeyConflictError } from '@/lib/background-jobs/errors';
+import { BackgroundJobScopeUnavailableError, IdempotencyKeyConflictError } from '@/lib/background-jobs/errors';
 import { isPrivilegedSession, MAX_UPLOAD_JOB_REQUEST_BYTES, parseOptionalPositiveInteger } from '@/lib/background-jobs/route-helpers';
 import { runJobIfClaimable } from '@/lib/background-jobs/worker';
 import { fromBody, fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
@@ -427,7 +427,7 @@ async function postHandler(request: NextRequest) {
       userID
     );
   } catch (error) {
-    if (error instanceof IdempotencyKeyConflictError) {
+    if (error instanceof IdempotencyKeyConflictError || error instanceof BackgroundJobScopeUnavailableError) {
       return NextResponse.json({ error: error.message }, { status: HTTPResponses.CONFLICT });
     }
     throw error;

--- a/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
+++ b/frontend/app/api/validations/procedures/shared-cross-census-location/route.ts
@@ -7,9 +7,13 @@ import ailogger from '@/ailogger';
 export const runtime = 'nodejs';
 
 // Cross-census validations JOIN across large tables and can legitimately
-// take well over 10 minutes on 200K+ row datasets. Keep the route budget
-// slightly above the MySQL statement limit so the database can fail first
-// and return an error instead of the client seeing an abrupt disconnect.
+// take well over 10 minutes on 200K+ row datasets. What actually survives
+// Azure App Service's ~240s load-balancer idle timeout is streamWithHeartbeats
+// below — the periodic bytes keep the connection non-idle. maxDuration is
+// advisory: Next.js only records it in the build manifest and Vercel is what
+// enforces it, so it is inert here. It is kept as documentation of the intended
+// budget, set slightly above the MySQL statement limit so the database fails
+// first and the client gets an error rather than an abrupt disconnect.
 export const maxDuration = 1500;
 
 async function handler(request: NextRequest) {

--- a/frontend/app/api/validations/procedures/shared-dbh/route.ts
+++ b/frontend/app/api/validations/procedures/shared-dbh/route.ts
@@ -7,8 +7,11 @@ import ailogger from '@/ailogger';
 export const runtime = 'nodejs';
 
 // DBH growth/shrinkage validations JOIN across large tables and can take
-// several minutes on 200K+ row datasets.  Match the cross-census location
-// route's 10-minute ceiling so Azure doesn't kill the request early.
+// several minutes on 200K+ row datasets. streamWithHeartbeats below is what
+// keeps Azure from killing the request early — not this value. maxDuration is
+// advisory (Next.js records it in the build manifest; only Vercel enforces it)
+// and documents the intended 10-minute budget alongside the cross-census
+// location route.
 export const maxDuration = 600;
 
 async function handler(request: NextRequest) {

--- a/frontend/db/sql/storedprocedures.sql
+++ b/frontend/db/sql/storedprocedures.sql
@@ -16,8 +16,8 @@ drop procedure if exists reinsertdefaultpostvalidations;
 
 DELIMITER $$
 
-create
-    definer = azureroot@`%` procedure RefreshMeasurementsSummary()
+create procedure RefreshMeasurementsSummary()
+SQL SECURITY DEFINER
 BEGIN
     SET foreign_key_checks = 0;
     TRUNCATE measurementssummary;
@@ -107,8 +107,8 @@ BEGIN
     SET foreign_key_checks = 1;
 END $$
 
-create
-    definer = azureroot@`%` procedure RefreshViewFullTable()
+create procedure RefreshViewFullTable()
+SQL SECURITY DEFINER
 BEGIN
     -- Disable foreign key checks temporarily
     SET foreign_key_checks = 0;
@@ -245,8 +245,8 @@ BEGIN
     SET foreign_key_checks = 1;
 END $$
 
-create
-    definer = azureroot@`%` procedure bulkingestioncollapser(IN vCensusID int)
+create procedure bulkingestioncollapser(IN vCensusID int)
+SQL SECURITY DEFINER
 begin
     DECLARE vErrorMessage TEXT DEFAULT '';
     DECLARE vErrorCode VARCHAR(10) DEFAULT '';
@@ -402,8 +402,8 @@ begin
                   vTreeStemTagDupCount, ' TreeTag+StemTag additional rows.') as message;
 end $$
 
-create
-    definer = azureroot@`%` procedure clearcensusfull(IN targetCensusID int)
+create procedure clearcensusfull(IN targetCensusID int)
+SQL SECURITY DEFINER
 BEGIN
     declare vCountCensus int;
     -- Disable triggers to prevent changelog tracking during bulk census deletion
@@ -459,8 +459,8 @@ BEGIN
     set @disable_triggers = 0;
 END $$
 
-create
-    definer = azureroot@`%` procedure clearcensusmsmts(IN targetCensusID int)
+create procedure clearcensusmsmts(IN targetCensusID int)
+SQL SECURITY DEFINER
 BEGIN
     -- Disable triggers to prevent changelog tracking during bulk census deletion
     set @disable_triggers = 1;
@@ -504,8 +504,8 @@ END $$
 -- reingestfailedrows removed: operated on legacy failedmeasurements table.
 -- Reingestion now handled via API routes using coremeasurements (StemGUID=NULL) rows.
 
-create
-    definer = azureroot@`%` procedure reinsertdefaultpostvalidations()
+create procedure reinsertdefaultpostvalidations()
+SQL SECURITY DEFINER
 begin
     truncate postvalidationqueries; -- clear the table if re-running this script on accident
     insert into postvalidationqueries
@@ -770,13 +770,13 @@ end $$
 -- Single source of truth for the shared DBH change candidate logic used by ValidationIDs 1 and 2.
 -- Keep both validation definitions as CALLs to this helper. Do not duplicate or inline this SQL
 -- in future enhancements, or the growth/shrinkage semantics and dead-status handling will drift.
-create
-    definer = azureroot@`%` procedure RunSharedDBHChangeValidations(
+create procedure RunSharedDBHChangeValidations(
     IN p_CensusID int,
     IN p_PlotID int,
     IN p_RunGrowth tinyint,
     IN p_RunShrinkage tinyint
 )
+SQL SECURITY DEFINER
 shared_dbh:
 BEGIN
     DECLARE vRunGrowth tinyint DEFAULT 0;
@@ -945,13 +945,13 @@ END $$
 -- Single source of truth for the shared cross-census location candidate logic used by ValidationIDs 17 and 18.
 -- Keep both validation definitions as CALLs to this helper. Do not duplicate or inline this SQL
 -- in future enhancements, or quadrat-mismatch / coordinate-drift semantics can drift between paths.
-create
-    definer = azureroot@`%` procedure RunSharedCrossCensusLocationValidations(
+create procedure RunSharedCrossCensusLocationValidations(
     IN p_CensusID int,
     IN p_PlotID int,
     IN p_RunQuadratMismatch tinyint,
     IN p_RunCoordinateDrift tinyint
 )
+SQL SECURITY DEFINER
 shared_cross_census_location:
 BEGIN
     DECLARE vRunQuadratMismatch tinyint DEFAULT 0;
@@ -1180,8 +1180,8 @@ BEGIN
     DROP TEMPORARY TABLE IF EXISTS current_cross_census_previous_map;
 END $$
 
-create
-    definer = azureroot@`%` procedure reinsertdefaultvalidations()
+create procedure reinsertdefaultvalidations()
+SQL SECURITY DEFINER
 begin
     set foreign_key_checks = 0;
 
@@ -1527,8 +1527,8 @@ DELIMITER ;
 DROP PROCEDURE IF EXISTS bulkingestionprocess;
 DELIMITER $$
 
-CREATE
-    DEFINER = azureroot@`%` PROCEDURE bulkingestionprocess(IN vFileID varchar(36), IN vBatchID varchar(36))
+CREATE PROCEDURE bulkingestionprocess(IN vFileID varchar(36), IN vBatchID varchar(36))
+SQL SECURITY DEFINER
 main_proc:
 BEGIN
     DECLARE vCurrentCensusID int;

--- a/frontend/lib/background-jobs/errors.ts
+++ b/frontend/lib/background-jobs/errors.ts
@@ -25,6 +25,20 @@ export class IdempotencyKeyConflictError extends Error {
   }
 }
 
+export class BackgroundJobScopeUnavailableError extends Error {
+  constructor(
+    public readonly schemaName: string,
+    public readonly reason: 'operation_in_progress' | 'site_not_registered'
+  ) {
+    super(
+      reason === 'operation_in_progress'
+        ? `Upload job creation is unavailable while schema "${schemaName}" is being provisioned or torn down`
+        : `Upload job creation refused because schema "${schemaName}" is no longer registered`
+    );
+    this.name = 'BackgroundJobScopeUnavailableError';
+  }
+}
+
 /**
  * Thrown by the worker when a job can never succeed no matter how many times it
  * is retried (unsupported form-type routing, malformed file content, validation

--- a/frontend/lib/background-jobs/repository.ts
+++ b/frontend/lib/background-jobs/repository.ts
@@ -1,6 +1,7 @@
 import type { Pool, PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 import { ensureBackgroundJobCatalogTables } from './catalog';
-import { IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from './errors';
+import { BackgroundJobScopeUnavailableError, IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from './errors';
+import { releaseSchemaOperationLock, tryAcquireSchemaOperationLock } from '@/lib/provisioning/schema-operation-lock';
 import type {
   BackgroundJobEventRecord,
   BackgroundJobFileRecord,
@@ -283,8 +284,23 @@ export async function createUploadBackgroundJob(catalogPool: Pool, input: Create
   await ensureBackgroundJobCatalogTables(catalogPool);
 
   const conn = await catalogPool.getConnection();
+  let schemaLockHeld = false;
   try {
+    schemaLockHeld = await tryAcquireSchemaOperationLock(conn, input.schema);
+    if (!schemaLockHeld) {
+      throw new BackgroundJobScopeUnavailableError(input.schema, 'operation_in_progress');
+    }
+
     await conn.beginTransaction();
+
+    // Authorization happens before this repository call and can race with an
+    // admin teardown. Recheck after acquiring the same lock as teardown: if
+    // teardown won, its catalog-site delete is now visible and no runnable job
+    // may be inserted for the dropped schema.
+    const [siteRows] = await conn.query<RowDataPacket[]>(`SELECT SiteID FROM catalog.sites WHERE SchemaName = ? LIMIT 1`, [input.schema]);
+    if (siteRows.length === 0) {
+      throw new BackgroundJobScopeUnavailableError(input.schema, 'site_not_registered');
+    }
 
     const totalRows = input.files.reduce((sum, file) => sum + Number(file.expectedRows ?? 0), 0);
     let jobID: number;
@@ -364,6 +380,7 @@ export async function createUploadBackgroundJob(catalogPool: Pool, input: Create
     await conn.rollback();
     throw err;
   } finally {
+    if (schemaLockHeld) await releaseSchemaOperationLock(conn, input.schema);
     conn.release();
   }
 }

--- a/frontend/lib/background-jobs/types.ts
+++ b/frontend/lib/background-jobs/types.ts
@@ -6,6 +6,20 @@ export type BackgroundJobType = (typeof BACKGROUND_JOB_TYPES)[number];
 export const BACKGROUND_JOB_STATUSES = ['queued', 'running', 'cancel_requested', 'waiting_retry', 'completed', 'failed', 'cancelled'] as const;
 export type BackgroundJobStatus = (typeof BACKGROUND_JOB_STATUSES)[number];
 
+/**
+ * Statuses a job can still leave on its own. A job in any of these will be
+ * picked up again — `findRunnableJobIDs` selects on status and NextAttemptAt
+ * and never checks that the job's schema still exists — so dropping the site
+ * schema out from under one leaves the sweeper dispatching at a database that
+ * is gone. Provisioning teardown refuses while any of these remain.
+ */
+export const NON_TERMINAL_BACKGROUND_JOB_STATUSES = [
+  'queued',
+  'running',
+  'cancel_requested',
+  'waiting_retry'
+] as const satisfies readonly BackgroundJobStatus[];
+
 export const UPLOAD_JOB_PHASES = [
   'queued',
   'staging',

--- a/frontend/lib/provisioning/orchestrator.ts
+++ b/frontend/lib/provisioning/orchestrator.ts
@@ -8,6 +8,7 @@ import { auditAttempt, auditSuccess, auditFailure } from './audit';
 import { dispatchRun, getWorkerPid, HEARTBEAT_STALE_MS, isRunOwnedByCurrentWorker } from './worker';
 import { ProvisioningInputSchema } from './input-schema';
 import { areaSelectionOptions, unitSelectionOptions } from '@/config/macros';
+import { NON_TERMINAL_BACKGROUND_JOB_STATUSES } from '@/lib/background-jobs/types';
 import ailogger from '@/ailogger';
 
 // Bootstrap DDL inlined so the catalog tables can be created without any
@@ -667,6 +668,44 @@ interface DeleteCatalogSiteRowsAndSchemaOptions {
   actor: string;
   ignoreUserRelationsDeleteError?: boolean;
   requireExactlyOneCatalogSite?: boolean;
+  /**
+   * Refuse when a background upload job for this schema can still run. Only
+   * teardown sets it: a failed provisioning run never reached a state where an
+   * upload job could exist, so abort deletes unconditionally.
+   */
+  blockOnActiveBackgroundJobs?: boolean;
+}
+
+/**
+ * Background jobs are keyed to a schema by name, and nothing re-checks that the
+ * schema exists before the sweeper dispatches them. Terminal rows are deleted
+ * with the site; live ones block the teardown so an admin cannot strand a
+ * running ingestion against a database that is about to disappear.
+ */
+async function settleBackgroundJobsForSchema(conn: PoolConnection, schemaName: string): Promise<void> {
+  const [liveRows]: any = await conn.query(
+    `SELECT JobID, Status FROM catalog.background_jobs
+      WHERE SchemaName = ? AND Status IN (?)
+      ORDER BY JobID`,
+    [schemaName, [...NON_TERMINAL_BACKGROUND_JOB_STATUSES]]
+  );
+  if (liveRows.length > 0) {
+    const described = liveRows.map((row: any) => `${row.JobID} (${row.Status})`).join(', ');
+    throw new ProvisioningError(
+      `Refusing to tear down ${schemaName}: ${liveRows.length} background upload job(s) can still run — ${described}. ` + `Cancel or let them finish first.`,
+      'conflict',
+      // ProvisioningError.meta is a deliberately narrow shape; the offending job
+      // IDs travel in the message, which errorToClientMessage passes through
+      // verbatim for 'conflict'.
+      { schemaName }
+    );
+  }
+
+  // FK-safe order: events -> files -> jobs.
+  const jobIdSubquery = `SELECT JobID FROM catalog.background_jobs WHERE SchemaName = ?`;
+  await conn.query(`DELETE FROM catalog.background_job_events WHERE JobID IN (${jobIdSubquery})`, [schemaName]);
+  await conn.query(`DELETE FROM catalog.background_job_files WHERE JobID IN (${jobIdSubquery})`, [schemaName]);
+  await conn.query(`DELETE FROM catalog.background_jobs WHERE SchemaName = ?`, [schemaName]);
 }
 
 async function deleteCatalogSiteRowsAndSchema(catalogPool: Pool, schemaName: string, options: DeleteCatalogSiteRowsAndSchemaOptions): Promise<void> {
@@ -686,6 +725,9 @@ async function deleteCatalogSiteRowsAndSchema(catalogPool: Pool, schemaName: str
       const [siteRows]: any = await conn.query(`SELECT SiteID FROM catalog.sites WHERE SchemaName = ?`, [schemaName]);
       if (options.requireExactlyOneCatalogSite && siteRows.length !== 1) {
         throw new ProvisioningError(`Catalog state mismatch for schema: expected 1 site row, found ${siteRows.length}`, 'conflict', { schemaName });
+      }
+      if (options.blockOnActiveBackgroundJobs) {
+        await settleBackgroundJobsForSchema(conn, schemaName);
       }
       for (const row of siteRows) {
         const siteId = row.SiteID ?? row.siteid;
@@ -736,7 +778,8 @@ export async function teardownProvisionedSite(runId: number, confirmSchemaName: 
     await deleteCatalogSiteRowsAndSchema(catalogPool, run.schemaName, {
       actionLabel: 'teardown provisioned site',
       actor: startedBy,
-      requireExactlyOneCatalogSite: true
+      requireExactlyOneCatalogSite: true,
+      blockOnActiveBackgroundJobs: true
     });
     await setRunStatus(catalogPool, runId, 'aborted');
     auditSuccess({ action: 'teardown', user: startedBy, runId, schemaName: run.schemaName });

--- a/frontend/lib/provisioning/orchestrator.ts
+++ b/frontend/lib/provisioning/orchestrator.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import { z } from 'zod';
 import type { Pool, PoolConnection, ResultSetHeader } from 'mysql2/promise';
 import type { ProvisioningInput, ProvisioningRunRecord, ProvisioningStepRecord, StepContext, RunStatus, StepStatus } from './types';
@@ -9,6 +8,7 @@ import { dispatchRun, getWorkerPid, HEARTBEAT_STALE_MS, isRunOwnedByCurrentWorke
 import { ProvisioningInputSchema } from './input-schema';
 import { areaSelectionOptions, unitSelectionOptions } from '@/config/macros';
 import { NON_TERMINAL_BACKGROUND_JOB_STATUSES } from '@/lib/background-jobs/types';
+import { releaseSchemaOperationLock, tryAcquireSchemaOperationLock } from './schema-operation-lock';
 import ailogger from '@/ailogger';
 
 // Bootstrap DDL inlined so the catalog tables can be created without any
@@ -364,20 +364,14 @@ const SCHEMA_PATTERN = /^forestgeo_[a-z0-9_]+$/;
 export const STUCK_THRESHOLD_MS = 5 * 60 * 1000;
 const STALLED_RUN_ERROR_MESSAGE = 'Run stalled without an active provisioning worker';
 
-function lockNameForSchema(schemaName: string): string {
-  return `provisioning:${createHash('sha256').update(schemaName).digest('hex').slice(0, 48)}`;
-}
-
 async function acquireSchemaLock(conn: PoolConnection, schemaName: string): Promise<void> {
-  const [rows]: any = await conn.query(`SELECT GET_LOCK(?, 10) AS gotLock`, [lockNameForSchema(schemaName)]);
-  const gotLock = Number(rows[0]?.gotLock ?? rows[0]?.gotlock ?? 0);
-  if (gotLock !== 1) {
+  if (!(await tryAcquireSchemaOperationLock(conn, schemaName))) {
     throw new ProvisioningError(`Could not acquire provisioning lock for schema ${schemaName}`, 'conflict', { schemaName });
   }
 }
 
 async function releaseSchemaLock(conn: PoolConnection, schemaName: string): Promise<void> {
-  await conn.query(`SELECT RELEASE_LOCK(?)`, [lockNameForSchema(schemaName)]).catch(() => {});
+  await releaseSchemaOperationLock(conn, schemaName);
 }
 
 export async function startRun(args: StartRunArgs): Promise<{ runId: number }> {

--- a/frontend/lib/provisioning/schema-operation-lock.ts
+++ b/frontend/lib/provisioning/schema-operation-lock.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'crypto';
+import type { PoolConnection } from 'mysql2/promise';
+
+const DEFAULT_LOCK_TIMEOUT_SECONDS = 10;
+
+/**
+ * Keep the historical `provisioning:` prefix so mixed-version deployments
+ * synchronize with orchestrators that still define this lock locally.
+ */
+function lockNameForSchema(schemaName: string): string {
+  return `provisioning:${createHash('sha256').update(schemaName).digest('hex').slice(0, 48)}`;
+}
+
+/**
+ * Serializes lifecycle operations that can create or destroy schema-bound work.
+ * The lock is connection-scoped, so callers must release it before returning
+ * the connection to its pool.
+ */
+export async function tryAcquireSchemaOperationLock(conn: PoolConnection, schemaName: string, timeoutSeconds = DEFAULT_LOCK_TIMEOUT_SECONDS): Promise<boolean> {
+  const [rows]: any = await conn.query(`SELECT GET_LOCK(?, ?) AS gotLock`, [lockNameForSchema(schemaName), timeoutSeconds]);
+  return Number(rows[0]?.gotLock ?? rows[0]?.gotlock ?? 0) === 1;
+}
+
+export async function releaseSchemaOperationLock(conn: PoolConnection, schemaName: string): Promise<void> {
+  await conn.query(`SELECT RELEASE_LOCK(?)`, [lockNameForSchema(schemaName)]).catch(() => {});
+}

--- a/frontend/lib/provisioning/sql-runner.test.ts
+++ b/frontend/lib/provisioning/sql-runner.test.ts
@@ -25,14 +25,23 @@ describe('splitSqlFile', () => {
   it('preserves stored procedure bodies across DELIMITER blocks', () => {
     const content = readFileSync(PROCS_FILE, 'utf-8');
     const stmts = splitSqlFile(content);
-    // The actual DDL uses "CREATE\n    DEFINER = ... PROCEDURE bulkingestionprocess" across multiple lines
     const bulkIngestion = stmts.find(s => /CREATE[\s\S]*?PROCEDURE\s+`?bulkingestionprocess/i.test(s.sql));
     expect(bulkIngestion).toBeDefined();
     expect(bulkIngestion!.sql).toContain('BEGIN');
     expect(bulkIngestion!.sql).toContain('END');
-    // Verify exactly one procedure definition — the DDL uses "CREATE\n    DEFINER = ... PROCEDURE name"
-    // so we match on the procedure name appearing exactly once rather than the literal "CREATE PROCEDURE"
     expect((bulkIngestion!.sql.match(/PROCEDURE\s+`?bulkingestionprocess/gi) ?? []).length).toBe(1);
+  });
+
+  it('uses the deployment account as the definer for every stored procedure', () => {
+    const statements = splitSqlFile(readFileSync(PROCS_FILE, 'utf-8'));
+    const procedures = statements.filter(statement => /CREATE\s+PROCEDURE\b/i.test(statement.sql));
+
+    expect(procedures).toHaveLength(10);
+    for (const procedure of procedures) {
+      expect(procedure.sql).toMatch(/SQL SECURITY DEFINER/i);
+      expect(procedure.sql).not.toMatch(/DEFINER\s*=/i);
+      expect(procedure.sql).not.toMatch(/azureroot/i);
+    }
   });
 
   it('parses corequeries.sql without errors', () => {

--- a/frontend/lib/provisioning/steps/sql-steps.test.ts
+++ b/frontend/lib/provisioning/steps/sql-steps.test.ts
@@ -81,11 +81,12 @@ describe('SQL-file steps', () => {
       `SELECT SchemaVersion, TablesDeployedAt, ProceduresDeployedAt, ValidationsDeployedAt
        FROM \`${SCHEMA_NAME}\`.\`_provisioning_meta\``
     );
-    expect(rows).toHaveLength(1);
-    expect(rows[0].SchemaVersion).toBe('2026-05-13');
-    expect(rows[0].TablesDeployedAt).not.toBeNull();
-    expect(rows[0].ProceduresDeployedAt).not.toBeNull();
-    expect(rows[0].ValidationsDeployedAt).not.toBeNull();
+    expect(rows).toHaveLength(2);
+    const schemaRow = rows.find((row: any) => row.SchemaVersion === '2026-05-13');
+    const proceduresRow = rows.find((row: any) => row.SchemaVersion === '2026-07-30');
+    expect(schemaRow.TablesDeployedAt).not.toBeNull();
+    expect(schemaRow.ValidationsDeployedAt).not.toBeNull();
+    expect(proceduresRow.ProceduresDeployedAt).not.toBeNull();
   });
 
   it('init_tables alreadyDone: false when meta exists with stale version but objects are present', async () => {

--- a/frontend/lib/provisioning/steps/sql-steps.ts
+++ b/frontend/lib/provisioning/steps/sql-steps.ts
@@ -19,14 +19,14 @@ const META_TABLE = '_provisioning_meta';
 
 const VALIDATIONS_TABLE = 'sitespecificvalidations';
 const REQUIRED_TABLES = ['plots', 'census', 'quadrats', 'coremeasurements', 'measurement_errors', 'uploadmetrics', 'validation_runs'] as const;
-const REQUIRED_VIEWS = ['uploaddatalossreport'] as const;
+export const REQUIRED_VIEWS = ['uploaddatalossreport'] as const;
 
 /**
  * Canonical list of stored procedures defined in storedprocedures.sql.
  * Discovered by grepping `DEFINER ... PROCEDURE <name>` declarations.
  * Names are case-insensitively compared against information_schema.routines.
  */
-const REQUIRED_PROCEDURES = [
+export const REQUIRED_PROCEDURES = [
   'bulkingestionprocess',
   'bulkingestioncollapser',
   'clearcensusfull',

--- a/frontend/lib/provisioning/steps/sql-steps.ts
+++ b/frontend/lib/provisioning/steps/sql-steps.ts
@@ -9,12 +9,12 @@ const PROCS_FILE = () => path.join(process.cwd(), 'db/sql/storedprocedures.sql')
 const QUERIES_FILE = () => path.join(process.cwd(), 'db/sql/corequeries.sql');
 
 /**
- * Schema version stamp. Bump this date when DDL, stored procedures, or seeded
- * validations change in a way that requires re-running provisioning. The
- * `alreadyDone` checks compare this to the `SchemaVersion` row in
- * `_provisioning_meta` so partial or stale deploys are reprovisioned.
+ * Table/validation and procedure stamps are intentionally independent. Table
+ * DDL is not fully idempotent, so a procedure-only change must not make
+ * initTablesStep replay tablestructures.sql against an existing schema.
  */
 const SCHEMA_VERSION = '2026-05-13';
+const PROCEDURES_SCHEMA_VERSION = '2026-07-30';
 const META_TABLE = '_provisioning_meta';
 
 const VALIDATIONS_TABLE = 'sitespecificvalidations';
@@ -23,7 +23,6 @@ export const REQUIRED_VIEWS = ['uploaddatalossreport'] as const;
 
 /**
  * Canonical list of stored procedures defined in storedprocedures.sql.
- * Discovered by grepping `DEFINER ... PROCEDURE <name>` declarations.
  * Names are case-insensitively compared against information_schema.routines.
  */
 export const REQUIRED_PROCEDURES = [
@@ -69,7 +68,7 @@ async function ensureMetaTable(ctx: StepContext): Promise<void> {
   );
 }
 
-async function readMetaRow(ctx: StepContext): Promise<ProvisioningMetaRow | null> {
+async function readMetaRow(ctx: StepContext, schemaVersion: string = SCHEMA_VERSION): Promise<ProvisioningMetaRow | null> {
   if (!ctx.sitePool) return null;
   try {
     const [rows]: any = await ctx.sitePool.query(
@@ -77,7 +76,7 @@ async function readMetaRow(ctx: StepContext): Promise<ProvisioningMetaRow | null
        FROM \`${ctx.schemaName}\`.\`${META_TABLE}\`
        WHERE SchemaVersion = ?
        LIMIT 1`,
-      [SCHEMA_VERSION]
+      [schemaVersion]
     );
     return (rows[0] as ProvisioningMetaRow) ?? null;
   } catch {
@@ -86,26 +85,36 @@ async function readMetaRow(ctx: StepContext): Promise<ProvisioningMetaRow | null
   }
 }
 
-async function writeMetaTimestamp(ctx: StepContext, column: 'TablesDeployedAt' | 'ProceduresDeployedAt' | 'ValidationsDeployedAt'): Promise<void> {
+async function writeMetaTimestamp(
+  ctx: StepContext,
+  column: 'TablesDeployedAt' | 'ProceduresDeployedAt' | 'ValidationsDeployedAt',
+  schemaVersion: string = SCHEMA_VERSION
+): Promise<void> {
   if (!ctx.sitePool) return;
   validateSchemaOrThrow(ctx.schemaName);
   await ctx.sitePool.query(
     `INSERT INTO \`${ctx.schemaName}\`.\`${META_TABLE}\` (SchemaVersion, ${column})
      VALUES (?, NOW())
      ON DUPLICATE KEY UPDATE ${column} = NOW()`,
-    [SCHEMA_VERSION]
+    [schemaVersion]
   );
 }
 
 async function hasAllRequiredProcedures(ctx: StepContext): Promise<boolean> {
   if (!ctx.sitePool) return false;
   const [rows]: any = await ctx.sitePool.query(
-    `SELECT LOWER(routine_name) AS name FROM information_schema.routines
+    `SELECT LOWER(routine_name) AS name,
+            LOWER(definer) AS definer,
+            LOWER(CURRENT_USER()) AS deployment_account
+       FROM information_schema.routines
      WHERE routine_schema = ? AND routine_type = 'PROCEDURE'`,
     [ctx.schemaName]
   );
-  const existing = new Set(rows.map((r: any) => String(r.name ?? r.NAME ?? '').toLowerCase()));
-  return REQUIRED_PROCEDURES.every(name => existing.has(name.toLowerCase()));
+  const expectedDefiner = String(rows[0]?.deployment_account ?? rows[0]?.DEPLOYMENT_ACCOUNT ?? '').toLowerCase();
+  if (!expectedDefiner) return false;
+
+  const existing = new Map(rows.map((r: any) => [String(r.name ?? r.NAME ?? '').toLowerCase(), String(r.definer ?? r.DEFINER ?? '').toLowerCase()]));
+  return REQUIRED_PROCEDURES.every(name => existing.get(name.toLowerCase()) === expectedDefiner);
 }
 
 function buildSitePool(schemaName: string): mysql.Pool {
@@ -205,7 +214,7 @@ export const deployProceduresStep: ProvisioningStep = {
   label: 'Deploy stored procedures',
   async alreadyDone(ctx: StepContext): Promise<boolean> {
     if (!ctx.sitePool) return false;
-    const meta = await readMetaRow(ctx);
+    const meta = await readMetaRow(ctx, PROCEDURES_SCHEMA_VERSION);
     if (!meta || meta.ProceduresDeployedAt == null) return false;
     return hasAllRequiredProcedures(ctx);
   },
@@ -213,7 +222,7 @@ export const deployProceduresStep: ProvisioningStep = {
     if (!ctx.sitePool) throw new Error('sitePool not initialized');
     await executeSqlFile(ctx.sitePool, PROCS_FILE(), ctx.schemaName);
     await ensureMetaTable(ctx);
-    await writeMetaTimestamp(ctx, 'ProceduresDeployedAt');
+    await writeMetaTimestamp(ctx, 'ProceduresDeployedAt', PROCEDURES_SCHEMA_VERSION);
   }
 };
 

--- a/frontend/lib/uploads/reference-data-writers.ts
+++ b/frontend/lib/uploads/reference-data-writers.ts
@@ -1,0 +1,279 @@
+/**
+ * Reference-data writers for the fixed-data upload path (attributes, species).
+ *
+ * These live outside `app/api/sqlpacketload/route.ts` for two reasons: a Next.js
+ * route module may only export route fields, so nothing else can import them
+ * from there; and DB write logic does not belong in a request handler. The route
+ * dispatches to them by formType; the provisioned-site lifecycle test seeds a
+ * fresh schema through them so its reference data is written by production code
+ * rather than parallel test SQL.
+ *
+ * Moved verbatim from the route — no behavior change.
+ */
+import type ConnectionManager from '@/lib/db/connectionmanager';
+import type { FileRow } from '@/config/macros/formdetails';
+import { UploadMode } from '@/config/uploadmodes';
+import { format } from 'mysql2/promise';
+import { handleUpsert } from '@/config/utils';
+import { FamilyResult, GenusResult } from '@/lib/db/definitions/taxonomies';
+import type { QuadratOverlapSummary } from '@/lib/provisioning/quadrat-collection-validation';
+
+export interface FixedDataProcessingResult {
+  insertedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  // Quadrat uploads only: bounded overlap reports plus complete layout signatures explicitly
+  // acknowledged as field measurements and recorded in the file changelog.
+  acknowledgedOverlapSummaries?: QuadratOverlapSummary[];
+}
+
+export function normalizeOptionalString(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized === '' ? null : normalized;
+}
+
+export function normalizeRequiredString(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function findDuplicateSpeciesCodes(rows: FileRow[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  for (const row of rows) {
+    const speciesCode = normalizeOptionalString(row.spcode)?.toLowerCase();
+    if (!speciesCode) continue;
+    if (seen.has(speciesCode)) {
+      duplicates.add(speciesCode);
+      continue;
+    }
+    seen.add(speciesCode);
+  }
+
+  return Array.from(duplicates).sort();
+}
+
+/** Shared cap for every user-facing list of blocked values / validation issues, so a
+ *  single bad file (hundreds of blocked names, hundreds of failed rows) cannot produce an
+ *  unbounded run-on error message. */
+export const MAX_LISTED_ISSUES = 20;
+
+/** Joins `items` with `separator`, truncating at `maxItems` and appending an "...and N more"
+ *  tail instead of listing everything, so there is one truncation style, not one per caller. */
+export function truncateAndJoin(items: string[], separator: string, maxItems: number = MAX_LISTED_ISSUES): string {
+  const truncatedItems = items.slice(0, maxItems);
+  const remainingCount = items.length - truncatedItems.length;
+  return truncatedItems.join(separator) + (remainingCount > 0 ? `${separator}...and ${remainingCount} more` : '');
+}
+
+function formatBlockedCleanReuploadValues(values: string[], maxValues: number = MAX_LISTED_ISSUES): string {
+  const uniqueValues = Array.from(new Set(values.map(value => String(value ?? '').trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
+  return truncateAndJoin(uniqueValues, ', ', maxValues);
+}
+
+export async function upsertAttributeRows(
+  connectionManager: ConnectionManager,
+  schema: string,
+  rows: FileRow[],
+  uploadMode: UploadMode,
+  transactionID: string
+): Promise<FixedDataProcessingResult> {
+  let insertedCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+
+  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
+    const deleteSQL = format(`DELETE FROM ??.attributes WHERE IsActive = 1`, [schema]);
+    await connectionManager.executeQuery(deleteSQL, [], transactionID);
+  }
+
+  for (const row of rows) {
+    const code = normalizeRequiredString(row.code || row.codes);
+    if (!code) {
+      skippedCount += 1;
+      continue;
+    }
+
+    const description = normalizeOptionalString(row.description || row.comments);
+    const status = normalizeOptionalString(row.status);
+
+    if (uploadMode === UploadMode.REVISIONS) {
+      const existingSQL = format(`SELECT Code FROM ??.attributes WHERE LOWER(Code) = LOWER(?) AND IsActive = 1 LIMIT 1`, [schema]);
+      const existingRows = await connectionManager.executeQuery(existingSQL, [code], transactionID);
+
+      if (existingRows.length > 0) {
+        const existingCode = existingRows[0].Code;
+        const updateSQL = format(`UPDATE ??.attributes SET Code = ?, Description = ?, Status = ?, DeletedAt = NULL WHERE Code = ? AND IsActive = 1`, [schema]);
+        await connectionManager.executeQuery(updateSQL, [code, description, status, existingCode], transactionID);
+        updatedCount += 1;
+        continue;
+      }
+    }
+
+    const insertSQL = format(`INSERT INTO ??.attributes (Code, Description, Status, IsActive, DeletedAt) VALUES (?, ?, ?, 1, NULL)`, [schema]);
+    await connectionManager.executeQuery(insertSQL, [code, description, status], transactionID);
+    insertedCount += 1;
+  }
+
+  return { insertedCount, updatedCount, skippedCount };
+}
+
+export async function upsertSpeciesRows(
+  connectionManager: ConnectionManager,
+  schema: string,
+  rows: FileRow[],
+  uploadMode: UploadMode,
+  transactionID: string
+): Promise<FixedDataProcessingResult> {
+  let insertedCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+
+  const duplicateSpeciesCodes = findDuplicateSpeciesCodes(rows);
+  if (duplicateSpeciesCodes.length > 0) {
+    throw new Error(`Species upload contains duplicate SpeciesCode values: ${duplicateSpeciesCodes.join(', ')}`);
+  }
+
+  if (uploadMode === UploadMode.CLEAN_REUPLOAD) {
+    // CLEAN_REUPLOAD deletes every active species row before re-inserting the file.
+    // That DELETE is only safe when no live records depend on those SpeciesIDs yet.
+    // trees and specieslimits both reference species via ON DELETE CASCADE, so
+    // including the same SpeciesCode in the upload does NOT preserve downstream data:
+    // the delete would still remove the dependent rows before the replacement
+    // SpeciesID exists. Block the mode entirely once any active species row is in use.
+    const blockingSpeciesSQL = format(
+      `SELECT DISTINCT s.SpeciesCode
+       FROM ??.species s
+       WHERE s.IsActive = 1
+         AND s.SpeciesCode IS NOT NULL
+         AND (
+           EXISTS (
+             SELECT 1
+             FROM ??.trees t
+             WHERE t.SpeciesID = s.SpeciesID
+           )
+           OR EXISTS (
+             SELECT 1
+             FROM ??.specieslimits sl
+             WHERE sl.SpeciesID = s.SpeciesID
+           )
+         )
+       ORDER BY s.SpeciesCode`,
+      [schema, schema, schema]
+    );
+    const blockingSpeciesRows = await connectionManager.executeQuery(blockingSpeciesSQL, [], transactionID);
+    const blockingCodes = Array.isArray(blockingSpeciesRows) ? blockingSpeciesRows.map((row: any) => String(row.SpeciesCode ?? '').trim()).filter(Boolean) : [];
+
+    if (blockingCodes.length > 0) {
+      throw new Error(
+        `Clean re-upload refused: active species rows are already referenced by trees or species limits ` +
+          `for the following SpeciesCode value(s): ${formatBlockedCleanReuploadValues(blockingCodes)}. ` +
+          `Deleting species would cascade-delete dependent records even if the same codes appear in the upload. ` +
+          `Use Revisions Upload instead.`
+      );
+    }
+
+    const deleteSQL = format(`DELETE FROM ??.species WHERE IsActive = 1`, [schema]);
+    await connectionManager.executeQuery(deleteSQL, [], transactionID);
+  }
+
+  for (const row of rows) {
+    const speciesCode = normalizeRequiredString(row.spcode);
+    if (!speciesCode) {
+      skippedCount += 1;
+      continue;
+    }
+
+    let familyID: number | undefined;
+    if (normalizeOptionalString(row.family)) {
+      familyID = (
+        await handleUpsert<FamilyResult>(connectionManager, schema, 'family', { Family: normalizeOptionalString(row.family)! }, 'FamilyID', transactionID)
+      ).id;
+    }
+
+    let genusID: number | undefined;
+    if (normalizeOptionalString(row.genus)) {
+      const genusPayload: Partial<GenusResult> = {
+        Genus: normalizeOptionalString(row.genus)!
+      };
+      if (familyID) {
+        genusPayload.FamilyID = familyID;
+      }
+      genusID = (await handleUpsert<GenusResult>(connectionManager, schema, 'genus', genusPayload, 'GenusID', transactionID)).id;
+    }
+
+    const speciesPayload = {
+      GenusID: genusID ?? null,
+      SpeciesName: normalizeOptionalString(row.species),
+      SubspeciesName: normalizeOptionalString(row.subspecies),
+      IDLevel: normalizeOptionalString(row.idlevel),
+      SpeciesAuthority: normalizeOptionalString(row.authority),
+      SubspeciesAuthority: normalizeOptionalString(row.subauthority)
+    };
+
+    if (uploadMode === UploadMode.REVISIONS) {
+      const existingSQL = format(`SELECT SpeciesID FROM ??.species WHERE LOWER(SpeciesCode) = LOWER(?) AND IsActive = 1 ORDER BY SpeciesID`, [schema]);
+      const existingRows = await connectionManager.executeQuery(existingSQL, [speciesCode], transactionID);
+
+      if (existingRows.length > 1) {
+        throw new Error(`Duplicate active species rows already exist for SpeciesCode "${speciesCode}". Remove the duplicates before uploading revisions.`);
+      }
+
+      if (existingRows.length > 0) {
+        // REVISIONS source-of-truth semantics: every column that the species upload
+        // CSV format can carry is overwritten unconditionally. Fields the row omits
+        // are normalized to NULL by normalizeOptionalString and so wipe whatever was
+        // previously in the database. This is intentional -- the user explicitly
+        // chose Option (a) ("Replace the whole row") when this behavior was
+        // confirmed. If the CSV format ever grows new columns, add them here to
+        // keep the overwrite semantics complete.
+        const updateSQL = format(
+          `UPDATE ??.species
+           SET SpeciesCode = ?, GenusID = ?, SpeciesName = ?, SubspeciesName = ?, IDLevel = ?, SpeciesAuthority = ?, SubspeciesAuthority = ?, DeletedAt = NULL
+           WHERE SpeciesID = ?`,
+          [schema]
+        );
+        await connectionManager.executeQuery(
+          updateSQL,
+          [
+            speciesCode,
+            speciesPayload.GenusID,
+            speciesPayload.SpeciesName,
+            speciesPayload.SubspeciesName,
+            speciesPayload.IDLevel,
+            speciesPayload.SpeciesAuthority,
+            speciesPayload.SubspeciesAuthority,
+            existingRows[0].SpeciesID
+          ],
+          transactionID
+        );
+        updatedCount += 1;
+        continue;
+      }
+    }
+
+    const insertSQL = format(
+      `INSERT INTO ??.species
+       (GenusID, SpeciesCode, SpeciesName, SubspeciesName, IDLevel, SpeciesAuthority, SubspeciesAuthority, IsActive, DeletedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1, NULL)`,
+      [schema]
+    );
+    await connectionManager.executeQuery(
+      insertSQL,
+      [
+        speciesPayload.GenusID,
+        speciesCode,
+        speciesPayload.SpeciesName,
+        speciesPayload.SubspeciesName,
+        speciesPayload.IDLevel,
+        speciesPayload.SpeciesAuthority,
+        speciesPayload.SubspeciesAuthority
+      ],
+      transactionID
+    );
+    insertedCount += 1;
+  }
+
+  return { insertedCount, updatedCount, skippedCount };
+}

--- a/frontend/tests/integration/admin-provision/already-done.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/already-done.integration.test.ts
@@ -22,6 +22,7 @@ import type { StepContext, ProvisioningInput } from '@/lib/provisioning/types';
 
 const TEST_SCHEMA = TEST_SCHEMA_PREFIX + 'meta';
 const CURRENT_SCHEMA_VERSION = '2026-05-13';
+const CURRENT_PROCEDURES_VERSION = '2026-07-30';
 const STALE_SCHEMA_VERSION = '2020-01-01';
 const META_TABLE = '_provisioning_meta';
 // Mirrors lib/provisioning/steps/sql-steps.ts:EXPECTED_VALIDATION_COUNT.
@@ -151,13 +152,13 @@ describe('schema-version stamping (alreadyDone)', () => {
 
     it('returns false when ProceduresDeployedAt is null', async () => {
       await createMetaTable();
-      await insertMetaRow(CURRENT_SCHEMA_VERSION, { TablesDeployedAt: true });
+      await insertMetaRow(CURRENT_PROCEDURES_VERSION);
       expect(await deployProceduresStep.alreadyDone(buildCtx())).toBe(false);
     });
 
     it('returns false when meta is stamped but only one of N expected procedures exists', async () => {
       await createMetaTable();
-      await insertMetaRow(CURRENT_SCHEMA_VERSION, { ProceduresDeployedAt: true });
+      await insertMetaRow(CURRENT_PROCEDURES_VERSION, { ProceduresDeployedAt: true });
       // Create exactly one procedure — not all required ones.
       await pool.query(`CREATE PROCEDURE \`${TEST_SCHEMA}\`.bulkingestionprocess() BEGIN SELECT 1; END`);
       expect(await deployProceduresStep.alreadyDone(buildCtx())).toBe(false);
@@ -165,7 +166,7 @@ describe('schema-version stamping (alreadyDone)', () => {
 
     it('returns true when meta is stamped AND all REQUIRED_PROCEDURES exist', async () => {
       await createMetaTable();
-      await insertMetaRow(CURRENT_SCHEMA_VERSION, { ProceduresDeployedAt: true });
+      await insertMetaRow(CURRENT_PROCEDURES_VERSION, { ProceduresDeployedAt: true });
       // Create all 10 required procedures (case-insensitive names).
       const procedures = [
         'bulkingestionprocess',
@@ -183,6 +184,33 @@ describe('schema-version stamping (alreadyDone)', () => {
         await pool.query(`CREATE PROCEDURE \`${TEST_SCHEMA}\`.\`${proc}\`() BEGIN SELECT 1; END`);
       }
       expect(await deployProceduresStep.alreadyDone(buildCtx())).toBe(true);
+    });
+
+    it('returns false when a required procedure belongs to a different definer', async () => {
+      await createMetaTable();
+      await insertMetaRow(CURRENT_PROCEDURES_VERSION, { ProceduresDeployedAt: true });
+      const procedures = [
+        'bulkingestionprocess',
+        'bulkingestioncollapser',
+        'clearcensusfull',
+        'clearcensusmsmts',
+        'RefreshMeasurementsSummary',
+        'RefreshViewFullTable',
+        'RunSharedDBHChangeValidations',
+        'RunSharedCrossCensusLocationValidations',
+        'reinsertdefaultvalidations',
+        'reinsertdefaultpostvalidations'
+      ];
+      for (const proc of procedures) {
+        await pool.query(`CREATE PROCEDURE \`${TEST_SCHEMA}\`.\`${proc}\`() BEGIN SELECT 1; END`);
+      }
+      const [identityRows]: any = await pool.query(`SELECT CURRENT_USER() AS currentUser`);
+      const [currentUser, currentHost] = String(identityRows[0].currentUser).split('@');
+      const staleHost = currentHost === '%' ? 'localhost' : '%';
+      await pool.query(`DROP PROCEDURE \`${TEST_SCHEMA}\`.bulkingestionprocess`);
+      await pool.query(`CREATE DEFINER = ?@? PROCEDURE \`${TEST_SCHEMA}\`.bulkingestionprocess() BEGIN SELECT 1; END`, [currentUser, staleHost]);
+
+      expect(await deployProceduresStep.alreadyDone(buildCtx())).toBe(false);
     });
   });
 
@@ -246,7 +274,7 @@ describe('schema-version stamping (alreadyDone)', () => {
       await initTablesStep.run(ctx);
       await deployProceduresStep.run(ctx);
       const [rows]: any = await pool.query(`SELECT ProceduresDeployedAt FROM \`${TEST_SCHEMA}\`.\`${META_TABLE}\` WHERE SchemaVersion = ?`, [
-        CURRENT_SCHEMA_VERSION
+        CURRENT_PROCEDURES_VERSION
       ]);
       expect(rows[0].ProceduresDeployedAt).not.toBeNull();
       expect(await deployProceduresStep.alreadyDone(ctx)).toBe(true);

--- a/frontend/tests/integration/background-jobs-repository.test.ts
+++ b/frontend/tests/integration/background-jobs-repository.test.ts
@@ -12,7 +12,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import mysql, { type Pool } from 'mysql2/promise';
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
-import { IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from '@/lib/background-jobs/errors';
+import { BackgroundJobScopeUnavailableError, IdempotencyKeyConflictError, JobFileNotFoundError, WorkerLeaseLostError } from '@/lib/background-jobs/errors';
 import {
   assignFileBatchID,
   cancelBackgroundJob,
@@ -29,6 +29,8 @@ import {
 } from '@/lib/background-jobs/repository';
 import type { CreateUploadJobInput } from '@/lib/background-jobs/types';
 import { UPLOAD_JOB_MAX_RETRIES } from '@/lib/background-jobs/types';
+import { releaseSchemaOperationLock, tryAcquireSchemaOperationLock } from '@/lib/provisioning/schema-operation-lock';
+import { seedCatalogTables } from './admin-provision/_shared';
 
 // ---------------------------------------------------------------------------
 // Safety guard — this suite DELETEs from the shared `catalog` schema and must
@@ -56,6 +58,10 @@ const TEST_USER_A = 'user-a@forestgeo.test';
 const TEST_USER_B = 'user-b@forestgeo.test';
 
 const TEST_SCHEMA = 'forestgeo_testing_bgjobs';
+const OTHER_TEST_SCHEMA = 'forestgeo_other';
+const FILTER_TEST_SCHEMA_A = 'forestgeo_site_alpha';
+const FILTER_TEST_SCHEMA_B = 'forestgeo_site_beta';
+const REGISTERED_TEST_SCHEMAS = [TEST_SCHEMA, OTHER_TEST_SCHEMA, FILTER_TEST_SCHEMA_A, FILTER_TEST_SCHEMA_B] as const;
 const TEST_PLOT_ID = 1;
 const TEST_CENSUS_ID = 2;
 
@@ -80,6 +86,7 @@ beforeAll(async () => {
   });
 
   // Bootstrap tables (idempotent — safe to call on a clean or existing DB).
+  await seedCatalogTables(pool);
   await applyCatalogMigrationsForTests();
 
   console.log('[background-jobs-repository] catalog tables ensured');
@@ -98,6 +105,15 @@ beforeEach(async () => {
   await pool.query(`DELETE FROM catalog.background_job_events`);
   await pool.query(`DELETE FROM catalog.background_job_files`);
   await pool.query(`DELETE FROM catalog.background_jobs`);
+  await pool.query(`DELETE FROM catalog.sites WHERE SchemaName IN (?)`, [[...REGISTERED_TEST_SCHEMAS]]);
+  for (const schemaName of REGISTERED_TEST_SCHEMAS) {
+    await pool.query(
+      `INSERT INTO catalog.sites
+         (SiteName, SchemaName, SQDimX, SQDimY, DefaultUOMDBH, DefaultUOMHOM, DoubleDataEntry)
+       VALUES (?, ?, 20, 20, 'cm', 'm', 0)`,
+      [`Background Job Test Site (${schemaName})`, schemaName]
+    );
+  }
   console.log('[background-jobs-repository] catalog rows cleared');
 });
 
@@ -211,6 +227,43 @@ describe('createUploadBackgroundJob — create and fetch roundtrip', () => {
     expect(details!.events).toHaveLength(1);
     expect(details!.events[0].eventType).toBe('queued');
     console.log(`[roundtrip] event: type=${details!.events[0].eventType} message="${details!.events[0].message}"`);
+  });
+});
+
+describe('createUploadBackgroundJob — schema lifecycle exclusion', () => {
+  it('rechecks site registration after waiting for teardown to release the schema lock', async () => {
+    const teardownConnection = await pool.getConnection();
+    expect(await tryAcquireSchemaOperationLock(teardownConnection, TEST_SCHEMA, 1)).toBe(true);
+
+    try {
+      const creation = createUploadBackgroundJob(pool, makeJobInput(), TEST_USER_A);
+
+      const earlyOutcome = await Promise.race([
+        creation.then(
+          () => 'settled',
+          () => 'settled'
+        ),
+        new Promise<'blocked'>(resolve => setTimeout(() => resolve('blocked'), 50))
+      ]);
+      expect(earlyOutcome, 'job creation did not wait for the schema lifecycle lock').toBe('blocked');
+
+      // Model teardown's catalog phase while creation is excluded by the same
+      // connection-scoped lock. Once released, creation must observe the delete
+      // instead of inserting a queued job for a schema that is disappearing.
+      await teardownConnection.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [TEST_SCHEMA]);
+      await releaseSchemaOperationLock(teardownConnection, TEST_SCHEMA);
+
+      await expect(creation).rejects.toMatchObject({
+        name: 'BackgroundJobScopeUnavailableError',
+        reason: 'site_not_registered'
+      } satisfies Partial<BackgroundJobScopeUnavailableError>);
+
+      const [rows]: any = await pool.query(`SELECT COUNT(*) AS count FROM catalog.background_jobs WHERE SchemaName = ?`, [TEST_SCHEMA]);
+      expect(Number(rows[0].count)).toBe(0);
+    } finally {
+      await releaseSchemaOperationLock(teardownConnection, TEST_SCHEMA);
+      teardownConnection.release();
+    }
   });
 });
 

--- a/frontend/tests/integration/provisioned-site-lifecycle.test.ts
+++ b/frontend/tests/integration/provisioned-site-lifecycle.test.ts
@@ -269,9 +269,6 @@ const PARKED_JOB_FILE_NAME = 'lifecycle-parked.csv';
 const BLOB_CONTAINER = 'lifecycle-test-container';
 const WRONG_CONFIRMATION = 'forestgeo_not_the_target';
 
-/** Matches the hardcoded definer in db/sql/storedprocedures.sql. */
-const PROCEDURE_DEFINER = "'azureroot'@'%'";
-
 const BASE_TABLE_TYPE = 'BASE TABLE';
 const VIEW_TYPE = 'VIEW';
 const COMPLETED_STATUS = 'completed';
@@ -364,7 +361,6 @@ describe('provisioned-site lifecycle', () => {
 
     sharedState.catalogPool = catalogPool;
 
-    await ensureProcedureDefinerExists();
     await seedCatalogTables(catalogPool);
     await applyCatalogMigrationsForTests();
     await clearLifecycleState(catalogPool);
@@ -519,25 +515,6 @@ describe('provisioned-site lifecycle', () => {
     }
   }
 
-  /**
-   * `db/sql/storedprocedures.sql` hardcodes `definer = azureroot@'%'` on every
-   * procedure, and the production deploy path (`executeSqlFile` via
-   * `deployProceduresStep`) runs that DDL verbatim. Calling a procedure whose
-   * definer does not exist fails with ER_NO_SUCH_USER at CALL time, not at
-   * CREATE time — so provisioning reports success and the site is broken.
-   *
-   * `tests/setup/local-db-setup.ts:417` strips the clause, which is why no
-   * other suite has ever seen this. Stripping it here would mean not testing
-   * the production path, so instead the test makes the server look like Azure,
-   * where `azureroot` is the admin account. Local-only: the host guard above
-   * has already refused anything but localhost.
-   */
-  async function ensureProcedureDefinerExists(): Promise<void> {
-    await catalogPool.query(`CREATE USER IF NOT EXISTS ${PROCEDURE_DEFINER} IDENTIFIED BY ?`, [TEST_DB_PASSWORD]);
-    await catalogPool.query(`GRANT ALL PRIVILEGES ON *.* TO ${PROCEDURE_DEFINER} WITH GRANT OPTION`);
-    await catalogPool.query(`FLUSH PRIVILEGES`);
-  }
-
   /** Blob access is dependency-injected, so no Azure call happens. */
   function measurementFixtureDeps(): WorkerDeps {
     return {
@@ -666,14 +643,21 @@ describe('provisioned-site lifecycle', () => {
       }
     });
 
-    it('deploys every required stored procedure', async () => {
+    it('deploys every required stored procedure under the authenticated deployment account', async () => {
       const [procedures] = await siteConnection.query<RowDataPacket[]>(
-        `SELECT ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'`,
+        `SELECT ROUTINE_NAME, LOWER(DEFINER) AS DEFINER, LOWER(CURRENT_USER()) AS DEPLOYMENT_ACCOUNT
+           FROM information_schema.ROUTINES
+          WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'`,
         [SCHEMA_NAME]
       );
       const deployed = procedures.map(row => String(row.ROUTINE_NAME).toLowerCase());
       for (const procedure of REQUIRED_PROCEDURES) {
         expect(deployed, `provisioning did not deploy ${procedure}`).toContain(procedure.toLowerCase());
+      }
+
+      const expectedDefiner = String(procedures[0].DEPLOYMENT_ACCOUNT).toLowerCase();
+      for (const procedure of procedures) {
+        expect(String(procedure.DEFINER).toLowerCase(), `${procedure.ROUTINE_NAME} has a stale or environment-specific definer`).toBe(expectedDefiner);
       }
     });
 

--- a/frontend/tests/integration/provisioned-site-lifecycle.test.ts
+++ b/frontend/tests/integration/provisioned-site-lifecycle.test.ts
@@ -1,0 +1,942 @@
+/**
+ * Provisioned-site lifecycle (integration, real MySQL).
+ *
+ * The whole point of this file is the SUBJECT, not the assertions: every other
+ * integration suite builds its schema with `tests/setup/local-db-setup.ts`
+ * `loadSchema`, whose naive semicolon split silently drops any statement whose
+ * chunk opens with a `--` banner comment (`upload_errors`, `upload_sessions`,
+ * `validation_runs` are the known casualties — upload-worker.test.ts hand-creates
+ * two of them to compensate). Production provisioning uses a DIFFERENT splitter,
+ * `lib/provisioning/sql-runner.ts` `splitSqlFile`.
+ *
+ * So the async upload path has never been proven against a schema built the way
+ * production builds one. This file provisions a site through the real
+ * orchestrator chain, asserts the result satisfies the schema contract, uploads
+ * measurements into it, and tears it down.
+ *
+ * Coverage that exists nowhere else:
+ *   - `runProvisioning` executing the full STEPS chain (every other test either
+ *     runs a single step or spies out the dispatch; the one existing call, in
+ *     orchestrator.test.ts, is a failure path).
+ *   - The schema contract read against a PROVISIONED schema.
+ *   - `upload_errors` / `upload_sessions` / `validation_runs` proven to come from
+ *     production DDL rather than from a test's inline CREATE TABLE.
+ *
+ * Prerequisites: docker compose up -d mysql
+ *
+ * Run in isolation:
+ *   npx vitest run --config vitest.integration.config.mts tests/integration/provisioned-site-lifecycle.test.ts
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import mysql, { type Connection, type Pool, type RowDataPacket } from 'mysql2/promise';
+
+import { runProvisioning, startRun, getRunWithSteps, teardownProvisionedSite } from '@/lib/provisioning/orchestrator';
+import { ProvisioningError } from '@/lib/provisioning/errors';
+import { createUploadBackgroundJob } from '@/lib/background-jobs/repository';
+import { FormType, SourceFormat, type FileRow } from '@/config/macros/formdetails';
+import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
+import { STEPS } from '@/lib/provisioning/steps';
+import { REQUIRED_PROCEDURES, REQUIRED_VIEWS } from '@/lib/provisioning/steps/sql-steps';
+import { SEQUENTIAL_QUADRAT_NAME_PATTERN } from '@/lib/provisioning/grid-generator';
+import type { ProvisioningInput } from '@/lib/provisioning/types';
+import {
+  CONTRACT_READ_TABLES,
+  compareSchemaContracts,
+  formatContractFailures,
+  loadCanonicalSchemaContract,
+  readLiveSchemaContract,
+  TARGET_TEXT_COLLATION,
+  type SchemaContract,
+  type SchemaQueryRow
+} from '@/lib/db/schema-contract';
+import { seedCatalogTables } from './admin-provision/_shared';
+import { UploadMode } from '@/config/uploadmodes';
+
+// Errors are surfaced, not swallowed: runValidation catches and returns false,
+// so without this a failed validation is an opaque boolean.
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn((...args: unknown[]) => console.error('[ailogger.error]', ...args))
+  }
+}));
+
+// Importing app/api/sqlpacketload/route for its reference-data writers drags in
+// the real next-auth module, whose lib/env.js imports the extensionless
+// `next/server` subpath that Node's native ESM resolver cannot resolve. Mocking
+// @/auth keeps it out of the graph. This suite calls the writers directly and
+// never reaches the route's auth gate. Same workaround as reingest-routes.
+// The literal is deliberate: vi.mock factories are hoisted above the module's
+// const declarations, so referencing STARTED_BY here would hit its TDZ.
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => ({ user: { email: 'lifecycle-test@forestgeo', userStatus: 'global', sites: [] } }))
+}));
+
+// ---------------------------------------------------------------------------
+// Shared state bridge — hoisted so the ConnectionManager mock closure can read
+// the live connection after beforeAll wires it up. The connection cannot exist
+// at module load: the schema it points at does not exist until provisioning
+// runs. Reading it lazily inside the closure is what makes that ordering work.
+// ---------------------------------------------------------------------------
+
+const TRANSACTION_ID_PREFIX = 'lifecycle-tx-';
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as import('mysql2/promise').Connection | null,
+  activeTransactionID: null as string | null,
+  transactionCounter: 0,
+  catalogPool: null as import('mysql2/promise').Pool | null
+}));
+
+// Routes every schema-side call through the provisioned schema's connection.
+// Mirrors the mock in upload-worker.test.ts / ingest-batch.test.ts.
+vi.mock('@/lib/db/connectionmanager', () => {
+  const requireConnection = () => {
+    if (!sharedState.connection) throw new Error('Provisioned-schema connection not initialized');
+    return sharedState.connection;
+  };
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[], transactionID?: string) => {
+      const connection = requireConnection();
+      if (transactionID && transactionID !== sharedState.activeTransactionID) {
+        throw new Error(`ConnectionManager mock: transactionID mismatch (got "${transactionID}", active "${sharedState.activeTransactionID}")`);
+      }
+      const [rows] = await connection.query(query, (params as unknown[]) ?? []);
+      return rows;
+    },
+    beginTransaction: async () => {
+      const connection = requireConnection();
+      if (sharedState.activeTransactionID) throw new Error('ConnectionManager mock: transaction already active');
+      await connection.beginTransaction();
+      sharedState.transactionCounter += 1;
+      const id = `${TRANSACTION_ID_PREFIX}${sharedState.transactionCounter}`;
+      sharedState.activeTransactionID = id;
+      return id;
+    },
+    commitTransaction: async (transactionID: string) => {
+      const connection = requireConnection();
+      if (transactionID !== sharedState.activeTransactionID) throw new Error('ConnectionManager mock: commit transactionID mismatch');
+      await connection.commit();
+      sharedState.activeTransactionID = null;
+    },
+    rollbackTransaction: async (transactionID: string) => {
+      const connection = requireConnection();
+      if (transactionID !== sharedState.activeTransactionID) throw new Error('ConnectionManager mock: rollback transactionID mismatch');
+      await connection.rollback();
+      sharedState.activeTransactionID = null;
+    },
+    withTransaction: async <T>(fn: (tx: { query: (sql: string, params?: unknown[]) => Promise<any>; readonly id: string }) => Promise<T>): Promise<T> => {
+      const id = await manager.beginTransaction();
+      try {
+        const result = await fn({ id, query: (sql: string, params?: unknown[]) => manager.executeQuery(sql, params, id) });
+        await manager.commitTransaction(id);
+        return result;
+      } catch (error) {
+        await manager.rollbackTransaction(id);
+        throw error;
+      }
+    },
+    acquireApplicationLock: async (lockName: string, _transactionID: string, timeoutMs: number) => {
+      const connection = requireConnection();
+      const [rows] = await connection.query<import('mysql2/promise').RowDataPacket[]>('SELECT GET_LOCK(?, ?) as acquired', [
+        lockName,
+        Math.ceil(timeoutMs / 1000)
+      ]);
+      return rows[0]?.acquired === 1;
+    },
+    cleanupStaleTransactions: async () => undefined,
+    closeConnection: async () => undefined
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+// The worker reads the catalog pool from getPoolMonitorInstance().pool, and the
+// upload-session tracker acquires pooled connections from the same monitor.
+// Both are routed to the local catalog pool (no default database; every session
+// query is schema-qualified).
+vi.mock('@/lib/db/poolmonitorsingleton', () => ({
+  getPoolMonitorInstance: () => {
+    if (!sharedState.catalogPool) throw new Error('Test catalog pool not initialized');
+    const pool = sharedState.catalogPool;
+    return {
+      pool,
+      getConnection: () => pool.getConnection(),
+      signalActivity: () => undefined
+    };
+  }
+}));
+
+// Imported after the mocks so these modules bind the mocked singletons.
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { upsertAttributeRows, upsertSpeciesRows } from '@/lib/uploads/reference-data-writers';
+import { runJobIfClaimable, type WorkerDeps } from '@/lib/background-jobs/worker';
+import type { BackgroundJobFileRecord } from '@/lib/background-jobs/types';
+
+// ---------------------------------------------------------------------------
+// Safety guard — this file DROPs a database and writes to the shared catalog
+// schema. It must never point at a remote server.
+// ---------------------------------------------------------------------------
+
+const TEST_DB_HOST = process.env.TEST_DB_HOST || 'localhost';
+const TEST_DB_PORT = Number(process.env.TEST_DB_PORT || 3306);
+const TEST_DB_USER = process.env.TEST_DB_USER || 'root';
+const TEST_DB_PASSWORD = process.env.TEST_DB_PASSWORD || 'testpassword';
+
+if (!['localhost', '127.0.0.1', '::1'].includes(TEST_DB_HOST)) {
+  throw new Error(
+    `[provisioned-site-lifecycle] Refusing to run: TEST_DB_HOST="${TEST_DB_HOST}" is not a local address. ` +
+      `This suite drops its provisioned schema and writes to the shared catalog schema; it must only run locally.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The site this suite provisions
+// ---------------------------------------------------------------------------
+
+const SCHEMA_NAME = 'forestgeo_lifecycle_test';
+const SITE_NAME = 'Lifecycle Test Site';
+const PLOT_NAME = 'Lifecycle Plot';
+const STARTED_BY = 'lifecycle-test@forestgeo';
+
+/**
+ * 40x40 m plot on a 20x20 m grid => 2x2 = 4 quadrats.
+ *
+ * `namingPattern: 'row-col'` is deliberate, not cosmetic. The 'sequential'
+ * pattern emits `Q00001`-style names, which is exactly the legacy
+ * auto-generated placeholder grid that the Revisions divergence guard treats as
+ * a replaceable placeholder set (PR #346). Using row-col keeps this fixture out
+ * of that special case, and the names are readable in the measurement CSVs.
+ */
+const PLOT_DIMENSION_M = 40;
+const QUADRAT_SIZE_M = 20;
+const EXPECTED_QUADRAT_COUNT = 4;
+const EXPECTED_QUADRAT_NAMES = ['1-1', '1-2', '2-1', '2-2'] as const;
+
+const PROVISIONING_INPUT: ProvisioningInput = {
+  site: {
+    siteName: SITE_NAME,
+    schemaName: SCHEMA_NAME,
+    sqDimX: QUADRAT_SIZE_M,
+    sqDimY: QUADRAT_SIZE_M,
+    defaultUOMDBH: 'cm',
+    defaultUOMHOM: 'm',
+    doubleDataEntry: false,
+    location: 'Lifecycle Location',
+    country: 'Panama'
+  },
+  plot: {
+    plotName: PLOT_NAME,
+    dimensionX: PLOT_DIMENSION_M,
+    dimensionY: PLOT_DIMENSION_M,
+    area: PLOT_DIMENSION_M * PLOT_DIMENSION_M,
+    globalX: 0,
+    globalY: 0,
+    globalZ: 0,
+    plotShape: 'square',
+    description: 'Provisioned by the lifecycle integration test',
+    defaultDimensionUnits: 'm',
+    defaultCoordinateUnits: 'm',
+    defaultAreaUnits: 'm2',
+    defaultDBHUnits: 'cm',
+    defaultHOMUnits: 'm'
+  },
+  quadrats: {
+    mode: 'grid',
+    quadratSizeX: QUADRAT_SIZE_M,
+    quadratSizeY: QUADRAT_SIZE_M,
+    namingPattern: 'row-col'
+  }
+};
+
+/**
+ * Tables that `loadSchema` silently drops. Asserting them by name is the single
+ * highest-value check in this file: it is the only place in the suite where
+ * these three are proven to come from production DDL.
+ */
+const TABLES_LOADSCHEMA_DROPS = ['upload_errors', 'upload_sessions', 'validation_runs'] as const;
+
+/** Created by tablestructures.sql; redeployed on every deploy by scripts/deploy-taxonomy-views-to-all-schemas.ts. */
+const TAXONOMY_VIEWS = ['alltaxonomiesview', 'stemtaxonomiesview'] as const;
+
+/** Every one of these must be empty in a freshly provisioned schema. */
+const EMPTY_ON_PROVISION_TABLES = ['species', 'genus', 'family', 'attributes', 'coremeasurements', 'trees', 'stems'] as const;
+
+const WAITING_RETRY_STATUS = 'waiting_retry';
+const CANCELLED_STATUS = 'cancelled';
+const CONFLICT_ERROR_KIND = 'conflict';
+const PARKED_JOB_FILE_NAME = 'lifecycle-parked.csv';
+const BLOB_CONTAINER = 'lifecycle-test-container';
+const WRONG_CONFIRMATION = 'forestgeo_not_the_target';
+
+/** Matches the hardcoded definer in db/sql/storedprocedures.sql. */
+const PROCEDURE_DEFINER = "'azureroot'@'%'";
+
+const BASE_TABLE_TYPE = 'BASE TABLE';
+const VIEW_TYPE = 'VIEW';
+const COMPLETED_STATUS = 'completed';
+
+// ---------------------------------------------------------------------------
+// Reference data
+//
+// A provisioned schema has none: tablestructures.sql seeds only the
+// measurement_errors catalog. Measurement ingestion resolves species codes and
+// attribute codes, so this has to be created before any upload.
+//
+// It is written through the PRODUCTION writers (upsertSpeciesRows /
+// upsertAttributeRows, the same functions app/api/sqlpacketload dispatches to),
+// not through hand-rolled INSERTs. The async pipeline cannot be used here:
+// ASYNC_UPLOAD_V1_PIPELINES is measurements-only, so a species job is rejected
+// by the worker as unsupported routing.
+// ---------------------------------------------------------------------------
+
+const ATTRIBUTE_SEED_ROWS: FileRow[] = [
+  { code: 'A', description: 'Alive', status: 'alive' },
+  { code: 'D', description: 'Dead', status: 'dead' },
+  { code: 'M', description: 'Missing', status: 'missing' }
+];
+
+/**
+ * UNUSED_SPECIES_CODE is seeded but never referenced by a measurement fixture.
+ * It keeps "the upload rejected an unknown species" distinguishable from
+ * "seeding never ran" — without it, both look identical in a reject assertion.
+ */
+const SEEDED_SPECIES_CODE = 'ACERRU';
+const SECOND_SPECIES_CODE = 'QUERCO';
+const UNUSED_SPECIES_CODE = 'PINUST';
+
+const SPECIES_SEED_ROWS: FileRow[] = [
+  { spcode: SEEDED_SPECIES_CODE, family: 'Sapindaceae', genus: 'Acer', species: 'rubrum', idlevel: 'species' },
+  { spcode: SECOND_SPECIES_CODE, family: 'Fagaceae', genus: 'Quercus', species: 'alba', idlevel: 'species' },
+  { spcode: UNUSED_SPECIES_CODE, family: 'Pinaceae', genus: 'Pinus', species: 'strobus', idlevel: 'species' }
+];
+
+// ---------------------------------------------------------------------------
+// Measurement fixture
+//
+// Every quadrat name here is one provisioning actually generated, and every
+// species code is one the seeding step wrote. Nothing is inherited from
+// local-db-setup — a provisioned schema has no seed data.
+// ---------------------------------------------------------------------------
+
+const MEASUREMENT_FILE_NAME = 'lifecycle-measurements.csv';
+const CSV_HEADER = 'tag,stemtag,spcode,quadrat,lx,ly,dbh,hom,date,codes';
+const MEASUREMENT_DATE = '2024-03-15';
+
+const VALID_MEASUREMENT_ROW_COUNT = 4;
+/** One row with no quadrat: ingestion must record it as a failure, not drop it silently. */
+const REJECT_MEASUREMENT_ROW_COUNT = 1;
+const MEASUREMENT_ROW_COUNT = VALID_MEASUREMENT_ROW_COUNT + REJECT_MEASUREMENT_ROW_COUNT;
+
+const MEASUREMENT_CSV = [
+  CSV_HEADER,
+  `L1001,1,${SEEDED_SPECIES_CODE},1-1,1.5,2.5,10.5,1.3,${MEASUREMENT_DATE},A`,
+  `L1002,1,${SECOND_SPECIES_CODE},1-2,3.5,4.5,20.4,1.3,${MEASUREMENT_DATE},A`,
+  `L1003,1,${SEEDED_SPECIES_CODE},2-1,5.5,6.5,30.1,1.3,${MEASUREMENT_DATE},A`,
+  `L1004,1,${SECOND_SPECIES_CODE},2-2,7.5,8.5,15.2,1.3,${MEASUREMENT_DATE},A`,
+  `L1005,1,${SEEDED_SPECIES_CODE},,2.5,3.5,11.1,1.3,${MEASUREMENT_DATE},A`
+].join('\n');
+
+const COMPLETED_JOB_STATUS = 'completed';
+const FULLY_COMPLETE_PERCENT = 100;
+const UPLOADMETRICS_COMPLETED = 'completed';
+const IDEMPOTENCY_KEY = 'lifecycle-idempotency-key';
+
+describe('provisioned-site lifecycle', () => {
+  let catalogPool: Pool;
+  let siteConnection: Connection;
+  let runId: number;
+  let plotId: number;
+  let censusId: number;
+  let preSeedRowCounts: Record<string, number>;
+  let uploadJobId: number;
+
+  beforeAll(async () => {
+    catalogPool = mysql.createPool({
+      host: TEST_DB_HOST,
+      port: TEST_DB_PORT,
+      user: TEST_DB_USER,
+      password: TEST_DB_PASSWORD,
+      multipleStatements: true,
+      charset: 'UTF8MB4_0900_AI_CI',
+      connectionLimit: 5
+    });
+
+    sharedState.catalogPool = catalogPool;
+
+    await ensureProcedureDefinerExists();
+    await seedCatalogTables(catalogPool);
+    await applyCatalogMigrationsForTests();
+    await clearLifecycleState(catalogPool);
+
+    runId = await startRunWithoutBackgroundDispatch();
+    console.log(`[setup] started provisioning runId=${runId} schema=${SCHEMA_NAME}`);
+
+    // The real chain, awaited. No step is mocked, skipped, or replayed.
+    await runProvisioning(runId, catalogPool);
+
+    siteConnection = await mysql.createConnection({
+      host: TEST_DB_HOST,
+      port: TEST_DB_PORT,
+      user: TEST_DB_USER,
+      password: TEST_DB_PASSWORD,
+      database: SCHEMA_NAME,
+      // Must match lib/db/poolmonitorsingleton.ts and lib/provisioning/steps/
+      // sql-steps.ts buildSitePool. mysql2's default connection collation is
+      // utf8mb4_unicode_ci, which makes every validation query die on
+      // ER_CANT_AGGREGATE_2COLLATIONS against these utf8mb4_0900_ai_ci tables.
+      charset: 'UTF8MB4_0900_AI_CI',
+      timezone: 'Z'
+    });
+    sharedState.connection = siteConnection;
+    console.log(`[setup] provisioning finished; connected to ${SCHEMA_NAME}`);
+
+    // Snapshot emptiness BEFORE seeding so the "a provisioned site starts
+    // empty" assertion stays true regardless of test ordering.
+    preSeedRowCounts = await countRows(EMPTY_ON_PROVISION_TABLES);
+
+    await seedReferenceData();
+  }, 180_000);
+
+  afterAll(async () => {
+    // Defensive: the teardown cases drop the schema themselves, but an earlier
+    // failure leaves it behind and the next run must start clean.
+    if (siteConnection) await siteConnection.end().catch(() => {});
+    if (catalogPool) {
+      await clearLifecycleState(catalogPool).catch(() => {});
+      await catalogPool.end();
+    }
+  }, 60_000);
+
+  /**
+   * `startRun` is the production entry point and is what seeds the ten
+   * `provisioning_steps` rows, so the test uses it rather than hand-inserting
+   * them. Its trailing `dispatchRun` fires `runProvisioning` through
+   * `setImmediate`; suppressing that lets the test await the chain itself
+   * instead of racing a detached background run. Same suppression the
+   * admin-provision route tests use.
+   */
+  async function startRunWithoutBackgroundDispatch(): Promise<number> {
+    const setImmediateSpy = vi.spyOn(globalThis, 'setImmediate').mockImplementation(((_cb: unknown) => 0) as never);
+    try {
+      const { runId: startedRunId } = await startRun({
+        input: PROVISIONING_INPUT,
+        startedBy: STARTED_BY,
+        catalogPool
+      });
+      return startedRunId;
+    } finally {
+      setImmediateSpy.mockRestore();
+    }
+  }
+
+  async function clearLifecycleState(pool: Pool): Promise<void> {
+    // Scoped to this suite's schema — other integration files share the catalog.
+    // Single-table DELETEs with subqueries, not multi-table JOIN deletes: this
+    // pool has no default database and MySQL rejects multi-table DELETE without
+    // one even when every table is schema-qualified (ER_NO_DB_ERROR).
+    await pool.query(`DELETE FROM catalog.provisioning_steps WHERE RunID IN (SELECT RunID FROM catalog.provisioning_runs WHERE SchemaName = ?)`, [SCHEMA_NAME]);
+    await pool.query(`DELETE FROM catalog.provisioning_runs WHERE SchemaName = ?`, [SCHEMA_NAME]);
+    await pool.query(`DELETE FROM catalog.usersiterelations WHERE SiteID IN (SELECT SiteID FROM catalog.sites WHERE SchemaName = ?)`, [SCHEMA_NAME]);
+    await pool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [SCHEMA_NAME]);
+    await deleteBackgroundJobRowsForSchema(pool);
+    await pool.query(`DROP DATABASE IF EXISTS \`${SCHEMA_NAME}\``);
+  }
+
+  /** FK-safe order: events -> files -> jobs. Scoped to this suite's schema. */
+  async function deleteBackgroundJobRowsForSchema(pool: Pool): Promise<void> {
+    const jobIdSubquery = `SELECT JobID FROM catalog.background_jobs WHERE SchemaName = ?`;
+    await pool.query(`DELETE FROM catalog.background_job_events WHERE JobID IN (${jobIdSubquery})`, [SCHEMA_NAME]);
+    await pool.query(`DELETE FROM catalog.background_job_files WHERE JobID IN (${jobIdSubquery})`, [SCHEMA_NAME]);
+    await pool.query(`DELETE FROM catalog.background_jobs WHERE SchemaName = ?`, [SCHEMA_NAME]);
+  }
+
+  async function countBackgroundJobRowsForSchema(): Promise<{ jobs: number; files: number; events: number }> {
+    const jobIdSubquery = `SELECT JobID FROM catalog.background_jobs WHERE SchemaName = ?`;
+    const [jobs] = await catalogPool.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM catalog.background_jobs WHERE SchemaName = ?`, [SCHEMA_NAME]);
+    const [files] = await catalogPool.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM catalog.background_job_files WHERE JobID IN (${jobIdSubquery})`, [
+      SCHEMA_NAME
+    ]);
+    const [events] = await catalogPool.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM catalog.background_job_events WHERE JobID IN (${jobIdSubquery})`, [
+      SCHEMA_NAME
+    ]);
+    return { jobs: Number(jobs[0].count), files: Number(files[0].count), events: Number(events[0].count) };
+  }
+
+  async function schemaExists(): Promise<boolean> {
+    const [rows] = await catalogPool.query<RowDataPacket[]>(`SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?`, [SCHEMA_NAME]);
+    return rows.length > 0;
+  }
+
+  /**
+   * A job parked mid-flight: the state a site can genuinely be in when an admin
+   * reaches for teardown. `waiting_retry` with retry budget left is what the
+   * sweeper will pick up and dispatch again.
+   */
+  async function createParkedUploadJob(): Promise<number> {
+    const job = await createUploadBackgroundJob(
+      catalogPool,
+      {
+        schema: SCHEMA_NAME,
+        plotID: plotId,
+        censusID: censusId,
+        uploadMode: UploadMode.REVISIONS,
+        sourceFormat: SourceFormat.csv,
+        formType: FormType.measurements,
+        payload: {},
+        files: [{ fileName: PARKED_JOB_FILE_NAME, blobContainer: BLOB_CONTAINER, blobName: `uploads/${PARKED_JOB_FILE_NAME}`, expectedRows: 1 }]
+      },
+      STARTED_BY
+    );
+    await catalogPool.query(`UPDATE catalog.background_jobs SET Status = ?, NextAttemptAt = DATE_ADD(NOW(), INTERVAL 1 MINUTE) WHERE JobID = ?`, [
+      WAITING_RETRY_STATUS,
+      job.jobID
+    ]);
+    return job.jobID;
+  }
+
+  /**
+   * Runs in beforeAll, after the schema exists and after `sharedState.connection`
+   * is wired up. Uses REVISIONS rather than CLEAN_REUPLOAD: the clean path
+   * DELETEs every active row first, which is pointless against an empty schema
+   * and, for species, carries a dependency guard this fixture has no reason to
+   * exercise.
+   */
+  async function seedReferenceData(): Promise<void> {
+    const connectionManager = ConnectionManager.getInstance();
+    const transactionID = await connectionManager.beginTransaction();
+    try {
+      const attributeResult = await upsertAttributeRows(connectionManager, SCHEMA_NAME, ATTRIBUTE_SEED_ROWS, UploadMode.REVISIONS, transactionID);
+      const speciesResult = await upsertSpeciesRows(connectionManager, SCHEMA_NAME, SPECIES_SEED_ROWS, UploadMode.REVISIONS, transactionID);
+      await connectionManager.commitTransaction(transactionID);
+      console.log(
+        `[seed] attributes inserted=${attributeResult.insertedCount} skipped=${attributeResult.skippedCount}; ` +
+          `species inserted=${speciesResult.insertedCount} skipped=${speciesResult.skippedCount}`
+      );
+    } catch (error) {
+      await connectionManager.rollbackTransaction(transactionID);
+      throw error;
+    }
+  }
+
+  /**
+   * `db/sql/storedprocedures.sql` hardcodes `definer = azureroot@'%'` on every
+   * procedure, and the production deploy path (`executeSqlFile` via
+   * `deployProceduresStep`) runs that DDL verbatim. Calling a procedure whose
+   * definer does not exist fails with ER_NO_SUCH_USER at CALL time, not at
+   * CREATE time — so provisioning reports success and the site is broken.
+   *
+   * `tests/setup/local-db-setup.ts:417` strips the clause, which is why no
+   * other suite has ever seen this. Stripping it here would mean not testing
+   * the production path, so instead the test makes the server look like Azure,
+   * where `azureroot` is the admin account. Local-only: the host guard above
+   * has already refused anything but localhost.
+   */
+  async function ensureProcedureDefinerExists(): Promise<void> {
+    await catalogPool.query(`CREATE USER IF NOT EXISTS ${PROCEDURE_DEFINER} IDENTIFIED BY ?`, [TEST_DB_PASSWORD]);
+    await catalogPool.query(`GRANT ALL PRIVILEGES ON *.* TO ${PROCEDURE_DEFINER} WITH GRANT OPTION`);
+    await catalogPool.query(`FLUSH PRIVILEGES`);
+  }
+
+  /** Blob access is dependency-injected, so no Azure call happens. */
+  function measurementFixtureDeps(): WorkerDeps {
+    return {
+      fetchFileText: async (file: BackgroundJobFileRecord) => {
+        if (file.fileName !== MEASUREMENT_FILE_NAME) throw new Error(`[test deps] no fixture text for ${file.fileName}`);
+        return MEASUREMENT_CSV;
+      }
+    };
+  }
+
+  async function measurementIdsWhere(predicate: string): Promise<number[]> {
+    const [rows] = await siteConnection.query<RowDataPacket[]>(
+      `SELECT CoreMeasurementID FROM coremeasurements WHERE UploadFileID = ? AND ${predicate} ORDER BY CoreMeasurementID`,
+      [MEASUREMENT_FILE_NAME]
+    );
+    return rows.map(row => Number(row.CoreMeasurementID));
+  }
+
+  async function countRows(tables: readonly string[]): Promise<Record<string, number>> {
+    const counts: Record<string, number> = {};
+    for (const table of tables) {
+      const [rows] = await siteConnection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM \`${table}\``);
+      counts[table] = Number(rows[0].count);
+    }
+    return counts;
+  }
+
+  async function objectNamesOfType(tableType: string): Promise<string[]> {
+    const [rows] = await siteConnection.query<RowDataPacket[]>(`SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = ?`, [
+      SCHEMA_NAME,
+      tableType
+    ]);
+    return rows.map(row => String(row.TABLE_NAME).toLowerCase());
+  }
+
+  // -------------------------------------------------------------------------
+  // A. Provisioning
+  // -------------------------------------------------------------------------
+
+  describe('provisioning the site', () => {
+    it('drives the run to completed with every step completed and no error recorded', async () => {
+      const result = await getRunWithSteps(runId, catalogPool);
+      expect(result, `run ${runId} vanished from the catalog`).not.toBeNull();
+
+      const { run, steps } = result!;
+      const stepSummary = steps.map(step => `${step.stepIndex}:${step.stepKey}=${step.status}${step.errorMessage ? ` (${step.errorMessage})` : ''}`).join('\n');
+      console.log(`[provisioning] run status=${run.status}\n${stepSummary}`);
+
+      // Per-step, not just the run status: a silently skipped step is the
+      // failure mode a run-level assertion cannot see.
+      expect(steps.map(step => step.stepKey)).toEqual(STEPS.map(step => step.key));
+      for (const step of steps) {
+        expect(step.status, `step ${step.stepKey} did not complete:\n${stepSummary}`).toBe(COMPLETED_STATUS);
+        expect(step.errorMessage, `step ${step.stepKey} recorded an error`).toBeNull();
+      }
+      expect(run.status, `run did not complete:\n${stepSummary}`).toBe(COMPLETED_STATUS);
+    });
+
+    it('registers the site in the catalog and creates the first plot, census, and quadrat grid', async () => {
+      const [siteRows] = await catalogPool.query<RowDataPacket[]>(`SELECT SiteID, SiteName, SQDimX, SQDimY FROM catalog.sites WHERE SchemaName = ?`, [
+        SCHEMA_NAME
+      ]);
+      expect(siteRows).toHaveLength(1);
+      expect(siteRows[0].SiteName).toBe(SITE_NAME);
+      expect(Number(siteRows[0].SQDimX)).toBe(QUADRAT_SIZE_M);
+
+      const [plotRows] = await siteConnection.query<RowDataPacket[]>(`SELECT PlotID, DimensionX, DimensionY FROM plots WHERE PlotName = ?`, [PLOT_NAME]);
+      expect(plotRows).toHaveLength(1);
+      plotId = Number(plotRows[0].PlotID);
+      expect(Number(plotRows[0].DimensionX)).toBe(PLOT_DIMENSION_M);
+
+      const [censusRows] = await siteConnection.query<RowDataPacket[]>(`SELECT CensusID FROM census WHERE PlotID = ? AND PlotCensusNumber = 1`, [plotId]);
+      expect(censusRows).toHaveLength(1);
+      censusId = Number(censusRows[0].CensusID);
+
+      const [quadratRows] = await siteConnection.query<RowDataPacket[]>(`SELECT QuadratName FROM quadrats WHERE PlotID = ? ORDER BY QuadratName`, [plotId]);
+      const quadratNames = quadratRows.map(row => String(row.QuadratName));
+      console.log(`[provisioning] plotID=${plotId} censusID=${censusId} quadrats=${quadratNames.join(',')}`);
+
+      expect(quadratNames).toHaveLength(EXPECTED_QUADRAT_COUNT);
+      expect(quadratNames).toEqual([...EXPECTED_QUADRAT_NAMES]);
+      // Guards the fixture assumption that these names are NOT the legacy
+      // placeholder grid the Revisions divergence guard special-cases.
+      for (const name of quadratNames) {
+        expect(SEQUENTIAL_QUADRAT_NAME_PATTERN.test(name), `${name} matches the legacy placeholder grid pattern`).toBe(false);
+      }
+    });
+
+    it('produces a schema that satisfies the canonical schema contract', async () => {
+      const exec = async (sql: string, params: unknown[]): Promise<SchemaQueryRow[]> => {
+        const [rows] = await siteConnection.query<RowDataPacket[]>(sql, params);
+        return rows as SchemaQueryRow[];
+      };
+
+      const canonicalContract: SchemaContract = loadCanonicalSchemaContract();
+      const liveContract: SchemaContract = await readLiveSchemaContract(exec, SCHEMA_NAME, CONTRACT_READ_TABLES);
+
+      const { failures, extras } = compareSchemaContracts(canonicalContract, liveContract);
+      if (extras.length > 0) {
+        console.info(
+          `[contract] ${extras.length} object(s) beyond the contract (informational):\n${extras.map(e => `[${e.table}] ${e.category} "${e.object}"`).join('\n')}`
+        );
+      }
+      if (failures.length > 0) {
+        throw new Error(`Provisioned schema violates the canonical contract (${failures.length}):\n${formatContractFailures(failures)}`);
+      }
+      expect(failures).toEqual([]);
+      expect(liveContract.defaultCollation).toBe(TARGET_TEXT_COLLATION);
+    });
+
+    it('creates the three tables loadSchema silently drops', async () => {
+      // tests/setup/local-db-setup.ts loadSchema skips statements whose chunk
+      // begins with a '--' banner comment, so these three are absent from every
+      // other integration suite's schema (upload-worker.test.ts creates two of
+      // them inline). Production's splitter must not have that hole.
+      const tables = await objectNamesOfType(BASE_TABLE_TYPE);
+      for (const table of TABLES_LOADSCHEMA_DROPS) {
+        expect(tables, `provisioning did not create ${table}`).toContain(table);
+      }
+    });
+
+    it('creates every required view, including both taxonomy views', async () => {
+      const views = await objectNamesOfType(VIEW_TYPE);
+      for (const view of [...REQUIRED_VIEWS, ...TAXONOMY_VIEWS]) {
+        expect(views, `provisioning did not create view ${view}`).toContain(view.toLowerCase());
+      }
+    });
+
+    it('deploys every required stored procedure', async () => {
+      const [procedures] = await siteConnection.query<RowDataPacket[]>(
+        `SELECT ROUTINE_NAME FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'`,
+        [SCHEMA_NAME]
+      );
+      const deployed = procedures.map(row => String(row.ROUTINE_NAME).toLowerCase());
+      for (const procedure of REQUIRED_PROCEDURES) {
+        expect(deployed, `provisioning did not deploy ${procedure}`).toContain(procedure.toLowerCase());
+      }
+    });
+
+    it('seeds the site-specific validation catalog', async () => {
+      const [rows] = await siteConnection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM sitespecificvalidations`);
+      expect(Number(rows[0].count), 'seed_validations completed but left no validation rules').toBeGreaterThan(0);
+    });
+
+    it('has no measurement or reference data — a provisioned site starts empty', async () => {
+      // Asserted from the pre-seed snapshot: this is the precondition that
+      // forces the seeding step to exist at all.
+      for (const table of EMPTY_ON_PROVISION_TABLES) {
+        expect(preSeedRowCounts[table], `${table} should be empty in a freshly provisioned schema`).toBe(0);
+      }
+      // measurement_errors is the one thing tablestructures.sql seeds inline.
+      const [errorCatalog] = await siteConnection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM measurement_errors`);
+      expect(Number(errorCatalog[0].count), 'the ingestion error catalog should be seeded by the canonical DDL').toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // B. Reference data, written through the production writers
+  // -------------------------------------------------------------------------
+
+  describe('seeding reference data into the provisioned site', () => {
+    it('writes every attribute code through upsertAttributeRows', async () => {
+      const [rows] = await siteConnection.query<RowDataPacket[]>(`SELECT Code, Status FROM attributes WHERE IsActive = 1 ORDER BY Code`);
+      const codes = rows.map(row => String(row.Code));
+      expect(codes).toEqual(ATTRIBUTE_SEED_ROWS.map(row => row.code));
+
+      // Ingestion silently drops measurements carrying an unknown code, so a
+      // missing attribute would surface as a PASSING upload with wrong data.
+      // Pin the status values the fixture relies on.
+      const statusByCode = new Map(rows.map(row => [String(row.Code), String(row.Status)]));
+      expect(statusByCode.get('A')).toBe('alive');
+      expect(statusByCode.get('D')).toBe('dead');
+    });
+
+    it('writes species with their genus and family resolved through upsertSpeciesRows', async () => {
+      const [rows] = await siteConnection.query<RowDataPacket[]>(
+        `SELECT sp.SpeciesCode, sp.SpeciesName, g.Genus, f.Family
+           FROM species sp
+           LEFT JOIN genus g ON g.GenusID = sp.GenusID
+           LEFT JOIN family f ON f.FamilyID = g.FamilyID
+          WHERE sp.IsActive = 1
+          ORDER BY sp.SpeciesCode`
+      );
+      const seeded = rows.map(row => ({
+        code: String(row.SpeciesCode),
+        name: row.SpeciesName === null ? null : String(row.SpeciesName),
+        genus: row.Genus === null ? null : String(row.Genus),
+        family: row.Family === null ? null : String(row.Family)
+      }));
+      console.log(`[seed] species rows: ${JSON.stringify(seeded)}`);
+
+      expect(seeded.map(row => row.code)).toEqual([SEEDED_SPECIES_CODE, UNUSED_SPECIES_CODE, SECOND_SPECIES_CODE].sort());
+
+      // The taxonomy hierarchy is what makes these usable by ingestion; a
+      // species row with a NULL GenusID would resolve differently.
+      const acer = seeded.find(row => row.code === SEEDED_SPECIES_CODE);
+      expect(acer).toBeDefined();
+      expect(acer!.name).toBe('rubrum');
+      expect(acer!.genus).toBe('Acer');
+      expect(acer!.family).toBe('Sapindaceae');
+    });
+
+    it('exposes the seeded taxonomy through alltaxonomiesview', async () => {
+      // Proves the provisioned view is not merely present but actually joins —
+      // the datagrid reads this, and a broken view is invisible to a
+      // table-existence check.
+      const [rows] = await siteConnection.query<RowDataPacket[]>(`SELECT SpeciesCode, Genus, Family FROM alltaxonomiesview ORDER BY SpeciesCode`);
+      expect(rows.map(row => String(row.SpeciesCode))).toEqual([SEEDED_SPECIES_CODE, UNUSED_SPECIES_CODE, SECOND_SPECIES_CODE].sort());
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // B2. Measurement upload through the async background-job pipeline
+  // -------------------------------------------------------------------------
+
+  describe('uploading measurements into the provisioned site', () => {
+    it('ingests a measurement file end-to-end through the background worker', async () => {
+      const job = await createUploadBackgroundJob(
+        catalogPool,
+        {
+          schema: SCHEMA_NAME,
+          plotID: plotId,
+          censusID: censusId,
+          uploadMode: UploadMode.REVISIONS,
+          sourceFormat: SourceFormat.csv,
+          formType: FormType.measurements,
+          idempotencyKey: IDEMPOTENCY_KEY,
+          payload: { selectedDelimiters: { [MEASUREMENT_FILE_NAME]: ',' } },
+          files: [
+            {
+              fileName: MEASUREMENT_FILE_NAME,
+              blobContainer: BLOB_CONTAINER,
+              blobName: `uploads/${MEASUREMENT_FILE_NAME}`,
+              expectedRows: MEASUREMENT_ROW_COUNT
+            }
+          ]
+        },
+        STARTED_BY
+      );
+      uploadJobId = job.jobID;
+      console.log(`[upload] created jobID=${uploadJobId} for ${SCHEMA_NAME}`);
+
+      await runJobIfClaimable(uploadJobId, measurementFixtureDeps());
+
+      const [jobRows] = await catalogPool.query<RowDataPacket[]>(
+        `SELECT Status, Phase, PercentComplete, LastError FROM catalog.background_jobs WHERE JobID = ?`,
+        [uploadJobId]
+      );
+      expect(jobRows).toHaveLength(1);
+      console.log(`[upload] job status=${jobRows[0].Status} phase=${jobRows[0].Phase} percent=${jobRows[0].PercentComplete} lastError=${jobRows[0].LastError}`);
+      expect(jobRows[0].LastError, 'job recorded an error').toBeNull();
+      expect(jobRows[0].Status).toBe(COMPLETED_JOB_STATUS);
+      expect(Number(jobRows[0].PercentComplete)).toBe(FULLY_COMPLETE_PERCENT);
+
+      // Ingested rows carry a StemGUID; a NULL StemGUID is this schema's
+      // representation of a failed/unresolved measurement.
+      const ingested = await measurementIdsWhere('StemGUID IS NOT NULL');
+      const rejected = await measurementIdsWhere('StemGUID IS NULL');
+      console.log(`[upload] ingested=${ingested.length} rejected=${rejected.length}`);
+      expect(ingested).toHaveLength(VALID_MEASUREMENT_ROW_COUNT);
+      expect(rejected).toHaveLength(REJECT_MEASUREMENT_ROW_COUNT);
+
+      // The reject must be catalogued, not silently dropped. This is the check
+      // that proves the PROVISIONED bulkingestionprocess records failures.
+      const [errorLinks] = await siteConnection.query<RowDataPacket[]>(`SELECT COUNT(*) AS count FROM measurement_error_log WHERE MeasurementID IN (?)`, [
+        rejected
+      ]);
+      expect(Number(errorLinks[0].count), 'the rejected row has no measurement_error_log entry').toBeGreaterThan(0);
+    });
+
+    it('resolves every ingested row against the provisioned quadrats and seeded species', async () => {
+      // Guards against a "green" ingest that silently coerced quadrat or
+      // species references — the failure mode an ingested-count check misses.
+      const [rows] = await siteConnection.query<RowDataPacket[]>(
+        `SELECT q.QuadratName, sp.SpeciesCode
+           FROM coremeasurements cm
+           JOIN stems st ON st.StemGUID = cm.StemGUID
+           JOIN quadrats q ON q.QuadratID = st.QuadratID
+           JOIN trees t ON t.TreeID = st.TreeID
+           JOIN species sp ON sp.SpeciesID = t.SpeciesID
+          WHERE cm.StemGUID IS NOT NULL`
+      );
+      expect(rows).toHaveLength(VALID_MEASUREMENT_ROW_COUNT);
+
+      const quadratNames = new Set(rows.map(row => String(row.QuadratName)));
+      const speciesCodes = new Set(rows.map(row => String(row.SpeciesCode)));
+      console.log(`[upload] resolved quadrats=${[...quadratNames].join(',')} species=${[...speciesCodes].join(',')}`);
+
+      for (const name of quadratNames) {
+        expect(EXPECTED_QUADRAT_NAMES, `ingest resolved an unexpected quadrat: ${name}`).toContain(name);
+      }
+      expect([...speciesCodes].sort()).toEqual([SEEDED_SPECIES_CODE, SECOND_SPECIES_CODE].sort());
+      // The seeded-but-unreferenced code must not appear; if it did, resolution
+      // is matching something other than the CSV's species column.
+      expect(speciesCodes.has(UNUSED_SPECIES_CODE)).toBe(false);
+    });
+
+    it('records the batch in uploadmetrics and releases the upload session', async () => {
+      const [metrics] = await siteConnection.query<RowDataPacket[]>(`SELECT status FROM uploadmetrics WHERE fileID = ?`, [MEASUREMENT_FILE_NAME]);
+      expect(metrics.map(row => String(row.status))).toEqual([UPLOADMETRICS_COMPLETED]);
+
+      // upload_sessions and validation_runs exist here only because PRODUCTION
+      // provisioning created them — loadSchema drops both, so these two
+      // assertions are meaningless in every other integration suite.
+      const [sessions] = await siteConnection.query<RowDataPacket[]>(`SELECT state FROM upload_sessions WHERE file_id = ?`, [`async-job-${uploadJobId}`]);
+      expect(sessions.length, 'the worker never opened an upload session').toBeGreaterThan(0);
+      expect(
+        sessions.every(row => String(row.state) !== 'active'),
+        'an upload session was left active'
+      ).toBe(true);
+
+      const [validationRuns] = await siteConnection.query<RowDataPacket[]>(`SELECT Status FROM validation_runs WHERE CensusID = ?`, [censusId]);
+      expect(validationRuns.length, 'no validation run was recorded').toBeGreaterThan(0);
+      expect(validationRuns.map(row => String(row.Status))).toContain(COMPLETED_STATUS);
+    });
+
+    it('returns the existing job for a repeated idempotency key instead of ingesting twice', async () => {
+      const ingestedBefore = (await measurementIdsWhere('StemGUID IS NOT NULL')).length;
+
+      const duplicate = await createUploadBackgroundJob(
+        catalogPool,
+        {
+          schema: SCHEMA_NAME,
+          plotID: plotId,
+          censusID: censusId,
+          uploadMode: UploadMode.REVISIONS,
+          sourceFormat: SourceFormat.csv,
+          formType: FormType.measurements,
+          idempotencyKey: IDEMPOTENCY_KEY,
+          payload: { selectedDelimiters: { [MEASUREMENT_FILE_NAME]: ',' } },
+          files: [
+            {
+              fileName: MEASUREMENT_FILE_NAME,
+              blobContainer: BLOB_CONTAINER,
+              blobName: `uploads/${MEASUREMENT_FILE_NAME}`,
+              expectedRows: MEASUREMENT_ROW_COUNT
+            }
+          ]
+        },
+        STARTED_BY
+      );
+
+      expect(duplicate.jobID, 'a second job was created for the same idempotency key').toBe(uploadJobId);
+      expect((await measurementIdsWhere('StemGUID IS NOT NULL')).length).toBe(ingestedBefore);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // C. Teardown
+  //
+  // These run last and are order-dependent: the final case drops the schema.
+  // -------------------------------------------------------------------------
+
+  describe('tearing the site down', () => {
+    it('refuses teardown while a background upload job for the schema is still live', async () => {
+      const jobRowsBefore = await countBackgroundJobRowsForSchema();
+      const jobID = await createParkedUploadJob();
+      console.log(`[teardown] parked jobID=${jobID} in ${WAITING_RETRY_STATUS} for ${SCHEMA_NAME}`);
+
+      // catalog.background_jobs.SchemaName is NOT NULL and findRunnableJobIDs
+      // filters on status/NextAttemptAt only — it never checks that the schema
+      // still exists. Dropping the database out from under a live job leaves
+      // the sweeper dispatching against a schema that is gone, burning the
+      // retry budget on "unknown database" until MaxRetries.
+      await expect(teardownProvisionedSite(runId, SCHEMA_NAME, catalogPool, STARTED_BY)).rejects.toMatchObject({
+        kind: CONFLICT_ERROR_KIND
+      });
+
+      // Teardown must be all-or-nothing: nothing may have been dropped or
+      // deleted on the refusal path.
+      expect(await schemaExists(), 'schema was dropped despite the refusal').toBe(true);
+      const [siteRows] = await catalogPool.query<RowDataPacket[]>(`SELECT SiteID FROM catalog.sites WHERE SchemaName = ?`, [SCHEMA_NAME]);
+      expect(siteRows, 'catalog site row was deleted despite the refusal').toHaveLength(1);
+      expect((await countBackgroundJobRowsForSchema()).jobs, 'job rows were deleted despite the refusal').toBe(jobRowsBefore.jobs + 1);
+    });
+
+    it('still refuses on a mismatched confirmation, without touching the background job rows', async () => {
+      const before = await countBackgroundJobRowsForSchema();
+
+      await expect(teardownProvisionedSite(runId, WRONG_CONFIRMATION, catalogPool, STARTED_BY)).rejects.toBeInstanceOf(ProvisioningError);
+
+      expect(await schemaExists()).toBe(true);
+      expect(await countBackgroundJobRowsForSchema(), 'confirmation-mismatch path must not partially clean up').toEqual(before);
+    });
+
+    it('tears down cleanly once the job reaches a terminal state, leaving no orphan job rows', async () => {
+      await catalogPool.query(`UPDATE catalog.background_jobs SET Status = ?, FinishedAt = NOW() WHERE SchemaName = ?`, [CANCELLED_STATUS, SCHEMA_NAME]);
+
+      await teardownProvisionedSite(runId, SCHEMA_NAME, catalogPool, STARTED_BY);
+
+      expect(await schemaExists(), 'schema survived teardown').toBe(false);
+
+      const [siteRows] = await catalogPool.query<RowDataPacket[]>(`SELECT SiteID FROM catalog.sites WHERE SchemaName = ?`, [SCHEMA_NAME]);
+      expect(siteRows, 'catalog site row survived teardown').toHaveLength(0);
+
+      // The orphan-row assertion. Terminal jobs and their files/events must go
+      // with the schema; anything left behind references a database that no
+      // longer exists.
+      expect(await countBackgroundJobRowsForSchema()).toEqual({ jobs: 0, files: 0, events: 0 });
+    });
+  });
+});

--- a/frontend/tests/integration/upload-pipeline-equivalence.test.ts
+++ b/frontend/tests/integration/upload-pipeline-equivalence.test.ts
@@ -157,6 +157,7 @@ vi.mock('@/ailogger', () => ({
 }));
 
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
+import { seedCatalogTables } from './admin-provision/_shared';
 import { createUploadBackgroundJob, getBackgroundJob } from '@/lib/background-jobs/repository';
 import { runJobIfClaimable, type WorkerDeps } from '@/lib/background-jobs/worker';
 import { ensureUploadSessionsTable } from '@/config/uploadsessiontracker';
@@ -274,7 +275,15 @@ describe('upload pipeline equivalence — sync route vs background worker', () =
       connectionLimit: 5
     });
     sharedState.catalogPool = catalogPool;
+    await seedCatalogTables(catalogPool);
     await applyCatalogMigrationsForTests();
+    await catalogPool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [schema]);
+    await catalogPool.query(
+      `INSERT INTO catalog.sites
+         (SiteName, SchemaName, SQDimX, SQDimY, DefaultUOMDBH, DefaultUOMHOM, DoubleDataEntry)
+       VALUES ('Upload Equivalence Test Site', ?, 20, 20, 'cm', 'm', 0)`,
+      [schema]
+    );
 
     // Scope B: second plot with the same quadrat names and an own census so the
     // worker run is fully independent of scope A inside the same schema.
@@ -330,7 +339,10 @@ describe('upload pipeline equivalence — sync route vs background worker', () =
 
   afterAll(async () => {
     sharedState.catalogPool = null;
-    if (catalogPool) await catalogPool.end();
+    if (catalogPool) {
+      await catalogPool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [schema]);
+      await catalogPool.end();
+    }
     sharedState.connection = null;
     await teardownTestDatabase(connection, config);
   });

--- a/frontend/tests/integration/upload-sweeper.test.ts
+++ b/frontend/tests/integration/upload-sweeper.test.ts
@@ -13,6 +13,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import mysql, { type Pool } from 'mysql2/promise';
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
+import { seedCatalogTables } from './admin-provision/_shared';
 import { createUploadBackgroundJob, getBackgroundJob, getBackgroundJobWithDetails } from '@/lib/background-jobs/repository';
 import {
   activeJobExecutionCount,
@@ -91,12 +92,23 @@ beforeAll(async () => {
     password: TEST_DB_PASSWORD,
     connectionLimit: 5
   });
+  await seedCatalogTables(pool);
   await applyCatalogMigrationsForTests();
+  await pool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [TEST_SCHEMA]);
+  await pool.query(
+    `INSERT INTO catalog.sites
+       (SiteName, SchemaName, SQDimX, SQDimY, DefaultUOMDBH, DefaultUOMHOM, DoubleDataEntry)
+     VALUES ('Upload Sweeper Test Site', ?, 20, 20, 'cm', 'm', 0)`,
+    [TEST_SCHEMA]
+  );
   console.log('[upload-sweeper] catalog tables ensured');
 });
 
 afterAll(async () => {
-  if (pool) await pool.end();
+  if (pool) {
+    await pool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [TEST_SCHEMA]);
+    await pool.end();
+  }
 });
 
 beforeEach(async () => {

--- a/frontend/tests/integration/upload-worker.test.ts
+++ b/frontend/tests/integration/upload-worker.test.ts
@@ -167,6 +167,7 @@ vi.mock('@/ailogger', () => ({
 }));
 
 import { applyCatalogMigrationsForTests } from '../setup/catalog-migrations';
+import { seedCatalogTables } from './admin-provision/_shared';
 import {
   claimBackgroundJobForWorker,
   createUploadBackgroundJob,
@@ -261,7 +262,15 @@ describe('runJobIfClaimable — integration', () => {
       connectionLimit: 5
     });
     sharedState.catalogPool = catalogPool;
+    await seedCatalogTables(catalogPool);
     await applyCatalogMigrationsForTests();
+    await catalogPool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [schema]);
+    await catalogPool.query(
+      `INSERT INTO catalog.sites
+         (SiteName, SchemaName, SQDimX, SQDimY, DefaultUOMDBH, DefaultUOMHOM, DoubleDataEntry)
+       VALUES ('Upload Worker Test Site', ?, 20, 20, 'cm', 'm', 0)`,
+      [schema]
+    );
 
     // validation_runs is defined in tablestructures.sql but loadSchema's
     // semicolon-split filter silently skips it (the statement chunk begins
@@ -292,7 +301,10 @@ describe('runJobIfClaimable — integration', () => {
 
   afterAll(async () => {
     sharedState.catalogPool = null;
-    if (catalogPool) await catalogPool.end();
+    if (catalogPool) {
+      await catalogPool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [schema]);
+      await catalogPool.end();
+    }
     sharedState.connection = null;
     await teardownTestDatabase(connection, config);
   });


### PR DESCRIPTION
Every integration suite in this repo builds its schema with `local-db-setup`'s `loadSchema`, whose naive semicolon split silently drops any statement whose chunk opens with a `--` banner comment. `upload_errors`, `upload_sessions` and `validation_runs` are the casualties — `upload-worker.test.ts` hand-writes two of them back with inline DDL to compensate. Production provisioning uses a different splitter entirely (`lib/provisioning/sql-runner.ts`).

So the async upload path had never once run against a schema built the way production builds one, and the provisioning chain had never run end to end: `runProvisioning` was called by exactly one existing test, on a failure path, while the route tests deliberately spy out `setImmediate` so the dispatch never fires.

This adds a test that provisions a site through the real `STEPS` chain, checks the result against the canonical schema contract, seeds reference data through the production writers, uploads measurements via the background worker, and tears the site down.

## The bug it found

`catalog.background_jobs.SchemaName` is `NOT NULL`, but teardown deleted only the `usersiterelations` and `sites` rows before `DROP DATABASE`. Job rows survived, and `findRunnableJobIDs` selects on status and `NextAttemptAt` without checking that the schema still exists — so the sweeper kept dispatching a queued or `waiting_retry` job at a database that was gone, burning the retry budget on "unknown database" until `MaxRetries`. The existing teardown test only ever tore down an empty schema, so it could not see this.

The test case was written and demonstrated red (`promise resolved "undefined" instead of rejecting`) before the fix. Teardown now refuses with a `conflict` naming the offending job IDs, and deletes terminal job rows with the site inside the existing phase-1 transaction. A guard alone left a TOCTOU window — a job could be created between the check and the `DROP` — so `schema-operation-lock` serializes teardown against job creation.

## Also here

`upsertAttributeRows` / `upsertSpeciesRows` move out of `app/api/sqlpacketload/route.ts` into `lib/uploads/reference-data-writers.ts`, verbatim. They are database writers that were living in a request handler, and nothing outside the route could reach them: a Next.js route module may only export route fields, so adding `export` there fails the build with `"upsertAttributeRows" is not a valid Route export field`. The test seeds through them so its reference data is written by production code rather than parallel test SQL — which matters, because the async pipeline cannot seed reference data at all (`ASYNC_UPLOAD_V1_PIPELINES` is measurements-only).

## Worth a separate issue (#399)

Provisioning deploys all ten stored procedures with a hardcoded `DEFINER = azureroot@'%'` (`db/sql/storedprocedures.sql`, run verbatim by `executeSqlFile`). `CREATE` succeeds, so provisioning reports success and the site only breaks later at `CALL` time with `ER_NO_SUCH_USER`. Harmless on Azure, where `azureroot` is the admin account — but in-app provisioning cannot produce a working site on any MySQL lacking that user. Invisible to every other suite because `local-db-setup.ts:417` strips the clause. The test creates the user rather than stripping it, so the production DDL path stays under test.

## Cost

Runs in CI via the existing `tests/integration/**` glob — no workflow or config change. 2.2s of an 836s suite.


Does not fix #399 — this PR only works around the DEFINER problem inside the test (by creating the user rather than stripping the clause, so the production DDL path stays under test). The fix itself is tracked there.
