### PR TITLE
fix(schema): repair and gate the viewfulltable StemID->StemGUID drift

### DIFF
--- a/frontend/db/migrations/manifest.ts
+++ b/frontend/db/migrations/manifest.ts
@@ -67,5 +67,9 @@ export const SCHEMA_MIGRATION_MANIFEST: readonly MigrationManifestEntry[] = [
   {
     id: '2026-08-04-02-add-plot-coordinate-epsg',
     file: 'schema-contract-repair/2026-08-04-02-add-plot-coordinate-epsg.sql'
+  },
+  {
+    id: '2026-08-07-01-rename-viewfulltable-stemid-to-stemguid',
+    file: 'schema-contract-repair/2026-08-07-01-rename-viewfulltable-stemid-to-stemguid.sql'
   }
 ] as const;

--- a/frontend/db/migrations/schema-contract-repair/2026-08-07-01-rename-viewfulltable-stemid-to-stemguid.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-08-07-01-rename-viewfulltable-stemid-to-stemguid.sql
@@ -1,0 +1,58 @@
+-- =====================================================================================
+-- Migration 2026-08-07-01: viewfulltable.StemID -> StemGUID
+-- =====================================================================================
+-- The 2025-09-04 identity rename (StemID => StemGUID, StemNumber => StemCrossID,
+-- commit 615e83da) updated the canonical DDL and the application code, but no
+-- migration carried live viewfulltable caches through the rename. Three schemas
+-- kept the pre-rename column (forestgeo_panama, forestgeo_mpala, forestgeo_serc;
+-- panama was created by the ctfs-migrations tooling AFTER the rename and inherited
+-- the stale shape from its target schema rather than the canonical DDL).
+--
+-- The drift was latent until 2026-04 (3f92e448 / 3003f4b6), when app-side refresh
+-- SQL in lib/measurementviewrefresh.ts began writing viewfulltable by explicit
+-- column list after every single-row measurement edit. On the drifted schemas that
+-- INSERT fails with "Unknown column 'StemGUID' in 'field list'" (42S22), aborting
+-- the apply transaction — every measurement edit rolls back and is silently
+-- discarded (measured on forestgeo_panama cocoli, 2026-08-07).
+--
+-- RENAME COLUMN is a metadata-only ALTER in MySQL 8: instant, and it preserves the
+-- cached rows, so no scope refresh is needed afterwards. A full column-name diff
+-- against the canonical DDL confirmed StemID/StemGUID is the ONLY viewfulltable
+-- drift on the three schemas (measured 2026-08-07), so a targeted rename restores
+-- the canonical shape exactly.
+--
+-- Legacy source dumps (stable_*) also carry a StemID column, but that is the
+-- historical CTFS export shape, not drift — this migration only runs against
+-- forestgeo_* schemas via the apply-schema-migrations runner, and only when the
+-- old column is actually present.
+
+SET @vft_exists := (
+    SELECT COUNT(*) FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'viewfulltable'
+);
+SET @old_column_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'viewfulltable'
+      AND COLUMN_NAME = 'StemID'
+);
+SET @new_column_exists := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'viewfulltable'
+      AND COLUMN_NAME = 'StemGUID'
+);
+SET @ddl := IF(@vft_exists = 0,
+    'SELECT ''viewfulltable does not exist in this schema; nothing to rename'' AS Status',
+    IF(@new_column_exists > 0,
+        'SELECT ''viewfulltable.StemGUID already present'' AS Status',
+        IF(@old_column_exists = 0,
+            'SELECT ''viewfulltable has neither StemID nor StemGUID; refusing to guess'' AS Status',
+            'ALTER TABLE `viewfulltable` RENAME COLUMN `StemID` TO `StemGUID`'
+        )
+    )
+);
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration 2026-08-07-01 complete: viewfulltable stem column matches canonical StemGUID.' AS Status;

--- a/frontend/lib/db/schema-contract.ts
+++ b/frontend/lib/db/schema-contract.ts
@@ -22,7 +22,17 @@ import path from 'path';
 
 export const TARGET_TEXT_COLLATION = 'utf8mb4_0900_ai_ci';
 
-/** Tables whose write contract the application must be able to trust. */
+/**
+ * Tables whose write contract the application must be able to trust.
+ *
+ * viewfulltable and measurementssummary are derived caches, but they are NOT
+ * exempt: lib/measurementviewrefresh.ts rebuilds them with explicit column-list
+ * INSERTs inside the single-row edit apply transaction, so a shape mismatch
+ * aborts (and rolls back) every measurement edit on the drifted schema. That is
+ * exactly what happened on forestgeo_panama/mpala/serc, whose viewfulltable kept
+ * the pre-rename StemID column from the 2025-09 identity rename until 2026-08
+ * because no gate compared these tables (repaired by migration 2026-08-07-01).
+ */
 export const CRITICAL_TABLES = [
   'temporarymeasurements',
   'coremeasurements',
@@ -32,7 +42,9 @@ export const CRITICAL_TABLES = [
   'stems',
   'measurement_error_log',
   'uploadintegrityalerts',
-  'uploadmetrics'
+  'uploadmetrics',
+  'measurementssummary',
+  'viewfulltable'
 ] as const;
 
 /**

--- a/frontend/tests/integration/schema-migration-contract.integration.test.ts
+++ b/frontend/tests/integration/schema-migration-contract.integration.test.ts
@@ -5,10 +5,12 @@
  * to the known live-schema drift (drops temporarymeasurements.PublishedStemID and
  * SourceFormat, stems.PublishedStemID and its lookup index, and
  * coremeasurements.RawPublishedStemID — the exact shape of a site provisioned by a
- * deployment that predates the PublishedStemID work; downgrades representative
- * VARCHAR/TEXT columns to utf8mb3; no migration ledger), then proves the migrate +
- * verify pipeline repairs the application write contract end to end without
- * rebuilding unrelated tables and remains idempotent:
+ * deployment that predates the PublishedStemID work; reverts viewfulltable to its
+ * pre-rename StemID column — the shape forestgeo_panama/mpala/serc carried, which
+ * made every single-row measurement edit roll back on "Unknown column 'StemGUID'";
+ * downgrades representative VARCHAR/TEXT columns to utf8mb3; no migration ledger),
+ * then proves the migrate + verify pipeline repairs the application write contract
+ * end to end without rebuilding unrelated tables and remains idempotent:
  *
  *   (1) the read-only contract audit FAILS, naming both the missing columns and
  *       the legacy-collation columns as maintenance warnings;
@@ -52,6 +54,10 @@ const LEGACY_CHARSET = 'utf8mb3';
 const LEGACY_COLLATION = 'utf8mb3_general_ci';
 const PUBLISHED_STEMID_INDEX = 'idx_stems_publishedstemid';
 const PUBLISHED_STEMID_CONFLICT_CODE = 'PUBLISHED_STEMID_CONFLICT';
+// Sentinel viewfulltable cache row: proves the StemID -> StemGUID repair is a
+// metadata-only RENAME that preserves cached rows, not a drop-and-recreate.
+const VFT_SENTINEL_CORE_MEASUREMENT_ID = 999001;
+const VFT_SENTINEL_STEM_VALUE = 424242;
 
 describe('Stale-schema migrate + verify pipeline', () => {
   let connection: Connection;
@@ -83,6 +89,11 @@ describe('Stale-schema migrate + verify pipeline', () => {
     await connection.query('ALTER TABLE stems DROP COLUMN PublishedStemID');
     await connection.query('ALTER TABLE coremeasurements DROP COLUMN RawPublishedStemID');
     await connection.query('DELETE FROM measurement_errors WHERE ErrorSource = ? AND ErrorCode = ?', ['ingestion', PUBLISHED_STEMID_CONFLICT_CODE]);
+    // The 2025-09 identity rename (StemID => StemGUID) never migrated the
+    // viewfulltable caches on ctfs-migrated schemas. Reproduce that shape, with
+    // a cached row that must survive the repair rename.
+    await connection.query('ALTER TABLE viewfulltable RENAME COLUMN StemGUID TO StemID');
+    await connection.query('INSERT INTO viewfulltable (CoreMeasurementID, StemID) VALUES (?, ?)', [VFT_SENTINEL_CORE_MEASUREMENT_ID, VFT_SENTINEL_STEM_VALUE]);
     await connection.query(
       `ALTER TABLE temporarymeasurements MODIFY COLUMN ${REPRESENTATIVE_TEXT_COLUMN} varchar(255) CHARACTER SET ${LEGACY_CHARSET} COLLATE ${LEGACY_COLLATION} NULL`
     );
@@ -117,6 +128,11 @@ describe('Stale-schema migrate + verify pipeline', () => {
     // stems.PublishedStemID is dropped from a different table than the
     // temporarymeasurements column of the same name — assert the table too.
     expect(audit.contractFailures.some(f => f.kind === 'missing' && f.category === 'column' && f.table === 'stems' && f.object === 'PublishedStemID')).toBe(
+      true
+    );
+    // The pre-rename viewfulltable cache (forestgeo_panama/mpala/serc shape) is
+    // named as drift on the exact table+column the edit-apply refresh writes.
+    expect(audit.contractFailures.some(f => f.kind === 'missing' && f.category === 'column' && f.table === 'viewfulltable' && f.object === 'StemGUID')).toBe(
       true
     );
     const missingIndexes = audit.contractFailures.filter(f => f.kind === 'missing' && f.category === 'index').map(f => f.object);
@@ -181,6 +197,14 @@ describe('Stale-schema migrate + verify pipeline', () => {
       PUBLISHED_STEMID_CONFLICT_CODE
     ]);
     expect(conflictCode.length).toBe(1);
+
+    // The viewfulltable repair must be a column RENAME, not a rebuild: the
+    // sentinel cache row survives with its stem value now under StemGUID.
+    const [sentinel] = await connection.query<RowDataPacket[]>(`SELECT StemGUID FROM viewfulltable WHERE CoreMeasurementID = ?`, [
+      VFT_SENTINEL_CORE_MEASUREMENT_ID
+    ]);
+    expect(sentinel.length).toBe(1);
+    expect(Number(sentinel[0].StemGUID)).toBe(VFT_SENTINEL_STEM_VALUE);
   });
 
   it('(5) a production keyed insert + one-row bulkingestionprocess succeed against the repaired schema', async () => {


### PR DESCRIPTION
## Summary

Single-row measurement edits on **forestgeo_panama, forestgeo_mpala, and forestgeo_serc** have been failing since late April: the per-edit derived-view refresh (`lib/measurementviewrefresh.ts`, wired in 3003f4b6) writes `viewfulltable` by explicit column list, but those three schemas still carry the pre-rename `StemID` column from before the 2025-09 identity rename (615e83da). The `INSERT` fails with `Unknown column 'StemGUID' in 'field list'` (42S22) inside the apply transaction, so every edit rolls back and the grid silently reverts — measured against cocoli (`forestgeo_panama`, plot 12 / census 22) on 2026-08-07. A full column diff confirmed `StemID`/`StemGUID` is the only drift on all three schemas; the other eight `forestgeo_*` schemas already match canonical.

## Changes

- **Migration `2026-08-07-01`** (manifest-listed): guarded, metadata-only `ALTER TABLE viewfulltable RENAME COLUMN StemID TO StemGUID`. No-ops when the table is absent, already renamed, or has neither column. Cached rows survive; no scope refresh needed. The migrate-before-deploy gate applies it to the drifted schemas on the next deploy.
- **Contract promotion**: `measurementssummary` and `viewfulltable` join `CRITICAL_TABLES` in `lib/db/schema-contract.ts`. They were excluded as derived caches, but the app writes them by explicit column list at edit time, so their shape is load-bearing — this class of drift is now visible to the audit and the deploy gate. (Schema contract only — deliberately not provisioning's `REQUIRED_VIEWS`.)
- **Stale-schema pipeline test**: the regression fixture now also reverts `viewfulltable` to the drifted shape and asserts the audit names `viewfulltable.StemGUID`, the manifest repairs it, and a sentinel cache row survives the rename (proving RENAME, not rebuild).

A read-only `check-schema-contract --all-sites` run with this change flags exactly the three drifted schemas (`DRIFT [viewfulltable] column "StemGUID" missing`) with the new migration listed as their pending remedy, and nothing else.

`stable_harvard`/`stable_mpala` keep `StemID` intentionally — that is the legacy CTFS source-dump shape, not drift.

Follow-up (separate PR): make the ctfs-migrations tooling recreate derived caches from canonical DDL and run the contract audit as its exit gate, so future migrated sites cannot be born drifted.