### PR TITLE
fix: self-heal the PoolMonitor pool for raw-pool consumers

### DIFF
--- a/frontend/app/api/admin/provision/[runId]/abort/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/abort/route.ts
@@ -22,7 +22,7 @@ export async function POST(_req: Request, { params }: { params: Promise<{ runId:
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/[runId]/mark-failed/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/mark-failed/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ runId: 
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/[runId]/reconcile/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/reconcile/route.ts
@@ -22,7 +22,7 @@ export async function POST(_req: Request, { params }: { params: Promise<{ runId:
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/[runId]/retry/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/retry/route.ts
@@ -22,7 +22,7 @@ export async function POST(_req: Request, { params }: { params: Promise<{ runId:
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/[runId]/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/route.ts
@@ -37,7 +37,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ runId: 
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/[runId]/teardown/route.ts
+++ b/frontend/app/api/admin/provision/[runId]/teardown/route.ts
@@ -35,7 +35,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ runId
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/list/route.ts
+++ b/frontend/app/api/admin/provision/list/route.ts
@@ -16,7 +16,7 @@ export async function GET(_req: Request) {
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/admin/provision/route.ts
+++ b/frontend/app/api/admin/provision/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
 
   let catalogPool;
   try {
-    catalogPool = getPoolMonitorInstance().pool;
+    catalogPool = await getPoolMonitorInstance().getUsablePool();
   } catch (err) {
     return provisioningErrorResponse(new ProvisioningError('Database unavailable', 'database_unavailable', { cause: err }));
   }

--- a/frontend/app/api/uploadjobs/[jobId]/route.test.ts
+++ b/frontend/app/api/uploadjobs/[jobId]/route.test.ts
@@ -9,7 +9,8 @@ const mocks = vi.hoisted(() => ({
   getBackgroundJobWithDetails: vi.fn(),
   cancelBackgroundJob: vi.fn(),
   requestBackgroundJobCancel: vi.fn(),
-  executeQuery: vi.fn()
+  executeQuery: vi.fn(),
+  loggerError: vi.fn()
 }));
 
 vi.mock('@/auth', () => ({
@@ -35,6 +36,14 @@ vi.mock('@/lib/background-jobs/repository', () => ({
   getBackgroundJobWithDetails: mocks.getBackgroundJobWithDetails,
   cancelBackgroundJob: mocks.cancelBackgroundJob,
   requestBackgroundJobCancel: mocks.requestBackgroundJobCancel
+}));
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    error: mocks.loggerError,
+    warn: vi.fn(),
+    info: vi.fn()
+  }
 }));
 
 const AUTHORIZED_SCHEMA = 'forestgeo_testing';
@@ -81,6 +90,18 @@ describe('GET /api/uploadjobs/[jobId]', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ job: ownedJob });
     expect(mocks.getBackgroundJobWithDetails).toHaveBeenCalledWith('catalog-pool', 42);
+  });
+
+  it('returns 503 and logs when the catalog pool cannot self-heal', async () => {
+    const failure = new Error('pool rebuild failed');
+    mocks.getPoolMonitorInstance.mockReturnValueOnce({ getUsablePool: vi.fn().mockRejectedValue(failure) });
+
+    const response = await GET(makeGetRequest(), jobProps());
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: 'Upload job database is unavailable' });
+    expect(mocks.getBackgroundJobWithDetails).not.toHaveBeenCalled();
+    expect(mocks.loggerError).toHaveBeenCalledWith('uploadjobs.database_unavailable', failure);
   });
 
   it('rejects access to another user job in the same schema with 403 after a single catalog read', async () => {

--- a/frontend/app/api/uploadjobs/[jobId]/route.test.ts
+++ b/frontend/app/api/uploadjobs/[jobId]/route.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   auth: vi.fn(),
   requireSession: vi.fn(() => null),
   getSessionUserId: vi.fn(() => 'mason@example.com'),
-  getPoolMonitorInstance: vi.fn(() => ({ pool: 'catalog-pool' })),
+  getPoolMonitorInstance: vi.fn(() => ({ getUsablePool: vi.fn(async () => 'catalog-pool') })),
   getBackgroundJobWithDetails: vi.fn(),
   cancelBackgroundJob: vi.fn(),
   requestBackgroundJobCancel: vi.fn(),

--- a/frontend/app/api/uploadjobs/[jobId]/route.ts
+++ b/frontend/app/api/uploadjobs/[jobId]/route.ts
@@ -47,7 +47,7 @@ async function getHandler(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Missing or invalid parameters' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const job = await getBackgroundJobWithDetails(getPoolMonitorInstance().pool, parsedJobID);
+  const job = await getBackgroundJobWithDetails(await getPoolMonitorInstance().getUsablePool(), parsedJobID);
   if (!job || !jobBelongsToAuthorizedSchema(job, schema)) {
     return NextResponse.json({ error: 'Upload job not found' }, { status: HTTPResponses.NOT_FOUND });
   }
@@ -74,7 +74,7 @@ async function postHandler(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Missing or invalid parameters' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const job = await getBackgroundJobWithDetails(getPoolMonitorInstance().pool, parsedJobID);
+  const job = await getBackgroundJobWithDetails(await getPoolMonitorInstance().getUsablePool(), parsedJobID);
   if (!job || !jobBelongsToAuthorizedSchema(job, schema)) {
     return NextResponse.json({ error: 'Upload job not found' }, { status: HTTPResponses.NOT_FOUND });
   }
@@ -102,7 +102,7 @@ async function postHandler(request: NextRequest, context: RouteContext) {
   }
 
   const userID = getSessionUserId(session!) ?? 'unknown';
-  const catalogPool = getPoolMonitorInstance().pool;
+  const catalogPool = await getPoolMonitorInstance().getUsablePool();
 
   // queued/waiting_retry jobs have no worker and are cancelled directly.
   const cancelled = await cancelBackgroundJob(catalogPool, parsedJobID, userID);

--- a/frontend/app/api/uploadjobs/[jobId]/route.ts
+++ b/frontend/app/api/uploadjobs/[jobId]/route.ts
@@ -13,6 +13,20 @@ import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz'
 
 export const runtime = 'nodejs';
 
+async function resolveCatalogPool() {
+  try {
+    return await getPoolMonitorInstance().getUsablePool();
+  } catch (error: unknown) {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    ailogger.error('uploadjobs.database_unavailable', normalized);
+    return null;
+  }
+}
+
+function databaseUnavailableResponse() {
+  return NextResponse.json({ error: 'Upload job database is unavailable' }, { status: HTTPResponses.SERVICE_UNAVAILABLE });
+}
+
 /**
  * The `schema` query param authorizes the request (withRouteAuthz already
  * confirmed the caller is a member of it, or an admin). A job lookup by
@@ -47,7 +61,10 @@ async function getHandler(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Missing or invalid parameters' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const job = await getBackgroundJobWithDetails(await getPoolMonitorInstance().getUsablePool(), parsedJobID);
+  const catalogPool = await resolveCatalogPool();
+  if (!catalogPool) return databaseUnavailableResponse();
+
+  const job = await getBackgroundJobWithDetails(catalogPool, parsedJobID);
   if (!job || !jobBelongsToAuthorizedSchema(job, schema)) {
     return NextResponse.json({ error: 'Upload job not found' }, { status: HTTPResponses.NOT_FOUND });
   }
@@ -74,7 +91,10 @@ async function postHandler(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Missing or invalid parameters' }, { status: HTTPResponses.INVALID_REQUEST });
   }
 
-  const job = await getBackgroundJobWithDetails(await getPoolMonitorInstance().getUsablePool(), parsedJobID);
+  const catalogPool = await resolveCatalogPool();
+  if (!catalogPool) return databaseUnavailableResponse();
+
+  const job = await getBackgroundJobWithDetails(catalogPool, parsedJobID);
   if (!job || !jobBelongsToAuthorizedSchema(job, schema)) {
     return NextResponse.json({ error: 'Upload job not found' }, { status: HTTPResponses.NOT_FOUND });
   }
@@ -102,8 +122,6 @@ async function postHandler(request: NextRequest, context: RouteContext) {
   }
 
   const userID = getSessionUserId(session!) ?? 'unknown';
-  const catalogPool = await getPoolMonitorInstance().getUsablePool();
-
   // queued/waiting_retry jobs have no worker and are cancelled directly.
   const cancelled = await cancelBackgroundJob(catalogPool, parsedJobID, userID);
   if (cancelled) {

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -231,6 +231,18 @@ describe('POST /api/uploadjobs', () => {
     expect(mocks.runJobIfClaimable).toHaveBeenCalledWith(42);
   });
 
+  it('returns 503 and logs when the catalog pool cannot self-heal', async () => {
+    const failure = new Error('pool rebuild failed');
+    mocks.getPoolMonitorInstance.mockReturnValueOnce({ getUsablePool: vi.fn().mockRejectedValue(failure) });
+
+    const response = await callPost(makeCreateRequest(makeCreateBody()));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: 'Upload job database is unavailable' });
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+    expect(mocks.loggerError).toHaveBeenCalledWith('uploadjobs.database_unavailable', failure);
+  });
+
   it('still returns 202 when the worker kick rejects, and logs the kick failure', async () => {
     mocks.runJobIfClaimable.mockRejectedValueOnce(new Error('claim-time infrastructure outage'));
 
@@ -774,6 +786,18 @@ describe('GET /api/uploadjobs', () => {
     vi.clearAllMocks();
     mocks.auth.mockResolvedValue(session);
     mocks.listBackgroundJobs.mockResolvedValue([{ jobID: 42, status: 'queued' }]);
+  });
+
+  it('returns 503 and logs when the catalog pool cannot self-heal', async () => {
+    const failure = new Error('pool rebuild failed');
+    mocks.getPoolMonitorInstance.mockReturnValueOnce({ getUsablePool: vi.fn().mockRejectedValue(failure) });
+
+    const response = await callGet(makeListRequest('?schema=forestgeo_testing'));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: 'Upload job database is unavailable' });
+    expect(mocks.listBackgroundJobs).not.toHaveBeenCalled();
+    expect(mocks.loggerError).toHaveBeenCalledWith('uploadjobs.database_unavailable', failure);
   });
 
   it('lists active jobs for the authenticated user and optional scope', async () => {

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   isValidSchema: vi.fn(() => true),
   assertCanEditMeasurementScope: vi.fn(async () => ({ plotCensusNumber: 2 })),
   getContainerName: vi.fn(() => 'forestgeo-testing-storage'),
-  getPoolMonitorInstance: vi.fn(() => ({ pool: 'catalog-pool' })),
+  getPoolMonitorInstance: vi.fn(() => ({ getUsablePool: vi.fn(async () => 'catalog-pool') })),
   createUploadBackgroundJob: vi.fn(),
   listBackgroundJobs: vi.fn(),
   isAsyncUploadEnabledFor: vi.fn(() => true),

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -33,6 +33,20 @@ const MYSQL_SIGNED_INT_MAX = 2_147_483_647;
 
 const SUPPORTED_DELIMITER_SET = new Set<string>(SUPPORTED_DELIMITERS);
 
+async function resolveCatalogPool() {
+  try {
+    return await getPoolMonitorInstance().getUsablePool();
+  } catch (error: unknown) {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    ailogger.error('uploadjobs.database_unavailable', normalized);
+    return null;
+  }
+}
+
+function databaseUnavailableResponse() {
+  return NextResponse.json({ error: 'Upload job database is unavailable' }, { status: HTTPResponses.SERVICE_UNAVAILABLE });
+}
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -408,7 +422,8 @@ async function postHandler(request: NextRequest) {
   const blobOwnershipError = await rejectUnownedBlobReferences(input, userID, authorizedContainer);
   if (blobOwnershipError) return blobOwnershipError;
 
-  const catalogPool = await getPoolMonitorInstance().getUsablePool();
+  const catalogPool = await resolveCatalogPool();
+  if (!catalogPool) return databaseUnavailableResponse();
   let job;
   try {
     job = await createUploadBackgroundJob(
@@ -480,7 +495,10 @@ async function getHandler(request: NextRequest) {
   const activeOnly = rawActiveOnly !== 'false';
   const includeAllUsers = rawAllUsers === 'true' && isPrivilegedSession(session!);
 
-  const jobs = await listBackgroundJobs(await getPoolMonitorInstance().getUsablePool(), {
+  const catalogPool = await resolveCatalogPool();
+  if (!catalogPool) return databaseUnavailableResponse();
+
+  const jobs = await listBackgroundJobs(catalogPool, {
     userID,
     includeAllUsers,
     activeOnly,

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -408,7 +408,7 @@ async function postHandler(request: NextRequest) {
   const blobOwnershipError = await rejectUnownedBlobReferences(input, userID, authorizedContainer);
   if (blobOwnershipError) return blobOwnershipError;
 
-  const catalogPool = getPoolMonitorInstance().pool;
+  const catalogPool = await getPoolMonitorInstance().getUsablePool();
   let job;
   try {
     job = await createUploadBackgroundJob(
@@ -480,7 +480,7 @@ async function getHandler(request: NextRequest) {
   const activeOnly = rawActiveOnly !== 'false';
   const includeAllUsers = rawAllUsers === 'true' && isPrivilegedSession(session!);
 
-  const jobs = await listBackgroundJobs(getPoolMonitorInstance().pool, {
+  const jobs = await listBackgroundJobs(await getPoolMonitorInstance().getUsablePool(), {
     userID,
     includeAllUsers,
     activeOnly,

--- a/frontend/instrumentation-node.ts
+++ b/frontend/instrumentation-node.ts
@@ -23,9 +23,11 @@ import { ensureCatalogTables } from '@/lib/provisioning/orchestrator';
 import { installShutdownHandler, pickupStaleRuns } from '@/lib/provisioning/worker';
 
 void (async () => {
-  let pool: ReturnType<typeof getPoolMonitorInstance>['pool'];
+  let monitor: ReturnType<typeof getPoolMonitorInstance>;
+  let pool: Awaited<ReturnType<ReturnType<typeof getPoolMonitorInstance>['getUsablePool']>>;
   try {
-    pool = getPoolMonitorInstance().pool;
+    monitor = getPoolMonitorInstance();
+    pool = await monitor.getUsablePool();
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     ailogger.warn('instrumentation.pool_unavailable', { errorMessage });
@@ -53,7 +55,9 @@ void (async () => {
   // the rest of instrumentation, and the interval keeps running even when the
   // startup sweep fails (the next tick retries).
   try {
-    startUploadJobSweeper(pool);
+    // The resolver keeps every tick healthy across the PoolMonitor's idle-hour
+    // shutdown; a pool captured here once would eventually go permanently dead.
+    startUploadJobSweeper(() => monitor.getUsablePool());
     // installUploadSweeperShutdown is HMR-safe: the shutdownInstalled flag on
     // the globalThis sentinel prevents stacking listeners across module reloads.
     // Both shutdown hooks (provisioning's installShutdownHandler and this one)

--- a/frontend/instrumentation-node.ts
+++ b/frontend/instrumentation-node.ts
@@ -66,7 +66,7 @@ void (async () => {
     // runSweepTick reports rather than throws, so the startup sweep's own
     // failure is escalated here: this pass IS the deploy-recovery moment, and
     // missing it is louder news than a routine mid-life tick failure.
-    const outcome = await runSweepTick(pool);
+    const outcome = await runSweepTick(() => monitor.getUsablePool());
     if (outcome.status === 'failed') {
       ailogger.error('upload.sweeper.startup_failed', outcome.error);
     } else if (outcome.status === 'completed' && (outcome.result.reclaimed.length > 0 || outcome.result.dispatched.length > 0)) {

--- a/frontend/lib/background-jobs/sweeper.ts
+++ b/frontend/lib/background-jobs/sweeper.ts
@@ -219,6 +219,8 @@ export async function sweepOnce(catalogPool: Pool, deps: SweepDeps = defaultSwee
  */
 export type SweepTickOutcome = { status: 'completed'; result: SweepResult } | { status: 'skipped_in_flight' } | { status: 'failed'; error: Error };
 
+type CatalogPoolSource = Pool | (() => Promise<Pool>);
+
 /**
  * One interval tick: skips when a previous pass hasn't resolved yet (in-flight
  * guard), otherwise runs a sweep pass. Never throws — a failed pass must not
@@ -230,7 +232,7 @@ export type SweepTickOutcome = { status: 'completed'; result: SweepResult } | { 
  * here and at the caller produced two events for one failure. Each caller emits
  * exactly one.
  */
-export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultSweepDeps): Promise<SweepTickOutcome> {
+export async function runSweepTick(catalogPoolSource: CatalogPoolSource, deps: SweepDeps = defaultSweepDeps): Promise<SweepTickOutcome> {
   const sweeperGlobal = globalThis as SweeperGlobal;
   const sentinel = sweeperGlobal[SWEEPER_SENTINEL];
   if (sentinel?.inFlight) {
@@ -239,6 +241,10 @@ export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultS
   }
   if (sentinel) sentinel.inFlight = true;
   try {
+    // Resolve inside the guard: rebuilding a pool is part of the tick and can
+    // itself take longer than SWEEP_INTERVAL_MS. Resolving before this point
+    // allowed multiple pending ticks to stack and later run back-to-back.
+    const catalogPool = typeof catalogPoolSource === 'function' ? await catalogPoolSource() : catalogPoolSource;
     return { status: 'completed', result: await sweepOnce(catalogPool, deps) };
   } catch (error: unknown) {
     // A failed pass must never kill the interval — the next tick retries.
@@ -269,18 +275,14 @@ export function startUploadJobSweeper(getCatalogPool: () => Promise<Pool>): void
   if (sweeperGlobal[SWEEPER_SENTINEL]) return;
 
   const interval = setInterval(() => {
-    void getCatalogPool()
-      .then(catalogPool => runSweepTick(catalogPool))
-      .then(outcome => {
-        if (outcome.status === 'failed') {
-          ailogger.warn('upload.sweeper.pass_failed', { errorMessage: outcome.error.message });
-        }
-      })
-      .catch((error: unknown) => {
-        // The resolver itself failed (pool could not be [re]built) — report it
-        // the same way a failed pass is reported; the next tick retries.
+    void runSweepTick(getCatalogPool).then(outcome => {
+      if (outcome.status === 'failed') {
+        // Includes resolver failures (pool could not be [re]built) and pass
+        // failures; the next interval retries either one.
+        const error = outcome.error;
         ailogger.warn('upload.sweeper.pass_failed', { errorMessage: error instanceof Error ? error.message : String(error) });
-      });
+      }
+    });
   }, SWEEP_INTERVAL_MS);
   interval.unref?.();
   sweeperGlobal[SWEEPER_SENTINEL] = { interval, inFlight: false, shutdownInstalled: false };

--- a/frontend/lib/background-jobs/sweeper.ts
+++ b/frontend/lib/background-jobs/sweeper.ts
@@ -254,20 +254,33 @@ export async function runSweepTick(catalogPool: Pool, deps: SweepDeps = defaultS
  * no-op (globalThis sentinel). The interval is unref()d so it never keeps the
  * process alive on its own.
  *
+ * Takes a pool RESOLVER, not a pool: the PoolMonitor's inactivity shutdown ends
+ * the underlying mysql2 pool after an idle hour, so a pool captured at process
+ * startup eventually goes permanently dead and every tick fails with "Pool is
+ * closed." (which is exactly what happened for days before 2026-08-04).
+ * Resolving per tick hands each pass a pool that is open at that moment.
+ *
  * Passes never stack: the in-flight guard in runSweepTick skips a tick while a
  * previous pass is still resolving. Job EXECUTIONS are bounded separately, by
  * MAX_CONCURRENT_JOB_EXECUTIONS, because a pass no longer waits for them.
  */
-export function startUploadJobSweeper(catalogPool: Pool): void {
+export function startUploadJobSweeper(getCatalogPool: () => Promise<Pool>): void {
   const sweeperGlobal = globalThis as SweeperGlobal;
   if (sweeperGlobal[SWEEPER_SENTINEL]) return;
 
   const interval = setInterval(() => {
-    void runSweepTick(catalogPool).then(outcome => {
-      if (outcome.status === 'failed') {
-        ailogger.warn('upload.sweeper.pass_failed', { errorMessage: outcome.error.message });
-      }
-    });
+    void getCatalogPool()
+      .then(catalogPool => runSweepTick(catalogPool))
+      .then(outcome => {
+        if (outcome.status === 'failed') {
+          ailogger.warn('upload.sweeper.pass_failed', { errorMessage: outcome.error.message });
+        }
+      })
+      .catch((error: unknown) => {
+        // The resolver itself failed (pool could not be [re]built) — report it
+        // the same way a failed pass is reported; the next tick retries.
+        ailogger.warn('upload.sweeper.pass_failed', { errorMessage: error instanceof Error ? error.message : String(error) });
+      });
   }, SWEEP_INTERVAL_MS);
   interval.unref?.();
   sweeperGlobal[SWEEPER_SENTINEL] = { interval, inFlight: false, shutdownInstalled: false };

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -281,6 +281,10 @@ function startHeartbeat(ctx: WorkerRunContext): void {
     if (tickInFlight) return; // a slow catalog round-trip must not stack ticks
     tickInFlight = true;
     try {
+      // This worker keeps a raw catalog Pool for the whole run. Its heartbeat
+      // therefore also keeps PoolMonitor's idle deadline alive for census-scale
+      // jobs that legitimately run longer than an hour.
+      getPoolMonitorInstance().signalActivity();
       const leaseAlive = await heartbeatBackgroundJob(ctx.catalogPool, ctx.job.jobID, ctx.workerID);
       if (!leaseAlive) {
         ctx.leaseLost = true;

--- a/frontend/lib/background-jobs/worker.ts
+++ b/frontend/lib/background-jobs/worker.ts
@@ -117,7 +117,7 @@ export interface WorkerDeps {
  * the job row through the fenced repository writes.
  */
 export async function runJobIfClaimable(jobID: number, deps?: WorkerDeps): Promise<void> {
-  const catalogPool = getPoolMonitorInstance().pool;
+  const catalogPool = await getPoolMonitorInstance().getUsablePool();
   // REQUIRED claim invariant (see claimBackgroundJobForWorker): worker IDs must
   // be unique per claim attempt or the confirm-then-throw fencing is racy.
   const workerID = `${process.pid}:${randomUUID()}`;

--- a/frontend/lib/db/poolmonitor.test.ts
+++ b/frontend/lib/db/poolmonitor.test.ts
@@ -264,6 +264,47 @@ describe('PoolMonitor', () => {
 
       await monitor.closeAllConnections();
     });
+
+    it('waits for an in-progress close and returns the replacement pool', async () => {
+      let finishClose!: () => void;
+      const closingPool = createFakePool({
+        end: vi.fn(
+          () =>
+            new Promise<void>(resolve => {
+              finishClose = resolve;
+            })
+        )
+      });
+      const freshPool = createFakePool();
+      const monitor = await makeMonitor(closingPool);
+      monitor.createManagedPool = () => freshPool;
+
+      const close = monitor.closeAllConnections();
+      expect(monitor.isPoolClosed(), 'closing must be published before pool.end() settles').toBe(true);
+
+      const usablePool = monitor.getUsablePool();
+      await Promise.resolve();
+      expect(closingPool.end).toHaveBeenCalledTimes(1);
+
+      finishClose();
+      await close;
+      await expect(usablePool).resolves.toBe(freshPool);
+
+      await monitor.closeAllConnections();
+    });
+
+    it('treats raw-pool resolution as activity and moves the idle deadline', async () => {
+      const HOUR_MS = 3_600_000;
+      const openPool = createFakePool();
+      const monitor = await makeMonitor(openPool);
+
+      await vi.advanceTimersByTimeAsync(HOUR_MS - 1);
+      await monitor.getUsablePool();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(openPool.end, 'the pre-resolution inactivity deadline must be invalidated').not.toHaveBeenCalled();
+      await monitor.closeAllConnections();
+    });
   });
 
   /**

--- a/frontend/lib/db/poolmonitor.test.ts
+++ b/frontend/lib/db/poolmonitor.test.ts
@@ -205,6 +205,68 @@ describe('PoolMonitor', () => {
   });
 
   /**
+   * getUsablePool exists because the inactivity timer closes the pool after an
+   * idle hour, and code that read the raw `pool` property (provisioning routes,
+   * uploadjobs routes, the background-job sweeper) then got a permanently dead
+   * mysql2 Pool: every query threw "Pool is closed." until unrelated
+   * getConnection() traffic happened to heal the monitor. This is the failure
+   * behind the 2026-08-04 "Internal provisioning error" incident.
+   */
+  describe('getUsablePool', () => {
+    async function makeMonitor(pool: ReturnType<typeof createFakePool>) {
+      const { PoolMonitor } = await vi.importActual<typeof import('./poolmonitor')>('./poolmonitor');
+      const monitor = new PoolMonitor({ connectionLimit: 2 }) as unknown as {
+        pool: ReturnType<typeof createFakePool>;
+        poolClosed: boolean;
+        createManagedPool: () => ReturnType<typeof createFakePool>;
+        getUsablePool: () => Promise<unknown>;
+        closeAllConnections: () => Promise<void>;
+        isPoolClosed: () => boolean;
+        reinitializePool: () => Promise<void>;
+      };
+      monitor.pool = pool;
+      monitor.poolClosed = false;
+      return monitor;
+    }
+
+    it('returns the current pool without reinitializing while the pool is open', async () => {
+      const openPool = createFakePool();
+      const monitor = await makeMonitor(openPool);
+      let reinitializeCalls = 0;
+      const originalReinitialize = monitor.reinitializePool.bind(monitor);
+      monitor.reinitializePool = async () => {
+        reinitializeCalls += 1;
+        await originalReinitialize();
+      };
+
+      const pool = await monitor.getUsablePool();
+
+      expect(pool).toBe(openPool);
+      expect(reinitializeCalls).toBe(0);
+      await monitor.closeAllConnections();
+    });
+
+    it('replaces a pool closed by the graceful shutdown instead of handing out the dead one', async () => {
+      const deadPool = createFakePool();
+      const freshPool = createFakePool();
+      const monitor = await makeMonitor(deadPool);
+      monitor.createManagedPool = () => freshPool;
+
+      // The inactivity timer's graceful shutdown runs exactly this.
+      await monitor.closeAllConnections();
+      expect(monitor.isPoolClosed()).toBe(true);
+      expect(deadPool.end).toHaveBeenCalledTimes(1);
+
+      const pool = await monitor.getUsablePool();
+
+      expect(pool, 'a caller must never receive the ended mysql2 pool').toBe(freshPool);
+      expect(monitor.isPoolClosed()).toBe(false);
+
+      await monitor.closeAllConnections();
+    });
+  });
+
+  /**
    * tryAcquireConnection exists for the out-of-band `KILL QUERY` that aborts a
    * timed-out statement. Two hazards it must not have:
    *

--- a/frontend/lib/db/poolmonitor.ts
+++ b/frontend/lib/db/poolmonitor.ts
@@ -22,6 +22,8 @@ export class PoolMonitor {
   private poolClosed = false;
   private reinitializePromise: Promise<void> | null = null;
   private closePromise: Promise<void> | null = null;
+  /** Invalidates an inactivity callback when newer work arrives while it awaits. */
+  private activityGeneration = 0;
   // mysql2 recycles physical PoolConnection objects across acquire/release, so guard
   // against re-attaching the same 'query'/'release' listeners on every acquire (which
   // would accumulate without bound -> MaxListenersExceededWarning + memory leak). A
@@ -46,13 +48,31 @@ export class PoolMonitor {
    * {@link getConnection} used to recover from that — code reading the raw
    * `pool` property got a permanently dead mysql2 Pool and every query threw
    * "Pool is closed." until unrelated traffic happened to heal the monitor.
-   * Callers must resolve this per use and never cache the returned pool across
-   * idle periods, or they recreate that failure mode.
+   * Short-lived callers must resolve this per use. Long-lived callers must also
+   * signal activity while they retain it (the background workers do so from
+   * their lease heartbeats), or they recreate that failure mode.
    */
   public async getUsablePool(): Promise<Pool> {
+    // poolClosed is set before pool.end() begins, but waiting explicitly also
+    // covers a close that failed: the reinitialization below can replace the
+    // now-unknown pool instead of handing it to the caller.
+    const closeInProgress = this.closePromise;
+    if (closeInProgress) {
+      try {
+        await closeInProgress;
+      } catch {
+        // _doCloseAllConnections logged the cause and left poolClosed=true.
+        // Reinitialize below so this access can still self-heal.
+      }
+    }
     if (this.poolClosed) {
+      ailogger.info('db.pool.self_heal', { reason: 'raw_pool_requested_after_close' });
       await this.reinitializePool();
     }
+    // Raw-pool consumers bypass getConnection(), so resolving the pool itself
+    // must count as activity. The generation also invalidates an inactivity
+    // callback that already fired and is awaiting its process-list query.
+    this.resetInactivityTimer();
     return this.pool;
   }
 
@@ -169,11 +189,13 @@ export class PoolMonitor {
       return;
     }
 
-    // Atomic check-and-set for poolClosed flag
+    // Atomic check-and-set: publish the closing state BEFORE pool.end() awaits.
+    // Otherwise getUsablePool() can return this pool while mysql2 is ending it.
     if (this.poolClosed) {
       ailogger.info(chalk.yellow('Pool already closed.'));
       return;
     }
+    this.poolClosed = true;
 
     // Store the close promise so concurrent calls wait
     this.closePromise = this._doCloseAllConnections();
@@ -219,7 +241,7 @@ export class PoolMonitor {
   }
 
   public signalActivity() {
-    this.resetInactivityTimer();
+    if (!this.poolClosed) this.resetInactivityTimer();
   }
 
   private async reinitializePool(): Promise<void> {
@@ -326,6 +348,7 @@ export class PoolMonitor {
   }
 
   private resetInactivityTimer(): void {
+    const scheduledGeneration = ++this.activityGeneration;
     if (this.inactivityTimer) {
       clearTimeout(this.inactivityTimer);
     }
@@ -344,6 +367,12 @@ export class PoolMonitor {
       } catch {
         // ConnectionManager not available — proceed with processlist check only.
       }
+
+      // clearTimeout cannot stop a callback that already began. If a raw-pool
+      // request or worker heartbeat arrived while either await above was in
+      // flight, the newer generation owns the deadline and this callback is
+      // stale; it must not close the pool underneath that work.
+      if (scheduledGeneration !== this.activityGeneration) return;
 
       if (live.length === 0 && !hasActiveTransactions) {
         ailogger.info(chalk.red('Inactivity period exceeded and no active connections found. Initiating graceful shutdown...'));

--- a/frontend/lib/db/poolmonitor.ts
+++ b/frontend/lib/db/poolmonitor.ts
@@ -39,6 +39,23 @@ export class PoolMonitor {
     this.resetInactivityTimer();
   }
 
+  /**
+   * Hand out a pool that is guaranteed open at the moment of the call.
+   *
+   * The inactivity timer closes the pool after an idle hour, and only
+   * {@link getConnection} used to recover from that — code reading the raw
+   * `pool` property got a permanently dead mysql2 Pool and every query threw
+   * "Pool is closed." until unrelated traffic happened to heal the monitor.
+   * Callers must resolve this per use and never cache the returned pool across
+   * idle periods, or they recreate that failure mode.
+   */
+  public async getUsablePool(): Promise<Pool> {
+    if (this.poolClosed) {
+      await this.reinitializePool();
+    }
+    return this.pool;
+  }
+
   public async getConnection(): Promise<PoolConnection> {
     let connection: PoolConnection | null = null;
     let connectionAcquired = false;

--- a/frontend/lib/provisioning/worker.ts
+++ b/frontend/lib/provisioning/worker.ts
@@ -19,6 +19,7 @@
  *     any `running` rows whose heartbeat is older than HEARTBEAT_STALE_MS or null.
  */
 import type { Pool, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+import { getPoolMonitorInstance } from '@/lib/db/poolmonitorsingleton';
 // `runProvisioning` is imported lazily inside `dispatchRun` to avoid a
 // module-load circular import between worker.ts ↔ orchestrator.ts. The
 // orchestrator imports `dispatchRun` at module load; if worker.ts also
@@ -50,6 +51,10 @@ export function getWorkerPid(): string {
 async function writeHeartbeat(catalogPool: Pool, runId: number): Promise<void> {
   if (shuttingDown) return;
   try {
+    // Provisioning retains the raw pool for the lifetime of the run. Keep the
+    // monitor's idle deadline aligned with this heartbeat so an hour-long schema
+    // operation cannot have its catalog pool ended underneath it.
+    getPoolMonitorInstance().signalActivity();
     await catalogPool.query(`UPDATE catalog.provisioning_runs SET WorkerHeartbeatAt = NOW() WHERE RunID = ? AND Status = 'running' AND WorkerPID = ?`, [
       runId,
       WORKER_PID

--- a/frontend/tests/integration/admin-provision/abort.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/abort.integration.test.ts
@@ -28,7 +28,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { POST } from '@/app/api/admin/provision/[runId]/abort/route';

--- a/frontend/tests/integration/admin-provision/get.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/get.integration.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { GET } from '@/app/api/admin/provision/[runId]/route';

--- a/frontend/tests/integration/admin-provision/list.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/list.integration.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { GET } from '@/app/api/admin/provision/list/route';

--- a/frontend/tests/integration/admin-provision/mark-failed.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/mark-failed.integration.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { POST } from '@/app/api/admin/provision/[runId]/mark-failed/route';

--- a/frontend/tests/integration/admin-provision/reconcile.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/reconcile.integration.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { POST } from '@/app/api/admin/provision/[runId]/reconcile/route';

--- a/frontend/tests/integration/admin-provision/retry.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/retry.integration.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { POST } from '@/app/api/admin/provision/[runId]/retry/route';

--- a/frontend/tests/integration/admin-provision/start.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/start.integration.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/auth', () => ({ auth: mocks.auth }));
 
 let testPool: Pool;
 vi.mock('@/lib/db/poolmonitorsingleton', () => ({
-  getPoolMonitorInstance: () => ({ pool: testPool })
+  getPoolMonitorInstance: () => ({ pool: testPool, getUsablePool: async () => testPool })
 }));
 
 import { POST } from '@/app/api/admin/provision/route';

--- a/frontend/tests/integration/provisioned-site-lifecycle.test.ts
+++ b/frontend/tests/integration/provisioned-site-lifecycle.test.ts
@@ -151,7 +151,7 @@ vi.mock('@/lib/db/connectionmanager', () => {
   return { default: { getInstance: () => manager } };
 });
 
-// The worker reads the catalog pool from getPoolMonitorInstance().pool, and the
+// The worker reads the catalog pool from getPoolMonitorInstance().getUsablePool(), and the
 // upload-session tracker acquires pooled connections from the same monitor.
 // Both are routed to the local catalog pool (no default database; every session
 // query is schema-qualified).
@@ -161,6 +161,7 @@ vi.mock('@/lib/db/poolmonitorsingleton', () => ({
     const pool = sharedState.catalogPool;
     return {
       pool,
+      getUsablePool: async () => pool,
       getConnection: () => pool.getConnection(),
       signalActivity: () => undefined
     };

--- a/frontend/tests/integration/upload-pipeline-equivalence.test.ts
+++ b/frontend/tests/integration/upload-pipeline-equivalence.test.ts
@@ -142,6 +142,7 @@ vi.mock('@/lib/db/poolmonitorsingleton', () => ({
     const pool = sharedState.catalogPool;
     return {
       pool,
+      getUsablePool: async () => pool,
       getConnection: () => pool.getConnection(),
       signalActivity: () => undefined
     };

--- a/frontend/tests/integration/upload-sweeper.test.ts
+++ b/frontend/tests/integration/upload-sweeper.test.ts
@@ -515,6 +515,42 @@ describe('startUploadJobSweeper / stopUploadJobSweeper — sentinel lifecycle', 
       vi.useRealTimers();
     }
   });
+
+  it('includes a slow pool resolution in the in-flight guard', async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(ailogger, 'warn').mockImplementation(() => {});
+    let rejectResolution: ((error: Error) => void) | undefined;
+    const resolver = vi.fn(
+      () =>
+        new Promise<Pool>((_resolve, reject) => {
+          rejectResolution = reject;
+        })
+    );
+
+    try {
+      startUploadJobSweeper(resolver);
+
+      await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+      expect(resolver).toHaveBeenCalledTimes(1);
+
+      // The first resolver is still pending. The next interval must skip the
+      // whole tick rather than queue another resolver behind it.
+      await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+      expect(resolver).toHaveBeenCalledTimes(1);
+
+      rejectResolution?.(new Error('slow pool rebuild failed'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+      expect(resolver).toHaveBeenCalledTimes(2);
+    } finally {
+      rejectResolution?.(new Error('test cleanup'));
+      await vi.advanceTimersByTimeAsync(0);
+      stopUploadJobSweeper();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/tests/integration/upload-sweeper.test.ts
+++ b/frontend/tests/integration/upload-sweeper.test.ts
@@ -23,6 +23,7 @@ import {
   stopUploadJobSweeper,
   sweepOnce,
   SWEEP_DISPATCH_LIMIT,
+  SWEEP_INTERVAL_MS,
   type SweepDeps
 } from '@/lib/background-jobs/sweeper';
 import type { CreateUploadJobInput } from '@/lib/background-jobs/types';
@@ -457,13 +458,13 @@ describe('startUploadJobSweeper / stopUploadJobSweeper — sentinel lifecycle', 
 
     expect(sweeperGlobal[SWEEPER_SENTINEL]).toBeUndefined();
 
-    startUploadJobSweeper(pool);
+    startUploadJobSweeper(async () => pool);
     const firstSentinel = sweeperGlobal[SWEEPER_SENTINEL];
     console.log(`[sentinel] after first start: sentinel present=${firstSentinel !== undefined}, inFlight=${firstSentinel?.inFlight}`);
     expect(firstSentinel).toBeDefined();
     expect(firstSentinel?.inFlight).toBe(false);
 
-    startUploadJobSweeper(pool);
+    startUploadJobSweeper(async () => pool);
     const secondSentinel = sweeperGlobal[SWEEPER_SENTINEL];
     console.log(`[sentinel] after double start: same object=${secondSentinel === firstSentinel}`);
     expect(secondSentinel).toBe(firstSentinel);
@@ -474,6 +475,45 @@ describe('startUploadJobSweeper / stopUploadJobSweeper — sentinel lifecycle', 
 
     // Stop is idempotent.
     expect(() => stopUploadJobSweeper()).not.toThrow();
+  });
+
+  /**
+   * Regression for the 2026-08-04 incident: the sweeper used to CAPTURE the
+   * catalog pool at process startup, so once the PoolMonitor's idle-hour
+   * shutdown ended that pool object, every subsequent tick failed with
+   * "Pool is closed." forever — even after other traffic rebuilt the pool.
+   * The interval must instead consult the resolver on EVERY tick, and a tick
+   * whose resolution fails must not kill the interval.
+   */
+  it('consults the pool resolver on every tick and survives a failed resolution', async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(ailogger, 'warn').mockImplementation(() => {});
+    const TICK_ERRORS = ['pool closed at tick 1', 'pool closed at tick 2'];
+    let resolverCalls = 0;
+
+    try {
+      startUploadJobSweeper(async () => {
+        const tickError = TICK_ERRORS[resolverCalls] ?? 'unexpected extra tick';
+        resolverCalls += 1;
+        throw new Error(tickError);
+      });
+
+      await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+      console.log(`[resolver] after tick 1: resolverCalls=${resolverCalls}`);
+      expect(resolverCalls).toBe(1);
+      expect(warnSpy).toHaveBeenCalledWith('upload.sweeper.pass_failed', { errorMessage: TICK_ERRORS[0] });
+
+      // A captured-pool sweeper would never ask again; a failed tick must not
+      // stop the interval from re-resolving on the next one.
+      await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+      console.log(`[resolver] after tick 2: resolverCalls=${resolverCalls}`);
+      expect(resolverCalls).toBe(2);
+      expect(warnSpy).toHaveBeenCalledWith('upload.sweeper.pass_failed', { errorMessage: TICK_ERRORS[1] });
+    } finally {
+      stopUploadJobSweeper();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -549,7 +589,7 @@ describe('runSweepTick — in-flight guard', () => {
     console.log(`[in-flight] holding all ${heldConnections.length} pooled connections`);
 
     // Start the sweeper so the sentinel exists and runSweepTick can read inFlight.
-    startUploadJobSweeper(pool);
+    startUploadJobSweeper(async () => pool);
     const sweeperGlobal = globalThis as SweeperGlobal;
 
     const { deps: blockedDeps, calls: blockedCalls } = makeDispatchStub();

--- a/frontend/tests/integration/upload-worker.test.ts
+++ b/frontend/tests/integration/upload-worker.test.ts
@@ -142,7 +142,7 @@ vi.mock('@/lib/db/connectionmanager', () => {
 });
 
 // PoolMonitor mock — the worker reads the catalog pool from
-// getPoolMonitorInstance().pool, and config/uploadsessiontracker's getConn()
+// getPoolMonitorInstance().getUsablePool(), and config/uploadsessiontracker's getConn()
 // path acquires pooled connections from the same monitor. Both are routed to
 // the local catalog pool (no default database; all session queries are
 // schema-qualified).
@@ -152,6 +152,7 @@ vi.mock('@/lib/db/poolmonitorsingleton', () => ({
     const pool = sharedState.catalogPool;
     return {
       pool,
+      getUsablePool: async () => pool,
       getConnection: () => pool.getConnection(),
       signalActivity: () => undefined
     };

--- a/frontend/tests/mocks/db-mocks.ts
+++ b/frontend/tests/mocks/db-mocks.ts
@@ -121,6 +121,12 @@ class MockPoolMonitor {
     return sharedConnection as unknown as PoolConnection;
   }
 
+  async getUsablePool(): Promise<any> {
+    // mirror the real semantics: hands out an open pool, reviving a closed one
+    this.closed = false;
+    return this.pool;
+  }
+
   async closeAllConnections(): Promise<void> {
     this.closed = true;
   }


### PR DESCRIPTION
## Summary

The PoolMonitor's one-hour inactivity timer closes the shared mysql2 pool, and only `getConnection()` recovered from that. Every consumer reading the raw `.pool` property — all eight `app/api/admin/provision*` routes, the `app/api/uploadjobs` routes, and the background-job worker/sweeper — got a dead pool and threw `Pool is closed.` until unrelated traffic happened to heal the monitor. The sweeper captured the pool once at process startup, so once the pool closed it failed every tick permanently. This is what surfaced as the 2026-08-04 **Internal provisioning error** on the dev site (and days of `upload.sweeper.pass_failed` noise in the App Service logs).

## Changes

- **`PoolMonitor.getUsablePool()`** — async accessor that waits out an in-progress close, reinitializes a closed pool, and counts the resolution as activity. `poolClosed` is now published before `pool.end()` begins so a concurrent raw-pool request can never receive a pool mysql2 is ending.
- **Inactivity callback generation guard** — activity arriving while the idle callback awaits its process-list query invalidates the callback, so it cannot close the pool underneath work that just started.
- **All raw `.pool` consumers** converted to `await getUsablePool()`; the uploadjobs routes return 503 with a logged cause when the pool cannot self-heal.
- **Sweeper** — `startUploadJobSweeper`/`runSweepTick` take a pool resolver consulted on every tick, resolved inside the in-flight guard so a slow rebuild cannot stack ticks.
- **Long-running work** — background-job and provisioning heartbeats call `signalActivity()`, keeping the idle deadline aligned with runs that legitimately exceed an hour while holding a retained pool.

Regression tests: `poolmonitor.test.ts` (closed pool is replaced, not handed out), `upload-sweeper.test.ts` (resolver consulted per tick, failed resolution survives), uploadjobs route 503 path.
