### PR TITLE
fix(validations): clear stale duplicate-tag errors on rerun

### DIFF
--- a/frontend/components/client/validationactionsmenu.test.tsx
+++ b/frontend/components/client/validationactionsmenu.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MenuList } from '@mui/joy';
+import ValidationActionsMenu from './validationactionsmenu';
+
+const noop = () => undefined;
+const noopAsync = async () => undefined;
+
+function renderMenu(counts: { pendingCount?: number; overridableCount?: number; revalidatableCount?: number }, onRunValidations: () => void = noop) {
+  // The component renders MenuItems for use inside a parent Menu; MenuList
+  // supplies the required ListContext without needing an anchored popup.
+  return render(
+    <MenuList>
+      <ValidationActionsMenu onRunValidations={onRunValidations} onOverrideValidations={noop} onResetValidations={noop} onRefreshView={noopAsync} {...counts} />
+    </MenuList>
+  );
+}
+
+function runValidationsItem(): HTMLElement {
+  const label = screen.getByText('Run Validations');
+  const item = label.closest('[role="menuitem"]');
+  if (!item) throw new Error('Run Validations menu item not found');
+  return item as HTMLElement;
+}
+
+describe('ValidationActionsMenu — Run Validations gating', () => {
+  it('is enabled with pending rows and describes the pending count', () => {
+    renderMenu({ pendingCount: 3, overridableCount: 0, revalidatableCount: 0 });
+
+    expect(screen.getByText('Validate 3 pending row(s)')).toBeInTheDocument();
+    expect(runValidationsItem()).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('is enabled with failed-but-revalidatable rows and describes the re-check count, not the overridable count', () => {
+    renderMenu({ pendingCount: 0, overridableCount: 5, revalidatableCount: 2 });
+
+    expect(screen.getByText('Re-check 2 failed row(s)')).toBeInTheDocument();
+    expect(screen.queryByText('Re-check 5 failed row(s)')).not.toBeInTheDocument();
+    expect(runValidationsItem()).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('is disabled when the only failures are ingestion failures a rerun cannot fix', () => {
+    // overridableCount includes IsValidated FALSE/NULL rows regardless of
+    // origin; revalidatableCount excludes ingestion failures (StemGUID NULL).
+    // Rerun must not be offered when it would be a no-op.
+    const onRun = vi.fn();
+    renderMenu({ pendingCount: 0, overridableCount: 4, revalidatableCount: 0 }, onRun);
+
+    expect(screen.getByText('No rows to validate')).toBeInTheDocument();
+    expect(runValidationsItem()).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(runValidationsItem());
+    expect(onRun).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is nothing to validate at all', () => {
+    renderMenu({ pendingCount: 0, overridableCount: 0, revalidatableCount: 0 });
+
+    expect(screen.getByText('No rows to validate')).toBeInTheDocument();
+    expect(runValidationsItem()).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('invokes onRunValidations when clicked in an enabled state', () => {
+    const onRun = vi.fn();
+    renderMenu({ pendingCount: 0, overridableCount: 2, revalidatableCount: 2 }, onRun);
+
+    fireEvent.click(runValidationsItem());
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the override action driven by the full overridable count', () => {
+    renderMenu({ pendingCount: 0, overridableCount: 5, revalidatableCount: 2 });
+
+    expect(screen.getByText('Force 5 failed or not-yet-validated row(s) to pass')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/client/validationactionsmenu.tsx
+++ b/frontend/components/client/validationactionsmenu.tsx
@@ -26,6 +26,14 @@ interface ValidationActionsMenuProps {
    * these all "failed" — that misreports pending rows as failures.
    */
   overridableCount?: number;
+  /**
+   * Failed rows a rerun can actually re-examine (IsValidated = FALSE, real
+   * stem, unresolved validation-source error) — prepareValidationRun's reset
+   * predicate. Excludes ingestion failures (StemGUID NULL), which no
+   * validation run can clear, so they must not make the run action look
+   * actionable.
+   */
+  revalidatableCount?: number;
   disabled?: boolean;
 }
 
@@ -35,7 +43,8 @@ export default function ValidationActionsMenu({
   onResetValidations,
   onRefreshView,
   pendingCount = 0,
-  overridableCount = 0
+  overridableCount = 0,
+  revalidatableCount = 0
 }: ValidationActionsMenuProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -52,11 +61,18 @@ export default function ValidationActionsMenu({
     {
       id: 'run-validations',
       label: 'Run Validations',
-      description: pendingCount > 0 ? `Validate ${pendingCount} pending row(s)` : 'No pending rows to validate',
+      description:
+        pendingCount > 0
+          ? `Validate ${pendingCount} pending row(s)`
+          : revalidatableCount > 0
+            ? `Re-check ${revalidatableCount} failed row(s)`
+            : 'No rows to validate',
       icon: <CloudSync />,
       onClick: onRunValidations,
       color: 'primary',
-      disabled: pendingCount === 0
+      // A rerun re-examines failed rows too (prepareValidationRun resets this
+      // validation's error carriers), so failed-only states stay actionable.
+      disabled: pendingCount === 0 && revalidatableCount === 0
     },
     {
       id: 'override-validations',

--- a/frontend/components/datagrids/measurementscommons.tsx
+++ b/frontend/components/datagrids/measurementscommons.tsx
@@ -257,6 +257,7 @@ function MeasurementsCommonsInner(props: Readonly<MeasurementsCommonsProps>) {
   const [invalidCount, setInvalidCount] = useState<number>(0);
   const [invalidBreakdown, setInvalidBreakdown] = useState<RowControlBreakdown>({ unresolvedLogged: 0, failedNoLog: 0 });
   const [validationErrorCount, setValidationErrorCount] = useState<number>(0);
+  const [revalidatableErrorCount, setRevalidatableErrorCount] = useState<number>(0);
   const [validCount, setValidCount] = useState<number>(0);
   const [pendingCount, setPendingCount] = useState<number>(0);
   const [otCount, setOTCount] = useState<number>(0);
@@ -371,6 +372,10 @@ function MeasurementsCommonsInner(props: Readonly<MeasurementsCommonsProps>) {
       // UPDATE predicate (IsValidated = FALSE OR IS NULL) exactly, and the menu copy
       // describes it as "failed or not-yet-validated" (never just "failed").
       setValidationErrorCount(overridableCount);
+      // Feeds the Run Validations menu item — CountRevalidatable mirrors
+      // prepareValidationRun's reset predicate, so the action stays disabled when
+      // the only failures are ingestion failures a rerun cannot clear.
+      setRevalidatableErrorCount(Number(countsData.CountRevalidatable) || 0);
       setPendingCount(pendingValidationCount);
       setOTCount(Number(countsData.CountOldTrees) || 0);
       setMSCount(Number(countsData.CountMultiStems) || 0);
@@ -1696,6 +1701,7 @@ function MeasurementsCommonsInner(props: Readonly<MeasurementsCommonsProps>) {
                         }}
                         pendingCount={pendingCount}
                         overridableCount={validationErrorCount}
+                        revalidatableCount={revalidatableErrorCount}
                       />
                     ),
                     errorControls: { show: showErrorRows, toggle: setShowErrorRows, count: invalidCount, breakdown: invalidBreakdown },

--- a/frontend/components/datagrids/measurementscommonsutils.ts
+++ b/frontend/components/datagrids/measurementscommonsutils.ts
@@ -217,9 +217,9 @@ export function selectMeasurementStateSnackbar(counts: MeasurementStateCounts): 
   // either case, so that is the honest prompt.
   const notYetValidated = counts.pending + counts.failedNoLog;
   if (notYetValidated > 0) {
-    // The validation procedures only process IsValidated IS NULL rows, and the Run Validations
-    // menu entry is disabled when pendingCount === 0 — so when every not-yet-validated row is
-    // FALSE-without-log, "run validations" would be a dead end; prompt the reset first.
+    // FALSE-without-log rows carry no unresolved validation error, so they are outside
+    // prepareValidationRun's rerun reset (CountRevalidatable = 0) and the Run Validations menu
+    // entry stays disabled for them — "run validations" would be a dead end; prompt the reset first.
     const message = counts.pending > 0 ? PENDING_VALIDATION_SNACKBAR_MESSAGE(notYetValidated) : RESET_THEN_VALIDATE_SNACKBAR_MESSAGE(notYetValidated);
     return { severity: 'info', message };
   }

--- a/frontend/components/processors/processorhelperfunctions.tsx
+++ b/frontend/components/processors/processorhelperfunctions.tsx
@@ -347,6 +347,38 @@ async function prepareValidationRun(
     `Validation ${validationProcedureName}`
   );
 
+  const censusID = params.p_CensusID ?? null;
+  const plotID = params.p_PlotID ?? null;
+
+  // Rows this validation previously failed must be re-examined on a rerun, or
+  // a correction elsewhere (e.g. renaming one half of a duplicate-tag pair)
+  // can never clear the partner row's stale error: validation definitions only
+  // process IsValidated IS NULL rows, so a row stuck at FALSE would keep its
+  // unresolved error forever. Reset only THIS validation's unresolved-error
+  // carriers — other validations' verdicts stay untouched, and rows overridden
+  // to TRUE or failed at ingestion (StemGUID IS NULL) are excluded.
+  const resetStaleFailuresQuery = `
+    UPDATE ${schema}.coremeasurements cm
+    JOIN ${schema}.census c ON cm.CensusID = c.CensusID
+    JOIN ${schema}.measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+    JOIN ${schema}.measurement_errors me ON me.ErrorID = mel.ErrorID
+    SET cm.IsValidated = NULL
+    WHERE me.ErrorSource = ?
+      AND me.ErrorCode = ?
+      AND mel.IsResolved = FALSE
+      AND cm.IsValidated = FALSE
+      AND cm.StemGUID IS NOT NULL
+      AND cm.IsActive = TRUE
+      AND (? IS NULL OR cm.CensusID = ?)
+      AND (? IS NULL OR c.PlotID = ?)
+  `;
+  const resetResult: any = await connectionManager.executeQuery(
+    resetStaleFailuresQuery,
+    [VALIDATION_ERROR_SOURCE, String(validationProcedureID), censusID, censusID, plotID, plotID],
+    transactionID
+  );
+  const resetRowCount = Number(resetResult?.affectedRows ?? 0);
+
   const cleanupQuery = `
     DELETE cme FROM ${schema}.measurement_error_log cme
     JOIN ${schema}.measurement_errors me ON me.ErrorID = cme.ErrorID
@@ -359,15 +391,13 @@ async function prepareValidationRun(
       AND (? IS NULL OR cm.CensusID = ?)
       AND (? IS NULL OR c.PlotID = ?)
   `;
-  const censusID = params.p_CensusID ?? null;
-  const plotID = params.p_PlotID ?? null;
   await connectionManager.executeQuery(
     cleanupQuery,
     [VALIDATION_ERROR_SOURCE, String(validationProcedureID), censusID, censusID, plotID, plotID],
     transactionID
   );
 
-  ailogger.info(`[${validationProcedureName}] Cleared stale errors before re-validation`);
+  ailogger.info(`[${validationProcedureName}] Reset ${resetRowCount} previously-failed row(s) and cleared stale errors before re-validation`);
 }
 
 function formatValidationQuery(schema: string, cursorQuery: string, validationProcedureID: number, params: ValidationExecutionParams): string {

--- a/frontend/config/measurementstatefilters.test.ts
+++ b/frontend/config/measurementstatefilters.test.ts
@@ -44,12 +44,13 @@ describe('measurementstatefilters', () => {
       return predicateMatch![1];
     }
 
-    it('projects the five measurement-state count aliases', () => {
+    it('projects the six measurement-state count aliases', () => {
       expect(countsSql).toContain('AS CountFailedNoLog');
       expect(countsSql).toContain('AS CountUnresolvedLogged');
       expect(countsSql).toContain('AS CountPending');
       expect(countsSql).toContain('AS CountValid');
       expect(countsSql).toContain('AS CountOverridable');
+      expect(countsSql).toContain('AS CountRevalidatable');
     });
 
     it('counts failed-no-log as IsValidated = FALSE rows WITHOUT an unresolved log entry (disjoint from CountUnresolvedLogged)', () => {
@@ -81,6 +82,14 @@ describe('measurementstatefilters', () => {
       const overridablePredicate = statePredicate('CountOverridable');
       expect(overridablePredicate).toBe('vft.IsValidated = FALSE OR vft.IsValidated IS NULL');
       expect(overridablePredicate).not.toContain('EXISTS');
+    });
+
+    it('counts revalidatable rows with exactly the prepareValidationRun reset predicate: failed, real stem, unresolved validation-source error', () => {
+      const revalidatablePredicate = statePredicate('CountRevalidatable');
+      expect(revalidatablePredicate).toContain('vft.IsValidated = FALSE AND vft.StemGUID IS NOT NULL AND (EXISTS');
+      expect(revalidatablePredicate).toContain('JOIN myschema.measurement_errors me ON me.ErrorID = mel.ErrorID');
+      expect(revalidatablePredicate).toContain("me.ErrorSource = 'validation'");
+      expect(revalidatablePredicate).toContain('COALESCE(mel.IsResolved, FALSE) = FALSE');
     });
   });
 });

--- a/frontend/config/measurementstatefilters.ts
+++ b/frontend/config/measurementstatefilters.ts
@@ -9,6 +9,17 @@ export function buildMeasurementHasUnresolvedErrorsSql(schema: string, alias: st
           )`;
 }
 
+export function buildMeasurementHasUnresolvedValidationErrorsSql(schema: string, alias: string): string {
+  return `EXISTS (
+            SELECT 1
+            FROM ${schema}.measurement_error_log mel
+            JOIN ${schema}.measurement_errors me ON me.ErrorID = mel.ErrorID
+            WHERE mel.MeasurementID = ${alias}.CoreMeasurementID
+              AND COALESCE(mel.IsResolved, FALSE) = FALSE
+              AND me.ErrorSource = 'validation'
+          )`;
+}
+
 /**
  * Projects measurement-state counts. The first four buckets are mutually exclusive and exhaustive
  * (they sum to the row total):
@@ -22,15 +33,22 @@ export function buildMeasurementHasUnresolvedErrorsSql(schema: string, alias: st
  * CountOverridable is intentionally NOT disjoint from the buckets above: it mirrors the validation
  * override modal's UPDATE predicate (IsValidated = FALSE OR IS NULL) exactly, so it overlaps
  * CountFailedNoLog, CountPending, and the FALSE/NULL portion of CountUnresolvedLogged.
+ *
+ * CountRevalidatable mirrors prepareValidationRun's reset predicate exactly (IsValidated = FALSE,
+ * a real stem, and an unresolved validation-source error): the rows a validation rerun will reset
+ * to pending and re-examine. Ingestion failures (StemGUID NULL, 'ingestion'-source errors) are
+ * excluded — no rerun can clear those, so they must not make the run action look actionable.
  */
 export function buildMeasurementStateCountsSql(schema: string, alias: string): string {
   const hasUnresolvedErrors = buildMeasurementHasUnresolvedErrorsSql(schema, alias);
+  const hasUnresolvedValidationErrors = buildMeasurementHasUnresolvedValidationErrorsSql(schema, alias);
 
   return `SUM(CASE WHEN ${alias}.IsValidated = FALSE AND NOT (${hasUnresolvedErrors}) THEN 1 ELSE 0 END) AS CountFailedNoLog,
           SUM(CASE WHEN ${hasUnresolvedErrors} THEN 1 ELSE 0 END) AS CountUnresolvedLogged,
           SUM(CASE WHEN ${alias}.IsValidated IS NULL AND NOT (${hasUnresolvedErrors}) THEN 1 ELSE 0 END) AS CountPending,
           SUM(CASE WHEN ${alias}.IsValidated = TRUE AND NOT (${hasUnresolvedErrors}) THEN 1 ELSE 0 END) AS CountValid,
-          SUM(CASE WHEN ${alias}.IsValidated = FALSE OR ${alias}.IsValidated IS NULL THEN 1 ELSE 0 END) AS CountOverridable`;
+          SUM(CASE WHEN ${alias}.IsValidated = FALSE OR ${alias}.IsValidated IS NULL THEN 1 ELSE 0 END) AS CountOverridable,
+          SUM(CASE WHEN ${alias}.IsValidated = FALSE AND ${alias}.StemGUID IS NOT NULL AND (${hasUnresolvedValidationErrors}) THEN 1 ELSE 0 END) AS CountRevalidatable`;
 }
 
 export function buildMeasurementVisibleConditionSql(schema: string, alias: string, visibleFilter: VisibleFilter): string {

--- a/frontend/tests/integration/validation-rerun-stale-errors.integration.test.ts
+++ b/frontend/tests/integration/validation-rerun-stale-errors.integration.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Validation Rerun — Stale Error Clearing Integration Tests
+ *
+ * Reproduces the field-reported bug: two measurements share a TreeTag/StemTag,
+ * the duplicate-tag validation flags BOTH rows, the user corrects the tag on
+ * ONE row, reruns validations — and the UN-EDITED partner row keeps its stale
+ * "duplicate" error forever, because both the pre-run cleanup and every
+ * validation definition only consider rows with IsValidated IS NULL. The
+ * partner row sits at IsValidated = FALSE, so it is never re-examined.
+ *
+ * These tests drive the REAL app code end to end against a live MySQL:
+ *   - runValidation / prepareValidationRun (components/processors/processorhelperfunctions.tsx)
+ *   - updateValidatedRows (same module — mirrors /api/validations/updatepassedvalidations)
+ *   - writeMeasurementsSummary (config/editplan/writers/measurementssummary.ts — the grid edit path)
+ *
+ * ConnectionManager is bridged onto the test connection using the same
+ * vi.mock pattern as editplan-writer-measurementssummary.integration.test.ts.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Connection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+
+import { setupTestDatabase, teardownTestDatabase, log, type TestData } from '../setup/local-db-setup';
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null,
+  activeTransactionID: null as string | null
+}));
+
+const TEST_TRANSACTION_ID = 'test-transaction-id';
+
+vi.mock('@/lib/db/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[], transactionID?: string) => {
+      if (!sharedState.connection) {
+        throw new Error('Test DB connection not initialized');
+      }
+      if (query.includes('??')) {
+        throw new Error(`ConnectionManager mock: query contains unformatted identifier placeholders: ${query}`);
+      }
+      if (transactionID && transactionID !== sharedState.activeTransactionID) {
+        throw new Error(`ConnectionManager mock: transactionID mismatch (got "${transactionID}", active "${sharedState.activeTransactionID}")`);
+      }
+      const [rows] = await sharedState.connection.query(query, (params as unknown[]) ?? []);
+      return rows;
+    },
+    beginTransaction: async () => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (sharedState.activeTransactionID) throw new Error('ConnectionManager mock: transaction already active');
+      await sharedState.connection.beginTransaction();
+      sharedState.activeTransactionID = TEST_TRANSACTION_ID;
+      return TEST_TRANSACTION_ID;
+    },
+    commitTransaction: async (transactionID: string) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (transactionID !== sharedState.activeTransactionID) {
+        throw new Error('ConnectionManager mock: commit transactionID mismatch');
+      }
+      await sharedState.connection.commit();
+      sharedState.activeTransactionID = null;
+    },
+    rollbackTransaction: async (transactionID: string) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (transactionID !== sharedState.activeTransactionID) {
+        throw new Error('ConnectionManager mock: rollback transactionID mismatch');
+      }
+      await sharedState.connection.rollback();
+      sharedState.activeTransactionID = null;
+    },
+    cleanupStaleTransactions: async () => undefined,
+    closeConnection: async () => undefined,
+    acquireApplicationLock: async () => true
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+// Route ailogger through the console so genuine failures inside runValidation
+// surface in test output instead of being swallowed.
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: (...args: unknown[]) => console.warn('[ailogger.warn]', ...args),
+    error: (...args: unknown[]) => console.error('[ailogger.error]', ...args)
+  }
+}));
+
+// Imports must follow vi.mock so the mocked ConnectionManager is wired in.
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { runValidation, updateValidatedRows } from '@/components/processors/processorhelperfunctions';
+import { writeMeasurementsSummary } from '@/config/editplan/writers/measurementssummary';
+import type { EditPlan, FieldChange } from '@/config/editplan/types';
+import type { ApplyInTransactionInput } from '@/config/editplan/apply';
+
+const DUPLICATE_TAG_VALIDATION_ID = 5; // ValidateFindDuplicateStemTreeTagCombinationsPerCensus
+
+const SPECIES_CODE = 'ACERRU';
+const QUADRAT_NAME = 'VRQ1';
+const DUPLICATED_TREE_TAG = 'VRT01';
+const CORRECTED_TREE_TAG = 'VRT02';
+const SHARED_STEM_TAG = 'VRS1';
+
+const PLAN_HASH_PLACEHOLDER = 'test-plan-hash';
+const CREATED_BY_USER = 'integration-test';
+
+interface DuplicateFixture {
+  plotID: number;
+  censusID: number;
+  treeID: number;
+  stemGUID: number;
+  editedMeasurementID: number;
+  partnerMeasurementID: number;
+}
+
+interface MeasurementValidationState {
+  isValidated: boolean | null;
+  unresolvedValidationErrorCodes: string[];
+}
+
+function toNullableBool(value: unknown): boolean | null {
+  if (value === null || value === undefined) return null;
+  if (Buffer.isBuffer(value)) return value[0] === 1;
+  return Number(value) === 1;
+}
+
+async function seedDuplicateTagFixture(connection: Connection, testData: TestData): Promise<DuplicateFixture> {
+  const plotID = testData.plots[0].plotID;
+  const censusID = testData.census[0].censusID;
+
+  const [speciesRows] = await connection.query<RowDataPacket[]>('SELECT SpeciesID FROM species WHERE SpeciesCode = ? LIMIT 1', [SPECIES_CODE]);
+  if (speciesRows.length === 0) throw new Error(`Seed species ${SPECIES_CODE} missing from test database`);
+  const speciesID = speciesRows[0].SpeciesID as number;
+
+  const [quadratRes] = await connection.query<ResultSetHeader>(
+    `INSERT INTO quadrats (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area, QuadratShape, IsActive)
+     VALUES (?, ?, 0, 0, 20, 20, 400, 'square', 1)`,
+    [plotID, QUADRAT_NAME]
+  );
+
+  const [treeRes] = await connection.query<ResultSetHeader>('INSERT INTO trees (TreeTag, SpeciesID, CensusID, IsActive) VALUES (?, ?, ?, 1)', [
+    DUPLICATED_TREE_TAG,
+    speciesID,
+    censusID
+  ]);
+  const treeID = treeRes.insertId;
+
+  const [stemRes] = await connection.query<ResultSetHeader>(
+    `INSERT INTO stems (TreeID, QuadratID, CensusID, StemTag, LocalX, LocalY, IsActive)
+     VALUES (?, ?, ?, ?, 1.5, 2.5, 1)`,
+    [treeID, quadratRes.insertId, censusID, SHARED_STEM_TAG]
+  );
+  const stemGUID = stemRes.insertId;
+
+  // Two field sheets both said tag VRT01 / stem VRS1, so ingestion attached
+  // both measurements to the same stem — the exact shape validation 5 flags.
+  const measurementIDs: number[] = [];
+  for (const seed of [
+    { dbh: 15.2, date: '2024-06-01' },
+    { dbh: 31.7, date: '2024-06-02' }
+  ]) {
+    const [cmRes] = await connection.query<ResultSetHeader>(
+      `INSERT INTO coremeasurements
+         (StemGUID, CensusID, MeasuredDBH, MeasuredHOM, MeasurementDate,
+          RawTreeTag, RawStemTag, RawSpCode, RawQuadrat, RawX, RawY, IsValidated, IsActive)
+       VALUES (?, ?, ?, 1.3, ?, ?, ?, ?, ?, 1.5, 2.5, NULL, 1)`,
+      [stemGUID, censusID, seed.dbh, seed.date, DUPLICATED_TREE_TAG, SHARED_STEM_TAG, SPECIES_CODE, QUADRAT_NAME]
+    );
+    measurementIDs.push(cmRes.insertId);
+  }
+
+  return {
+    plotID,
+    censusID,
+    treeID,
+    stemGUID,
+    editedMeasurementID: measurementIDs[0],
+    partnerMeasurementID: measurementIDs[1]
+  };
+}
+
+async function getMeasurementValidationState(connection: Connection, measurementID: number): Promise<MeasurementValidationState> {
+  const [cmRows] = await connection.query<RowDataPacket[]>('SELECT IsValidated FROM coremeasurements WHERE CoreMeasurementID = ? LIMIT 1', [measurementID]);
+  if (cmRows.length === 0) throw new Error(`coremeasurements row ${measurementID} vanished`);
+
+  const [errorRows] = await connection.query<RowDataPacket[]>(
+    `SELECT me.ErrorCode
+     FROM measurement_error_log mel
+     JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+     WHERE mel.MeasurementID = ?
+       AND mel.IsResolved = FALSE
+       AND me.ErrorSource = 'validation'
+     ORDER BY me.ErrorCode`,
+    [measurementID]
+  );
+
+  return {
+    isValidated: toNullableBool(cmRows[0].IsValidated),
+    unresolvedValidationErrorCodes: errorRows.map(row => String(row.ErrorCode))
+  };
+}
+
+async function runDuplicateTagValidation(connection: Connection, schema: string, plotID: number, censusID: number): Promise<void> {
+  const [defRows] = await connection.query<RowDataPacket[]>(
+    'SELECT ProcedureName, Definition FROM sitespecificvalidations WHERE ValidationID = ? AND IsEnabled = 1 LIMIT 1',
+    [DUPLICATE_TAG_VALIDATION_ID]
+  );
+  if (defRows.length === 0) throw new Error(`Validation ${DUPLICATE_TAG_VALIDATION_ID} missing or disabled in test database`);
+
+  const succeeded = await runValidation(DUPLICATE_TAG_VALIDATION_ID, String(defRows[0].ProcedureName), schema, String(defRows[0].Definition), {
+    p_CensusID: censusID,
+    p_PlotID: plotID
+  });
+  if (!succeeded) throw new Error('runValidation reported failure — see logs');
+
+  await updateValidatedRows(schema, { p_CensusID: censusID, p_PlotID: plotID });
+}
+
+async function correctTreeTagViaGridEdit(schema: string, fixture: DuplicateFixture): Promise<void> {
+  const cm = ConnectionManager.getInstance();
+
+  const fieldChanges: FieldChange[] = [{ field: 'TreeTag', from: DUPLICATED_TREE_TAG, to: CORRECTED_TREE_TAG }];
+  const plan: EditPlan = {
+    dataType: 'measurementssummary',
+    targetID: fixture.editedMeasurementID,
+    fieldChanges,
+    effects: [],
+    maxSeverity: 'info',
+    planHash: PLAN_HASH_PLACEHOLDER,
+    generatedAt: new Date().toISOString()
+  };
+  const input: ApplyInTransactionInput = {
+    dataType: 'measurementssummary',
+    schema,
+    plotID: fixture.plotID,
+    censusID: fixture.censusID,
+    targetID: fixture.editedMeasurementID,
+    newRow: { TreeTag: CORRECTED_TREE_TAG },
+    expectedPlanHash: null,
+    createdBy: CREATED_BY_USER,
+    transactionID: TEST_TRANSACTION_ID,
+    refreshViews: false
+  };
+
+  const txID = await cm.beginTransaction();
+  await writeMeasurementsSummary(cm, { ...input, transactionID: txID }, plan, txID);
+  await cm.commitTransaction(txID);
+}
+
+describe('Validation rerun clears stale errors (duplicate tag correction)', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let config: { database: string };
+  let fixture: DuplicateFixture;
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    config = setup.config;
+    sharedState.connection = connection;
+  }, 90000);
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    sharedState.activeTransactionID = null;
+    await teardownTestDatabase(connection, config);
+  });
+
+  beforeEach(async () => {
+    sharedState.activeTransactionID = null;
+    await connection.query('DELETE FROM measurement_error_log');
+    await connection.query('DELETE FROM cmattributes');
+    await connection.query('DELETE FROM coremeasurements');
+    await connection.query('DELETE FROM stems');
+    await connection.query('DELETE FROM trees');
+    await connection.query('DELETE FROM quadrats WHERE QuadratName = ?', [QUADRAT_NAME]);
+    fixture = await seedDuplicateTagFixture(connection, testData);
+  });
+
+  it('flags BOTH measurements of a duplicated tag pair on the first run', async () => {
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    const edited = await getMeasurementValidationState(connection, fixture.editedMeasurementID);
+    const partner = await getMeasurementValidationState(connection, fixture.partnerMeasurementID);
+    log.debug(`After first run — edited: ${JSON.stringify(edited)}, partner: ${JSON.stringify(partner)}`);
+
+    expect(edited.unresolvedValidationErrorCodes).toEqual([String(DUPLICATE_TAG_VALIDATION_ID)]);
+    expect(partner.unresolvedValidationErrorCodes).toEqual([String(DUPLICATE_TAG_VALIDATION_ID)]);
+    expect(edited.isValidated).toBe(false);
+    expect(partner.isValidated).toBe(false);
+  });
+
+  it('clears the stale duplicate error on the UN-EDITED partner row after tag correction + rerun', async () => {
+    // Step 1: first validation run flags both rows of the duplicate pair.
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    // Step 2: the user corrects the tag on ONE row via the grid edit path.
+    await correctTreeTagViaGridEdit(config.database, fixture);
+
+    const editedAfterEdit = await getMeasurementValidationState(connection, fixture.editedMeasurementID);
+    log.debug(`After edit — edited row: ${JSON.stringify(editedAfterEdit)}`);
+    expect(editedAfterEdit.isValidated).toBeNull(); // edit resets the edited row to pending
+    expect(editedAfterEdit.unresolvedValidationErrorCodes).toEqual([]);
+
+    // Step 3: the user reruns validations.
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    const edited = await getMeasurementValidationState(connection, fixture.editedMeasurementID);
+    const partner = await getMeasurementValidationState(connection, fixture.partnerMeasurementID);
+    log.debug(`After rerun — edited: ${JSON.stringify(edited)}, partner: ${JSON.stringify(partner)}`);
+
+    // The corrected row passes.
+    expect(edited.unresolvedValidationErrorCodes).toEqual([]);
+    expect(edited.isValidated).toBe(true);
+
+    // THE BUG: the partner row is no longer a duplicate (its tag is now unique
+    // in the census) but keeps the stale unresolved error and stays failed.
+    expect(partner.unresolvedValidationErrorCodes).toEqual([]);
+    expect(partner.isValidated).toBe(true);
+  });
+
+  it('keeps flagging both rows when the duplicate is NOT corrected between reruns', async () => {
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    const edited = await getMeasurementValidationState(connection, fixture.editedMeasurementID);
+    const partner = await getMeasurementValidationState(connection, fixture.partnerMeasurementID);
+    log.debug(`After double run without correction — edited: ${JSON.stringify(edited)}, partner: ${JSON.stringify(partner)}`);
+
+    expect(edited.unresolvedValidationErrorCodes).toEqual([String(DUPLICATE_TAG_VALIDATION_ID)]);
+    expect(partner.unresolvedValidationErrorCodes).toEqual([String(DUPLICATE_TAG_VALIDATION_ID)]);
+    expect(edited.isValidated).toBe(false);
+    expect(partner.isValidated).toBe(false);
+  });
+
+  it('does not disturb rows whose validation state was overridden to TRUE', async () => {
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    // Simulate the "override validations" action: force both rows valid while
+    // their duplicate errors are still unresolved.
+    await connection.query('UPDATE coremeasurements SET IsValidated = TRUE WHERE CoreMeasurementID IN (?, ?)', [
+      fixture.editedMeasurementID,
+      fixture.partnerMeasurementID
+    ]);
+
+    await runDuplicateTagValidation(connection, config.database, fixture.plotID, fixture.censusID);
+
+    const edited = await getMeasurementValidationState(connection, fixture.editedMeasurementID);
+    const partner = await getMeasurementValidationState(connection, fixture.partnerMeasurementID);
+    log.debug(`After rerun with override — edited: ${JSON.stringify(edited)}, partner: ${JSON.stringify(partner)}`);
+
+    expect(edited.isValidated).toBe(true);
+    expect(partner.isValidated).toBe(true);
+  });
+});

--- a/frontend/tests/integration/validation-trap-families.integration.test.ts
+++ b/frontend/tests/integration/validation-trap-families.integration.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Confirms the prepareValidationRun rerun-reset clears stale errors across
+ * every "trap family," not just the duplicate-tag case covered by
+ * validation-rerun-stale-errors.integration.test.ts.
+ *
+ * Families exercised, one representative each — in every case the CORRECTION
+ * NEVER TOUCHES THE FLAGGED MEASUREMENT, which is exactly the shape that used
+ * to strand rows at IsValidated = FALSE forever:
+ *   - V4  duplicated quadrat names  → fix = rename a quadrat (reference table)
+ *   - V11 DBH outside species limits → fix = widen specieslimits (reference table)
+ *   - V6  outside census date bounds → fix = widen census dates (reference table)
+ *   - V1  DBH growth exceeds max     → fix = correct the PREVIOUS census's DBH
+ *         (cross-census, and runs through the RunSharedDBHChangeValidations
+ *         stored-procedure path via runCombinedDBHValidations)
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Connection, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
+
+import {
+  cleanupTestMeasurements,
+  insertCrossCensusMeasurements,
+  seedStatusAttributes,
+  setupTestDatabase,
+  setupTwoCensusScenario,
+  teardownTestDatabase,
+  log,
+  type CensusInfo,
+  type TestData
+} from '../setup/local-db-setup';
+
+const sharedState = vi.hoisted(() => ({
+  connection: null as Connection | null,
+  activeTransactionID: null as string | null
+}));
+
+const TEST_TRANSACTION_ID = 'test-transaction-id';
+
+vi.mock('@/lib/db/connectionmanager', () => {
+  const manager = {
+    executeQuery: async (query: string, params?: unknown[], transactionID?: string) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (query.includes('??')) throw new Error(`ConnectionManager mock: unformatted identifier placeholders: ${query}`);
+      if (transactionID && transactionID !== sharedState.activeTransactionID) {
+        throw new Error(`ConnectionManager mock: transactionID mismatch (got "${transactionID}", active "${sharedState.activeTransactionID}")`);
+      }
+      const [rows] = await sharedState.connection.query(query, (params as unknown[]) ?? []);
+      return rows;
+    },
+    beginTransaction: async () => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (sharedState.activeTransactionID) throw new Error('ConnectionManager mock: transaction already active');
+      await sharedState.connection.beginTransaction();
+      sharedState.activeTransactionID = TEST_TRANSACTION_ID;
+      return TEST_TRANSACTION_ID;
+    },
+    commitTransaction: async (transactionID: string) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (transactionID !== sharedState.activeTransactionID) throw new Error('ConnectionManager mock: commit transactionID mismatch');
+      await sharedState.connection.commit();
+      sharedState.activeTransactionID = null;
+    },
+    rollbackTransaction: async (transactionID: string) => {
+      if (!sharedState.connection) throw new Error('Test DB connection not initialized');
+      if (transactionID !== sharedState.activeTransactionID) throw new Error('ConnectionManager mock: rollback transactionID mismatch');
+      await sharedState.connection.rollback();
+      sharedState.activeTransactionID = null;
+    },
+    cleanupStaleTransactions: async () => undefined,
+    closeConnection: async () => undefined,
+    acquireApplicationLock: async () => true
+  };
+  return { default: { getInstance: () => manager } };
+});
+
+vi.mock('@/ailogger', () => ({
+  default: {
+    info: () => undefined,
+    warn: (...args: unknown[]) => console.warn('[ailogger.warn]', ...args),
+    error: (...args: unknown[]) => console.error('[ailogger.error]', ...args)
+  }
+}));
+
+import { runCombinedDBHValidations, runValidation, updateValidatedRows } from '@/components/processors/processorhelperfunctions';
+
+const VALIDATION_IDS = {
+  DBH_GROWTH: 1,
+  DUPLICATE_QUADRAT_NAMES: 4,
+  OUTSIDE_CENSUS_DATE_BOUNDS: 6,
+  DBH_OUTSIDE_SPECIES_LIMITS: 11
+} as const;
+
+const SPECIES_CODE = 'ACERRU';
+
+interface RowState {
+  isValidated: boolean | null;
+  unresolvedValidationErrorCodes: string[];
+}
+
+function toNullableBool(value: unknown): boolean | null {
+  if (value === null || value === undefined) return null;
+  if (Buffer.isBuffer(value)) return value[0] === 1;
+  return Number(value) === 1;
+}
+
+describe('Validation rerun clears stale errors across trap families', () => {
+  let connection: Connection;
+  let testData: TestData;
+  let config: { database: string };
+  let census1: CensusInfo;
+  let census2: CensusInfo;
+  let plotID: number;
+  let speciesID: number;
+
+  async function rowState(measurementID: number): Promise<RowState> {
+    const [cmRows] = await connection.query<RowDataPacket[]>('SELECT IsValidated FROM coremeasurements WHERE CoreMeasurementID = ? LIMIT 1', [measurementID]);
+    if (cmRows.length === 0) throw new Error(`coremeasurements row ${measurementID} vanished`);
+    const [errorRows] = await connection.query<RowDataPacket[]>(
+      `SELECT me.ErrorCode
+       FROM measurement_error_log mel
+       JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+       WHERE mel.MeasurementID = ? AND mel.IsResolved = FALSE AND me.ErrorSource = 'validation'
+       ORDER BY me.ErrorCode`,
+      [measurementID]
+    );
+    return { isValidated: toNullableBool(cmRows[0].IsValidated), unresolvedValidationErrorCodes: errorRows.map(row => String(row.ErrorCode)) };
+  }
+
+  async function runValidationByID(validationID: number, censusID: number): Promise<void> {
+    const [defRows] = await connection.query<RowDataPacket[]>(
+      'SELECT ProcedureName, Definition FROM sitespecificvalidations WHERE ValidationID = ? AND IsEnabled = 1 LIMIT 1',
+      [validationID]
+    );
+    if (defRows.length === 0) throw new Error(`Validation ${validationID} missing or disabled`);
+    const ok = await runValidation(validationID, String(defRows[0].ProcedureName), config.database, String(defRows[0].Definition), {
+      p_CensusID: censusID,
+      p_PlotID: plotID
+    });
+    if (!ok) throw new Error(`runValidation ${validationID} reported failure`);
+    await updateValidatedRows(config.database, { p_CensusID: censusID, p_PlotID: plotID });
+  }
+
+  async function seedQuadrat(name: string, startX: number): Promise<number> {
+    const [res] = await connection.query<ResultSetHeader>(
+      `INSERT INTO quadrats (PlotID, QuadratName, StartX, StartY, DimensionX, DimensionY, Area, QuadratShape, IsActive)
+       VALUES (?, ?, ?, 0, 20, 20, 400, 'square', 1)`,
+      [plotID, name, startX]
+    );
+    return res.insertId;
+  }
+
+  async function seedMeasuredStem(opts: { treeTag: string; stemTag: string; quadratID: number; censusID: number; dbh: number; date: string }): Promise<number> {
+    const [treeRes] = await connection.query<ResultSetHeader>('INSERT INTO trees (TreeTag, SpeciesID, CensusID, IsActive) VALUES (?, ?, ?, 1)', [
+      opts.treeTag,
+      speciesID,
+      opts.censusID
+    ]);
+    const [stemRes] = await connection.query<ResultSetHeader>(
+      `INSERT INTO stems (TreeID, QuadratID, CensusID, StemTag, LocalX, LocalY, IsActive) VALUES (?, ?, ?, ?, 1, 1, 1)`,
+      [treeRes.insertId, opts.quadratID, opts.censusID, opts.stemTag]
+    );
+    const [cmRes] = await connection.query<ResultSetHeader>(
+      `INSERT INTO coremeasurements (StemGUID, CensusID, MeasuredDBH, MeasuredHOM, MeasurementDate, IsValidated, IsActive)
+       VALUES (?, ?, ?, 1.3, ?, NULL, 1)`,
+      [stemRes.insertId, opts.censusID, opts.dbh, opts.date]
+    );
+    return cmRes.insertId;
+  }
+
+  beforeAll(async () => {
+    const setup = await setupTestDatabase();
+    connection = setup.connection;
+    testData = setup.testData;
+    config = setup.config;
+    sharedState.connection = connection;
+    plotID = testData.plots[0].plotID;
+
+    const scenario = await setupTwoCensusScenario(connection, testData);
+    census1 = scenario.census1;
+    census2 = scenario.census2;
+
+    await seedStatusAttributes(connection);
+    const [speciesRows] = await connection.query<RowDataPacket[]>('SELECT SpeciesID FROM species WHERE SpeciesCode = ? LIMIT 1', [SPECIES_CODE]);
+    speciesID = speciesRows[0].SpeciesID as number;
+  }, 90000);
+
+  afterAll(async () => {
+    sharedState.connection = null;
+    sharedState.activeTransactionID = null;
+    await teardownTestDatabase(connection, config);
+  });
+
+  beforeEach(async () => {
+    sharedState.activeTransactionID = null;
+    await cleanupTestMeasurements(connection, testData);
+    await connection.query('DELETE FROM specieslimits');
+    await connection.query("DELETE FROM quadrats WHERE QuadratName LIKE 'TRAP%'");
+  });
+
+  it('V4: renaming a duplicated quadrat (pure reference edit, zero measurement edits) clears both flagged rows on rerun', async () => {
+    // uq_quadrats_active_name (PR #346) blocks NEW duplicate names, so this
+    // scenario only exists as legacy data on schemas that predate the guard.
+    // Drop the constraint to simulate that legacy state; restore it after.
+    await connection.query('ALTER TABLE quadrats DROP INDEX uq_quadrats_active_name');
+    const quadratAID = await seedQuadrat('TRAPQ', 0);
+    const quadratBID = await seedQuadrat('TRAPQ', 20);
+    const rowA = await seedMeasuredStem({ treeTag: 'TQ1', stemTag: 'Q1', quadratID: quadratAID, censusID: census1.censusID, dbh: 50, date: '2024-06-10' });
+    const rowB = await seedMeasuredStem({ treeTag: 'TQ2', stemTag: 'Q2', quadratID: quadratBID, censusID: census1.censusID, dbh: 60, date: '2024-06-11' });
+
+    await runValidationByID(VALIDATION_IDS.DUPLICATE_QUADRAT_NAMES, census1.censusID);
+    expect((await rowState(rowA)).unresolvedValidationErrorCodes).toEqual(['4']);
+    expect((await rowState(rowB)).unresolvedValidationErrorCodes).toEqual(['4']);
+
+    try {
+      await connection.query('UPDATE quadrats SET QuadratName = ? WHERE QuadratID = ?', ['TRAPQ2', quadratBID]);
+
+      await runValidationByID(VALIDATION_IDS.DUPLICATE_QUADRAT_NAMES, census1.censusID);
+      const a = await rowState(rowA);
+      const b = await rowState(rowB);
+      log.debug(`V4 after fix+rerun — A: ${JSON.stringify(a)}, B: ${JSON.stringify(b)}`);
+      expect(a.unresolvedValidationErrorCodes).toEqual([]);
+      expect(b.unresolvedValidationErrorCodes).toEqual([]);
+      expect(a.isValidated).toBe(true);
+      expect(b.isValidated).toBe(true);
+    } finally {
+      await connection.query("DELETE FROM quadrats WHERE QuadratName LIKE 'TRAP%' AND QuadratID NOT IN (?, ?)", [quadratAID, quadratBID]);
+      await connection.query('ALTER TABLE quadrats ADD CONSTRAINT uq_quadrats_active_name UNIQUE (PlotID, QuadratName, IsActive)');
+    }
+  });
+
+  it('V11: widening specieslimits (pure reference edit) clears the flagged row on rerun', async () => {
+    const quadratID = await seedQuadrat('TRAPL', 0);
+    const row = await seedMeasuredStem({ treeTag: 'TL1', stemTag: 'L1', quadratID, censusID: census1.censusID, dbh: 150, date: '2024-06-10' });
+    await connection.query(`INSERT INTO specieslimits (SpeciesID, CensusID, LimitType, LowerBound, UpperBound, IsActive) VALUES (?, ?, 'DBH', 10, 100, 1)`, [
+      speciesID,
+      census1.censusID
+    ]);
+
+    await runValidationByID(VALIDATION_IDS.DBH_OUTSIDE_SPECIES_LIMITS, census1.censusID);
+    expect((await rowState(row)).unresolvedValidationErrorCodes).toEqual(['11']);
+
+    await connection.query('UPDATE specieslimits SET UpperBound = 500 WHERE SpeciesID = ? AND CensusID = ?', [speciesID, census1.censusID]);
+
+    await runValidationByID(VALIDATION_IDS.DBH_OUTSIDE_SPECIES_LIMITS, census1.censusID);
+    const state = await rowState(row);
+    log.debug(`V11 after fix+rerun — ${JSON.stringify(state)}`);
+    expect(state.unresolvedValidationErrorCodes).toEqual([]);
+    expect(state.isValidated).toBe(true);
+  });
+
+  it('V6: widening the census date bounds (census-table edit) clears the flagged row on rerun', async () => {
+    await connection.query('UPDATE census SET StartDate = ?, EndDate = ? WHERE CensusID = ?', ['2024-06-01', '2024-06-30', census1.censusID]);
+    const quadratID = await seedQuadrat('TRAPD', 0);
+    const row = await seedMeasuredStem({ treeTag: 'TD1', stemTag: 'D1', quadratID, censusID: census1.censusID, dbh: 50, date: '2024-07-15' });
+
+    await runValidationByID(VALIDATION_IDS.OUTSIDE_CENSUS_DATE_BOUNDS, census1.censusID);
+    expect((await rowState(row)).unresolvedValidationErrorCodes).toEqual(['6']);
+
+    await connection.query('UPDATE census SET EndDate = ? WHERE CensusID = ?', ['2024-07-31', census1.censusID]);
+
+    await runValidationByID(VALIDATION_IDS.OUTSIDE_CENSUS_DATE_BOUNDS, census1.censusID);
+    const state = await rowState(row);
+    log.debug(`V6 after fix+rerun — ${JSON.stringify(state)}`);
+    expect(state.unresolvedValidationErrorCodes).toEqual([]);
+    expect(state.isValidated).toBe(true);
+  });
+
+  it('V1 (stored-proc path): correcting the PREVIOUS census DBH clears the flagged current-census row on rerun', async () => {
+    await seedQuadrat('TRAPG', 0);
+    const { census1MeasurementIDs, census2MeasurementIDs } = await insertCrossCensusMeasurements(connection, testData, census1.censusID, census2.censusID, [
+      {
+        treeTag: 'TG1',
+        stemTag: 'G1',
+        speciesCode: SPECIES_CODE,
+        quadratName: 'TRAPG',
+        x: 1,
+        y: 1,
+        hom: 1.3,
+        census1DBH: 100,
+        census2DBH: 200,
+        census1Date: '2024-01-15',
+        census2Date: '2024-06-15'
+      }
+    ]);
+    const pastRow = census1MeasurementIDs[0];
+    const presentRow = census2MeasurementIDs[0];
+
+    const first = await runCombinedDBHValidations(config.database, { p_CensusID: census2.censusID, p_PlotID: plotID });
+    expect(first.success).toBe(true);
+    await updateValidatedRows(config.database, { p_CensusID: census2.censusID, p_PlotID: plotID });
+    expect((await rowState(presentRow)).unresolvedValidationErrorCodes).toEqual(['1']);
+    expect((await rowState(presentRow)).isValidated).toBe(false);
+
+    // The field correction: the PAST census's DBH was the typo. Fix it there;
+    // the flagged present-census row is never touched.
+    await connection.query('UPDATE coremeasurements SET MeasuredDBH = 180 WHERE CoreMeasurementID = ?', [pastRow]);
+
+    const second = await runCombinedDBHValidations(config.database, { p_CensusID: census2.censusID, p_PlotID: plotID });
+    expect(second.success).toBe(true);
+    await updateValidatedRows(config.database, { p_CensusID: census2.censusID, p_PlotID: plotID });
+    const state = await rowState(presentRow);
+    log.debug(`V1 after fix+rerun — ${JSON.stringify(state)}`);
+    expect(state.unresolvedValidationErrorCodes).toEqual([]);
+    expect(state.isValidated).toBe(true);
+  });
+});

--- a/frontend/tests/setup/local-db-setup.ts
+++ b/frontend/tests/setup/local-db-setup.ts
@@ -1585,6 +1585,29 @@ export async function runValidationForTest(
     return false;
   }
 
+  // Mirrors prepareValidationRun (processorhelperfunctions.tsx): reset rows
+  // this validation previously failed back to pending so the definition
+  // re-examines them, then clear their stale error links.
+  const resetStaleFailuresQuery = `
+    UPDATE coremeasurements cm
+    JOIN census c ON cm.CensusID = c.CensusID
+    JOIN measurement_error_log mel ON mel.MeasurementID = cm.CoreMeasurementID
+    JOIN measurement_errors me ON me.ErrorID = mel.ErrorID
+    SET cm.IsValidated = NULL
+    WHERE me.ErrorSource = 'validation'
+      AND me.ErrorCode = CAST(? AS CHAR)
+      AND mel.IsResolved = FALSE
+      AND cm.IsValidated = FALSE
+      AND cm.StemGUID IS NOT NULL
+      AND cm.IsActive = TRUE
+      ${params.censusID ? 'AND cm.CensusID = ?' : ''}
+      ${params.plotID ? 'AND c.PlotID = ?' : ''}
+  `;
+  const scopeParams: (number | undefined)[] = [validationID];
+  if (params.censusID) scopeParams.push(params.censusID);
+  if (params.plotID) scopeParams.push(params.plotID);
+  await connection.query(resetStaleFailuresQuery, scopeParams);
+
   // Clear stale validation errors for this validation
   const cleanupQuery = `
     DELETE mel FROM measurement_error_log mel
@@ -1598,10 +1621,7 @@ export async function runValidationForTest(
       ${params.censusID ? 'AND cm.CensusID = ?' : ''}
       ${params.plotID ? 'AND c.PlotID = ?' : ''}
   `;
-  const cleanupParams: (number | undefined)[] = [validationID];
-  if (params.censusID) cleanupParams.push(params.censusID);
-  if (params.plotID) cleanupParams.push(params.plotID);
-  await connection.query(cleanupQuery, cleanupParams);
+  await connection.query(cleanupQuery, scopeParams);
 
   // Format the validation query with parameter replacements
   // We're already connected to the test database, so no schema prefix is needed


### PR DESCRIPTION
## Summary

Field-reported by Suzanne: after correcting one half of a duplicate tag/stemtag pair, rerunning validations never cleared the error on the un-edited partner record, leaving it permanently flagged and excluded from the data.

Root cause: validation definitions and the pre-run stale-error cleanup both filter on `IsValidated IS NULL`. The duplicate-tag validation flags both rows of a pair; editing one row resets only that row to pending, so the partner sits at `IsValidated = FALSE` forever — never re-examined, error never cleared.

- `prepareValidationRun` now resets rows carrying the running validation's own unresolved error back to pending before clearing their stale error links, so the definition re-checks them (and logs how many rows it reset). Only that validation's error carriers are touched: other validations' verdicts, overridden (TRUE) rows, and ingestion failures (`StemGUID IS NULL`) are excluded. Covers the combined DBH and cross-census stored-procedure validations too, since they all route through `prepareValidationRun`.
- The Run Validations menu entry was disabled whenever no rows were pending, which made the rerun unreachable in exactly the stuck state above. It now gates on a new `CountRevalidatable` bucket that mirrors the reset predicate exactly (failed, real stem, unresolved validation-source error), so ingestion-only failure states keep it disabled instead of offering a no-op.
- New integration test reproduces the field scenario end-to-end through the real `runValidation`, `updateValidatedRows`, and grid-edit writer against live MySQL: red before the fix, green after. Guard cases pin that genuine duplicates keep getting re-flagged across reruns and overrides survive. Unit tests cover the menu gating states and the new SQL bucket.