### PR TITLE
Distinguish un-provisioned logins from auth outages; revive client App Insights telemetry

### DIFF
--- a/.github/workflows/dev-forestgeo-livesite.yml
+++ b/.github/workflows/dev-forestgeo-livesite.yml
@@ -48,6 +48,10 @@ jobs:
           echo AZURE_SQL_CATALOG_SCHEMA=${{ secrets.AZURE_SQL_CATALOG_SCHEMA }} >> frontend/.env
           echo AZURE_STORAGE_CONNECTION_STRING=${{ secrets.AZURE_STORAGE_CONNECTION_STRING }} >> frontend/.env
           echo APP_INSIGHTS_CONNECTION_STRING=${{ secrets.APP_INSIGHTS_CONNECTION_STRING }} >> frontend/.env
+          # NEXT_PUBLIC_ variant is inlined into the client bundle at build time;
+          # without it the browser App Insights SDK never initializes (the
+          # connection string is a public telemetry identifier, not a secret).
+          echo NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING=${{ secrets.APP_INSIGHTS_CONNECTION_STRING }} >> frontend/.env
           echo NEXTAUTH_DEBUG=true >> frontend/.env
           echo NODE_ENV=development >> frontend/.env
           echo NEXT_RUNTIME=nodejs >> frontend/.env

--- a/.github/workflows/main-forestgeo-livesite.yml
+++ b/.github/workflows/main-forestgeo-livesite.yml
@@ -47,6 +47,10 @@ jobs:
           echo AZURE_SQL_CATALOG_SCHEMA=${{ secrets.AZURE_SQL_CATALOG_SCHEMA }} >> frontend/.env
           echo AZURE_STORAGE_CONNECTION_STRING=${{ secrets.AZURE_STORAGE_CONNECTION_STRING }} >> frontend/.env
           echo APP_INSIGHTS_CONNECTION_STRING=${{ secrets.APP_INSIGHTS_CONNECTION_STRING }} >> frontend/.env
+          # NEXT_PUBLIC_ variant is inlined into the client bundle at build time;
+          # without it the browser App Insights SDK never initializes (the
+          # connection string is a public telemetry identifier, not a secret).
+          echo NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING=${{ secrets.APP_INSIGHTS_CONNECTION_STRING }} >> frontend/.env
           echo NEXTAUTH_DEBUG=true >> frontend/.env
           echo NODE_ENV=production >> frontend/.env
           echo NEXT_RUNTIME=nodejs >> frontend/.env

--- a/frontend/ailogger.test.ts
+++ b/frontend/ailogger.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { getAppInsights } from './applicationinsights';
+import ailogger from './ailogger';
+
+// The global test setup replaces @/ailogger with a stub; this suite tests the
+// real implementation, so restore it and control only the AI accessor.
+vi.unmock('@/ailogger');
+vi.mock('./applicationinsights', () => ({
+  getAppInsights: vi.fn(() => null)
+}));
+
+// Regression test for the initialization race: ailogger is a module-level
+// singleton, so it is constructed the moment any page chunk imports it —
+// usually BEFORE the Providers useEffect calls initializeAppInsights. The old
+// implementation captured getAppInsights() once in the constructor, leaving
+// the logger permanently detached (all telemetry silently dropped) whenever
+// it lost that race. The logger must resolve the instance lazily instead.
+describe('ailogger late-initialization binding', () => {
+  const mockGetAppInsights = getAppInsights as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAppInsights.mockReturnValue(null);
+  });
+
+  it('does not throw when Application Insights is not initialized yet', () => {
+    expect(() => ailogger.event('pre-init-event')).not.toThrow();
+    expect(() => ailogger.error('pre-init-error')).not.toThrow();
+  });
+
+  it('delivers telemetry emitted AFTER Application Insights initializes, even though the logger was constructed before', () => {
+    // Simulate the race being lost at import time…
+    ailogger.event('dropped-while-uninitialized');
+
+    // …then Application Insights coming up (Providers useEffect ran).
+    const trackEvent = vi.fn();
+    const trackTrace = vi.fn();
+    const trackException = vi.fn();
+    mockGetAppInsights.mockReturnValue({ trackEvent, trackTrace, trackException });
+
+    ailogger.event('login-failure-displayed', { reason: 'user-not-provisioned', email: 'someone@example.com' });
+    expect(trackEvent).toHaveBeenCalledWith(
+      { name: 'login-failure-displayed' },
+      expect.objectContaining({ reason: 'user-not-provisioned', email: 'someone@example.com' })
+    );
+
+    ailogger.error('late error', new Error('boom'));
+    expect(trackException).toHaveBeenCalledTimes(1);
+    expect(trackTrace).toHaveBeenCalled();
+  });
+
+  it('survives getAppInsights throwing and falls back to console', () => {
+    mockGetAppInsights.mockImplementation(() => {
+      throw new Error('accessor exploded');
+    });
+    expect(() => ailogger.warn('still logs to console')).not.toThrow();
+  });
+});

--- a/frontend/ailogger.ts
+++ b/frontend/ailogger.ts
@@ -26,14 +26,16 @@ const levelToSeverityCode: Record<LogLevel, number> = {
  * Core logger that emits to Application Insights and also falls back to console
  */
 class Logger {
-  private readonly ai: ApplicationInsights | null = null;
-
-  constructor() {
+  // Resolved lazily on every access: this module is imported at page-chunk
+  // load, which races the Providers useEffect that calls initializeAppInsights.
+  // Capturing the instance once in a constructor left `ai` permanently null
+  // whenever the logger module loaded first, silently dropping all telemetry.
+  private get ai(): ApplicationInsights | null {
     try {
-      this.ai = getAppInsights();
+      return getAppInsights();
     } catch (error) {
-      console.warn('[ailogger] Failed to initialize Application Insights:', error);
-      this.ai = null;
+      console.warn('[ailogger] Failed to get Application Insights instance:', error);
+      return null;
     }
   }
 

--- a/frontend/app/(hub)/layout.tsx
+++ b/frontend/app/(hub)/layout.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/app/contexts/compat-hooks';
 import { useHasHydrated } from '@/config/store/appstore';
 import { DOCUMENTATION_URL, getEndpointHeaderName, siteConfig } from '@/config/macros/siteconfigs';
+import { LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
 import GithubFeedbackModal from '@/components/client/modals/githubfeedbackmodal';
 import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined';
 import { useLockAnimation } from '../contexts/lockanimationcontext';
@@ -224,9 +225,9 @@ export default function HubLayout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (session?.user?.permissionsUnavailable) {
-      redirect('/loginfailed?reason=permissions-unavailable');
+      redirect(`/loginfailed?reason=${session.user.permissionsFailureReason ?? LOGIN_FAILURE_REASONS.PERMISSIONS_UNAVAILABLE}`);
     }
-  }, [session?.user?.permissionsUnavailable]);
+  }, [session?.user?.permissionsUnavailable, session?.user?.permissionsFailureReason]);
 
   // Fetch site list after hydration when session exists
   // IMPORTANT: Wait for Zustand hydration before fetching to avoid race conditions

--- a/frontend/auth.ts
+++ b/frontend/auth.ts
@@ -1,7 +1,8 @@
 // auth.ts
 import NextAuth from 'next-auth';
 import authConfig from '@/auth.config';
-import { getOrFetchPermissions } from '@/lib/permissionscache';
+import { getOrFetchPermissions, UserNotProvisionedError } from '@/lib/permissionscache';
+import { LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
 
 export const { auth, handlers, signIn, signOut } = NextAuth({
   secret: process.env.AUTH_SECRET!,
@@ -72,6 +73,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         session.user.sites = [];
         session.user.allsites = [];
         session.user.permissionsUnavailable = true;
+        // A 404 means this login has no catalog.users row — retrying can never
+        // succeed, so the login-failure page must not present it as transient.
+        session.user.permissionsFailureReason =
+          error instanceof UserNotProvisionedError ? LOGIN_FAILURE_REASONS.USER_NOT_PROVISIONED : LOGIN_FAILURE_REASONS.PERMISSIONS_UNAVAILABLE;
       }
       return session;
     }

--- a/frontend/components/client/modals/loginfailure.test.tsx
+++ b/frontend/components/client/modals/loginfailure.test.tsx
@@ -79,6 +79,20 @@ describe('LoginFailed - Functional Tests', () => {
       expect(screen.queryByText(/permissions-unavailable/i)).not.toBeInTheDocument();
     });
 
+    it('MUST display actionable non-transient message for user-not-provisioned slug', () => {
+      mockUseSearchParams.mockReturnValue({
+        get: vi.fn().mockReturnValue('user-not-provisioned')
+      });
+
+      render(<LoginFailed />);
+
+      expect(screen.getByText(/no forestgeo account has been set up/i)).toBeInTheDocument();
+      // Must NOT show the transient-outage message — an unprovisioned user
+      // retrying forever was exactly the bug this slug exists to fix.
+      expect(screen.queryByText(/could not reach the authentication service/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/user-not-provisioned/i)).not.toBeInTheDocument();
+    });
+
     it('MUST fall through to default message for unknown reason slug', () => {
       mockUseSearchParams.mockReturnValue({
         get: vi.fn().mockReturnValue('some-unmapped-slug')

--- a/frontend/components/client/modals/loginfailure.test.tsx
+++ b/frontend/components/client/modals/loginfailure.test.tsx
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoginFailed from './loginfailure';
-import { signOut } from 'next-auth/react';
+import { signOut, useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
+import ailogger from '@/ailogger';
 
 // Mock next-auth/react
 vi.mock('next-auth/react', () => ({
-  signOut: vi.fn()
+  signOut: vi.fn(),
+  useSession: vi.fn()
 }));
 
 // Mock next/navigation
@@ -18,16 +20,19 @@ vi.mock('next/navigation', () => ({
 // Mock ailogger
 vi.mock('@/ailogger', () => ({
   default: {
-    error: vi.fn()
+    error: vi.fn(),
+    event: vi.fn()
   }
 }));
 
 describe('LoginFailed - Functional Tests', () => {
   const mockSignOut = signOut as unknown as ReturnType<typeof vi.fn>;
+  const mockUseSession = useSession as unknown as ReturnType<typeof vi.fn>;
   const mockUseSearchParams = useSearchParams as unknown as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
 
     // Mock sessionStorage and localStorage
     global.sessionStorage = {
@@ -91,6 +96,52 @@ describe('LoginFailed - Functional Tests', () => {
       // retrying forever was exactly the bug this slug exists to fix.
       expect(screen.queryByText(/could not reach the authentication service/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/user-not-provisioned/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/contact a forestgeo administrator to request access/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+    });
+
+    it('MUST emit a telemetry event carrying the exact session email claim and reason slug', () => {
+      mockUseSearchParams.mockReturnValue({
+        get: vi.fn().mockReturnValue('user-not-provisioned')
+      });
+      mockUseSession.mockReturnValue({ data: { user: { email: '72325639@nebraska.edu' } }, status: 'authenticated' });
+
+      render(<LoginFailed />);
+
+      // The email property must be the verbatim claim — it is the string an
+      // administrator has to copy into catalog.users to unblock the user.
+      expect(ailogger.event).toHaveBeenCalledWith('login-failure-displayed', {
+        reason: 'user-not-provisioned',
+        email: '72325639@nebraska.edu'
+      });
+    });
+
+    it('MUST emit telemetry with placeholders when session is absent and reason is missing', () => {
+      mockUseSearchParams.mockReturnValue({
+        get: vi.fn().mockReturnValue(null)
+      });
+
+      render(<LoginFailed />);
+
+      expect(ailogger.event).toHaveBeenCalledWith('login-failure-displayed', {
+        reason: 'none',
+        email: 'unknown'
+      });
+    });
+
+    it('MUST truncate attacker-length reason slugs before forwarding to telemetry', () => {
+      const longReason = 'A'.repeat(500);
+      mockUseSearchParams.mockReturnValue({
+        get: vi.fn().mockReturnValue(longReason)
+      });
+
+      render(<LoginFailed />);
+
+      const eventMock = ailogger.event as unknown as ReturnType<typeof vi.fn>;
+      const forwardedReason = eventMock.mock.calls[0][1].reason as string;
+      expect(forwardedReason).toHaveLength(100);
+      expect(forwardedReason).toBe('A'.repeat(100));
     });
 
     it('MUST fall through to default message for unknown reason slug', () => {

--- a/frontend/components/client/modals/loginfailure.tsx
+++ b/frontend/components/client/modals/loginfailure.tsx
@@ -4,11 +4,14 @@ import { Button, Stack, Typography } from '@mui/joy';
 import { signOut } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import ailogger from '@/ailogger';
+import { LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
 
 // Map known reason slugs to user-facing messages. Unknown slugs fall through
 // to a generic "contact administrator" message — never expose the raw slug.
 const REASON_MESSAGES: Record<string, string> = {
-  'permissions-unavailable': 'We could not reach the authentication service. This is usually temporary — please try again in a moment.'
+  [LOGIN_FAILURE_REASONS.PERMISSIONS_UNAVAILABLE]: 'We could not reach the authentication service. This is usually temporary — please try again in a moment.',
+  [LOGIN_FAILURE_REASONS.USER_NOT_PROVISIONED]:
+    'Your Microsoft sign-in worked, but no ForestGEO account has been set up for it yet. Retrying will not help — please ask a ForestGEO administrator to add your account.'
 };
 
 const DEFAULT_MESSAGE = 'Login failure triggered without reason. Please speak to an administrator.';

--- a/frontend/components/client/modals/loginfailure.tsx
+++ b/frontend/components/client/modals/loginfailure.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Button, Stack, Typography } from '@mui/joy';
-import { signOut } from 'next-auth/react';
+import { signOut, useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import ailogger from '@/ailogger';
-import { LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
+import { LOGIN_FAILURE_EVENT_NAME, LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
 
 // Map known reason slugs to user-facing messages. Unknown slugs fall through
 // to a generic "contact administrator" message — never expose the raw slug.
@@ -16,12 +17,30 @@ const REASON_MESSAGES: Record<string, string> = {
 
 const DEFAULT_MESSAGE = 'Login failure triggered without reason. Please speak to an administrator.';
 
+// The reason slug is attacker-controllable query input; cap what we forward
+// to telemetry so a crafted URL cannot stuff arbitrary payloads into it.
+const MAX_TELEMETRY_REASON_LENGTH = 100;
+
 const LoginFailed = () => {
   const searchParams = useSearchParams();
+  const { data: session } = useSession();
   const reasonSlug = searchParams?.get('reason') ?? '';
   const failureMessage = REASON_MESSAGES[reasonSlug] ?? DEFAULT_MESSAGE;
+  const isUserNotProvisioned = reasonSlug === LOGIN_FAILURE_REASONS.USER_NOT_PROVISIONED;
+  const userEmail = session?.user?.email;
 
-  const handleTryAgain = () => {
+  // Surface the failure to App Insights with the exact email claim the session
+  // presented. Server-side logs never leave the box, so for user-not-provisioned
+  // this event is the only remotely queryable record of the one string an
+  // administrator has to copy into catalog.users.
+  useEffect(() => {
+    ailogger.event(LOGIN_FAILURE_EVENT_NAME, {
+      reason: reasonSlug.slice(0, MAX_TELEMETRY_REASON_LENGTH) || 'none',
+      email: userEmail ?? 'unknown'
+    });
+  }, [reasonSlug, userEmail]);
+
+  const handleSignOut = () => {
     sessionStorage.clear();
     localStorage.clear();
     signOut({ redirectTo: '/login' }).catch(ailogger.error);
@@ -35,9 +54,13 @@ const LoginFailed = () => {
       <Typography level="h4" component={'h5'} color={'warning'}>
         {failureMessage}
       </Typography>
-      <Typography>We couldn&apos;t log you in. Please try again or contact support for more help.</Typography>
-      <Button variant="solid" onClick={handleTryAgain}>
-        Try Again
+      <Typography>
+        {isUserNotProvisioned
+          ? 'Contact a ForestGEO administrator to request access. After your account has been added, sign out and log in again.'
+          : "We couldn't log you in. Please try again or contact support for more help."}
+      </Typography>
+      <Button variant="solid" onClick={handleSignOut}>
+        {isUserNotProvisioned ? 'Sign Out' : 'Try Again'}
       </Button>
     </Stack>
   );

--- a/frontend/config/loginfailurereasons.ts
+++ b/frontend/config/loginfailurereasons.ts
@@ -8,3 +8,9 @@ export const LOGIN_FAILURE_REASONS = {
 } as const;
 
 export type LoginFailureReason = (typeof LOGIN_FAILURE_REASONS)[keyof typeof LOGIN_FAILURE_REASONS];
+
+// App Insights custom event emitted when the login-failure page is shown.
+// Queryable via: customEvents | where name == 'login-failure-displayed'
+// — the properties carry the reason slug and the exact email claim the
+// session presented, which is the string an admin must put in catalog.users.
+export const LOGIN_FAILURE_EVENT_NAME = 'login-failure-displayed';

--- a/frontend/config/loginfailurereasons.ts
+++ b/frontend/config/loginfailurereasons.ts
@@ -1,0 +1,10 @@
+// Reason slugs shared between the session callback (which classifies the
+// failure), the hub layout (which builds the /loginfailed redirect), and the
+// login-failure page (which maps slugs to user-facing messages). Kept
+// dependency-free so it is safe to import from both server and client code.
+export const LOGIN_FAILURE_REASONS = {
+  PERMISSIONS_UNAVAILABLE: 'permissions-unavailable',
+  USER_NOT_PROVISIONED: 'user-not-provisioned'
+} as const;
+
+export type LoginFailureReason = (typeof LOGIN_FAILURE_REASONS)[keyof typeof LOGIN_FAILURE_REASONS];

--- a/frontend/lib/permissionscache.test.ts
+++ b/frontend/lib/permissionscache.test.ts
@@ -125,6 +125,21 @@ describe('permissionscache', () => {
     expect(getCachedPermissions(EMAIL)).toBeNull();
   });
 
+  it('upstream 404 with the structured User not found payload throws UserNotProvisionedError', async () => {
+    const fetchMock = makeFetchErr(404, JSON.stringify({ error: 'User not found' }));
+    await expect(getOrFetchPermissions(EMAIL, fetchMock)).rejects.toBeInstanceOf(UserNotProvisionedError);
+  });
+
+  it('unrecognized 404 responses stay generic errors instead of misclassifying every user as unprovisioned', async () => {
+    for (const body of ['Not Found', '<html><body>Function route not found</body></html>', JSON.stringify({ error: 'Route not found' })]) {
+      _clearCacheForTest();
+      const fetchMock = makeFetchErr(404, body);
+      const error = await getOrFetchPermissions(EMAIL, fetchMock).catch(e => e);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(UserNotProvisionedError);
+    }
+  });
+
   it('non-404 failures stay generic errors — outages must never be classified as unprovisioned users', async () => {
     for (const status of [500, 502, 503]) {
       _clearCacheForTest();

--- a/frontend/lib/permissionscache.test.ts
+++ b/frontend/lib/permissionscache.test.ts
@@ -3,6 +3,7 @@ import {
   getOrFetchPermissions,
   getCachedPermissions,
   invalidatePermissions,
+  UserNotProvisionedError,
   _clearCacheForTest,
   _seedCacheForTest,
   type CachedPermissions
@@ -114,6 +115,24 @@ describe('permissionscache', () => {
     const fetchMock = makeFetchErr(503, 'service unavailable');
     await expect(getOrFetchPermissions(EMAIL, fetchMock)).rejects.toThrow(/503/);
     expect(getCachedPermissions(EMAIL)).toBeNull();
+  });
+
+  it('upstream 404 (User not found) throws UserNotProvisionedError and does not cache', async () => {
+    const fetchMock = makeFetchErr(404, 'User not found');
+    await expect(getOrFetchPermissions(EMAIL, fetchMock)).rejects.toBeInstanceOf(UserNotProvisionedError);
+    // Not negatively cached: once an admin creates the catalog.users row, the
+    // very next poll must succeed without waiting out a TTL.
+    expect(getCachedPermissions(EMAIL)).toBeNull();
+  });
+
+  it('non-404 failures stay generic errors — outages must never be classified as unprovisioned users', async () => {
+    for (const status of [500, 502, 503]) {
+      _clearCacheForTest();
+      const fetchMock = makeFetchErr(status);
+      const error = await getOrFetchPermissions(EMAIL, fetchMock).catch(e => e);
+      expect(error, `status ${status}`).toBeInstanceOf(Error);
+      expect(error, `status ${status}`).not.toBeInstanceOf(UserNotProvisionedError);
+    }
   });
 
   it('missing AUTH_FUNCTIONS_POLL_URL is a configuration error, not a 500-from-upstream', async () => {

--- a/frontend/lib/permissionscache.ts
+++ b/frontend/lib/permissionscache.ts
@@ -32,6 +32,18 @@ interface AuthFunctionResponse {
   allSites: SitesResult[];
 }
 
+// The auth function returns 404 exclusively for "User not found" — an email
+// with no catalog.users row. Surfacing that as a distinct error type lets the
+// session callback tell "you have no account yet" apart from a real outage.
+const HTTP_NOT_FOUND = 404;
+
+export class UserNotProvisionedError extends Error {
+  constructor(email: string) {
+    super(`auth function has no user registered for ${email}`);
+    this.name = 'UserNotProvisionedError';
+  }
+}
+
 // 5 minutes default TTL — short enough that revocation propagates within a
 // reasonable window, long enough that the auth fetch is amortized across many
 // requests. Override with PERMISSIONS_CACHE_TTL_MS for tuning.
@@ -92,6 +104,9 @@ async function fetchAndShape(email: string, fetchImpl: typeof fetch): Promise<Ca
       statusText: response.statusText,
       body: body.slice(0, 500)
     });
+    if (response.status === HTTP_NOT_FOUND) {
+      throw new UserNotProvisionedError(email);
+    }
     throw new Error(`auth function poll failed (${response.status})`);
   }
   const data = (await response.json()) as AuthFunctionResponse;

--- a/frontend/lib/permissionscache.ts
+++ b/frontend/lib/permissionscache.ts
@@ -32,10 +32,24 @@ interface AuthFunctionResponse {
   allSites: SitesResult[];
 }
 
-// The auth function returns 404 exclusively for "User not found" — an email
-// with no catalog.users row. Surfacing that as a distinct error type lets the
-// session callback tell "you have no account yet" apart from a real outage.
+// The auth function uses a 404 with a "User not found" payload for an email
+// with no catalog.users row. Check both signals so a missing or misconfigured
+// function route is not mistaken for an unprovisioned user.
 const HTTP_NOT_FOUND = 404;
+
+function isUserNotFoundResponse(body: string): boolean {
+  const trimmedBody = body.trim();
+  if (trimmedBody.toLowerCase() === 'user not found') return true;
+
+  try {
+    const payload = JSON.parse(trimmedBody) as unknown;
+    if (!payload || typeof payload !== 'object') return false;
+    const error = (payload as { error?: unknown }).error;
+    return typeof error === 'string' && error.trim().toLowerCase() === 'user not found';
+  } catch {
+    return false;
+  }
+}
 
 export class UserNotProvisionedError extends Error {
   constructor(email: string) {
@@ -104,7 +118,7 @@ async function fetchAndShape(email: string, fetchImpl: typeof fetch): Promise<Ca
       statusText: response.statusText,
       body: body.slice(0, 500)
     });
-    if (response.status === HTTP_NOT_FOUND) {
+    if (response.status === HTTP_NOT_FOUND && isUserNotFoundResponse(body)) {
       throw new UserNotProvisionedError(email);
     }
     throw new Error(`auth function poll failed (${response.status})`);

--- a/frontend/tests/mocks/bg-mocks.ts
+++ b/frontend/tests/mocks/bg-mocks.ts
@@ -19,7 +19,7 @@ vi.mock('chalk', () => ({
 
 vi.mock('@/ailogger', () => {
   const noop = vi.fn();
-  return { default: { info: noop, warn: noop, error: noop, debug: noop } };
+  return { default: { info: noop, warn: noop, error: noop, debug: noop, critical: noop, event: noop, metric: noop } };
 });
 
 // ---------------------------

--- a/frontend/tests/mocks/db-mocks.ts
+++ b/frontend/tests/mocks/db-mocks.ts
@@ -23,7 +23,10 @@ vi.mock('@/ailogger', () => {
       info: noop,
       warn: noop,
       error: noop,
-      debug: noop
+      debug: noop,
+      critical: noop,
+      event: noop,
+      metric: noop
     }
   };
 });

--- a/frontend/tests/mocks/mockstesting/auth-mocks.test.ts
+++ b/frontend/tests/mocks/mockstesting/auth-mocks.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import '@/tests/mocks/auth-mocks';
 import { __auth } from '@/tests/mocks/auth-mocks';
 import { loadRoute } from '@/tests/mocks/supportstruts';
+import { LOGIN_FAILURE_REASONS } from '@/config/loginfailurereasons';
 
 // If you keep shared types here, fine; otherwise inline:
 type RouteHandler = (req: Request, ctx?: { params?: { nextauth?: string[] } }) => Promise<Response>;
@@ -140,6 +141,22 @@ describe('NextAuth route (App Router compliant)', () => {
     expect(result.user.sites).toEqual([]);
     expect(result.user.allsites).toEqual([]);
     expect(result.user.permissionsUnavailable).toBe(true);
+  });
+
+  it('carries the user-not-provisioned reason through the session callback for a recognized 404', async () => {
+    await loadRoute<Record<string, unknown>>(ROUTE_PATH);
+    const cfg = __auth.getConfig();
+    expect(cfg?.callbacks?.session).toBeTypeOf('function');
+
+    __auth.pushFetchFail(404, { error: 'User not found' });
+
+    const result = await cfg.callbacks.session({
+      session: { user: { email: 'unprovisioned@example.com' } },
+      token: { email: 'unprovisioned@example.com', isE2ETestUser: false }
+    });
+
+    expect(result.user.permissionsUnavailable).toBe(true);
+    expect(result.user.permissionsFailureReason).toBe(LOGIN_FAILURE_REASONS.USER_NOT_PROVISIONED);
   });
 
   it('does NOT mark permissionsUnavailable on the success path', async () => {

--- a/frontend/tests/mocks/platform-mocks.ts
+++ b/frontend/tests/mocks/platform-mocks.ts
@@ -86,7 +86,7 @@ vi.mock('chalk', () => ({
 }));
 vi.mock('@/ailogger', () => {
   const noop = vi.fn();
-  return { default: { info: noop, warn: noop, error: noop, debug: noop } };
+  return { default: { info: noop, warn: noop, error: noop, debug: noop, critical: noop, event: noop, metric: noop } };
 });
 
 beforeEach(() => {

--- a/frontend/types/next-auth.d.ts
+++ b/frontend/types/next-auth.d.ts
@@ -1,6 +1,7 @@
 import 'next-auth';
 import { Profile } from 'next-auth';
 import { UserAuthRoles } from '@/config/macros';
+import { LoginFailureReason } from '@/config/loginfailurereasons';
 import { SitesRDS } from '@/lib/db/definitions/zones';
 
 declare module 'next-auth' {
@@ -19,6 +20,10 @@ declare module 'next-auth' {
        *  from the auth function (transient failure). The hub layout treats
        *  this as fail-closed and redirects instead of rendering a broken UI. */
       permissionsUnavailable?: boolean;
+      /** Why permissions failed: distinguishes a login with no catalog.users
+       *  row (auth function 404 — retrying can never succeed) from a transient
+       *  outage, so the login-failure page can show actionable guidance. */
+      permissionsFailureReason?: LoginFailureReason;
     };
   }
 


### PR DESCRIPTION
## Summary

An invited user with no `catalog.users` row (auth function 404) was told "could not reach the authentication service — try again," trapping them in a sign-in loop (hit by Sabrina Russo on the dev site 2026-07-30). This PR makes that case diagnosable and self-explanatory, and fixes the two defects that had left client-side App Insights telemetry dead in every deployed environment.

### Login failure classification
- `permissionscache`: a 404 whose body carries the auth function's "User not found" payload now throws a typed `UserNotProvisionedError`; other 404s and all 5xx stay generic so infrastructure faults are never reported as "no account exists."
- `auth.ts` stamps `permissionsFailureReason` on the session alongside the existing fail-closed `permissionsUnavailable` flag (all downstream 503/authz behavior unchanged).
- The hub layout passes the reason through to `/loginfailed`, which now tells un-provisioned users to contact an administrator (with a Sign Out button) instead of suggesting a retry that can never succeed.

### Observability
- `ailogger` resolved its App Insights instance once at module load, racing the provider's `initializeAppInsights` — losing left it permanently detached. It now resolves lazily (regression-tested).
- The deploy workflows only wrote `APP_INSIGHTS_CONNECTION_STRING`, which nothing reads; the browser accessor needs `NEXT_PUBLIC_APP_INSIGHTS_CONNECTION_STRING` inlined at build time. Both workflows now write it. Measured before this fix: zero browser telemetry on both livesite and development App Insights over 14 days.
- `/loginfailed` emits a `login-failure-displayed` custom event carrying the reason slug and the exact session email claim — the string an administrator must copy into `catalog.users`. Server logs never leave the App Service (application logging is off), so this client-side event is the only remotely queryable record of these failures.

Unit (245 files / 3,638 tests), integration (118 files / 1,008 tests), lint, and a local production build are all green.