### PR TITLE
fix(ui): make the failed-measurements recovery modal reachable

### DIFF
--- a/frontend/app/(hub)/measurementshub/summary/page.test.tsx
+++ b/frontend/app/(hub)/measurementshub/summary/page.test.tsx
@@ -28,4 +28,10 @@ describe('SummaryPage — failed-measurements deep link', () => {
 
     expect(element.props.autoOpenFailedMeasurements).toBe(false);
   });
+
+  it('fails closed when the query parameter is repeated', async () => {
+    const element = await SummaryPage({ searchParams: Promise.resolve({ openFailed: ['1', '1'] }) });
+
+    expect(element.props.autoOpenFailedMeasurements).toBe(false);
+  });
 });

--- a/frontend/app/(hub)/measurementshub/summary/page.test.tsx
+++ b/frontend/app/(hub)/measurementshub/summary/page.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The page's contract under test is which props it passes to the grid; the
+// grid's own import chain (datagrid HCs, DB definitions) stays out of scope.
+vi.mock('@/components/datagrids/applications/msvdatagrid', () => ({
+  default: () => null
+}));
+
+import SummaryPage from './page';
+
+describe('SummaryPage — failed-measurements deep link', () => {
+  it('opens the failed-measurements modal and strips the query on close when ?openFailed=1', async () => {
+    const element = await SummaryPage({ searchParams: Promise.resolve({ openFailed: '1' }) });
+
+    expect(element.props.autoOpenFailedMeasurements).toBe(true);
+    expect(element.props.failedMeasurementsCloseRedirectHref).toBe('/measurementshub/summary');
+  });
+
+  it('renders the plain grid when the query parameter is absent', async () => {
+    const element = await SummaryPage({ searchParams: Promise.resolve({}) });
+
+    expect(element.props.autoOpenFailedMeasurements).toBe(false);
+    expect(element.props.failedMeasurementsCloseRedirectHref).toBeUndefined();
+  });
+
+  it('ignores unexpected values for the query parameter', async () => {
+    const element = await SummaryPage({ searchParams: Promise.resolve({ openFailed: 'yes' }) });
+
+    expect(element.props.autoOpenFailedMeasurements).toBe(false);
+  });
+});

--- a/frontend/app/(hub)/measurementshub/summary/page.tsx
+++ b/frontend/app/(hub)/measurementshub/summary/page.tsx
@@ -1,9 +1,21 @@
 import MeasurementsSummaryViewDataGrid from '@/components/datagrids/applications/msvdatagrid';
 
-export default function SummaryPage() {
+interface SummaryPageProps {
+  searchParams: Promise<{ openFailed?: string }>;
+}
+
+export default async function SummaryPage({ searchParams }: SummaryPageProps) {
+  // Entry point for "fix your failed uploads" links (e.g. from the Errors
+  // Explorer): /measurementshub/summary?openFailed=1 lands with the Failed
+  // Measurements modal already open. Closing it strips the query so a page
+  // refresh does not re-open the modal.
+  const { openFailed } = await searchParams;
+  const shouldOpenFailedMeasurements = openFailed === '1';
+
   return (
-    <>
-      <MeasurementsSummaryViewDataGrid />
-    </>
+    <MeasurementsSummaryViewDataGrid
+      autoOpenFailedMeasurements={shouldOpenFailedMeasurements}
+      failedMeasurementsCloseRedirectHref={shouldOpenFailedMeasurements ? '/measurementshub/summary' : undefined}
+    />
   );
 }

--- a/frontend/app/(hub)/measurementshub/summary/page.tsx
+++ b/frontend/app/(hub)/measurementshub/summary/page.tsx
@@ -1,7 +1,7 @@
 import MeasurementsSummaryViewDataGrid from '@/components/datagrids/applications/msvdatagrid';
 
 interface SummaryPageProps {
-  searchParams: Promise<{ openFailed?: string }>;
+  searchParams: Promise<{ openFailed?: string | string[] }>;
 }
 
 export default async function SummaryPage({ searchParams }: SummaryPageProps) {

--- a/frontend/app/api/failedmeasurements/count/[schema]/[plotID]/[censusID]/route.test.ts
+++ b/frontend/app/api/failedmeasurements/count/[schema]/[plotID]/[censusID]/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAuth, mockExecuteQuery, mockCloseConnection, mockLoggerError } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockExecuteQuery: vi.fn(),
+  mockCloseConnection: vi.fn(),
+  mockLoggerError: vi.fn()
+}));
+
+vi.mock('@/auth', () => ({ auth: mockAuth }));
+
+vi.mock('@/lib/db/connectionmanager', () => ({
+  default: {
+    getInstance: () => ({
+      executeQuery: mockExecuteQuery,
+      closeConnection: mockCloseConnection
+    })
+  }
+}));
+
+vi.mock('@/config/measurementerrors', () => ({
+  buildFailedMeasurementsSelectQuery: vi.fn(() => 'SELECT * FROM failed_measurements_source')
+}));
+
+vi.mock('@/ailogger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: mockLoggerError }
+}));
+
+import { GET } from './route';
+
+function request(schema = 'forestgeo_testing', plotID = '7', censusID = '3') {
+  return GET(new Request('http://localhost/api/failedmeasurements/count') as any, {
+    params: Promise.resolve({ schema, plotID, censusID })
+  });
+}
+
+describe('failed-measurement count route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { userStatus: 'field crew', sites: [{ schemaName: 'forestgeo_testing' }] }
+    });
+    mockExecuteQuery.mockResolvedValue([{ total: 4 }]);
+    mockCloseConnection.mockResolvedValue(undefined);
+  });
+
+  it('allows a non-admin site member to read the scoped count', async () => {
+    const response = await request();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ recordCount: 4 });
+    expect(mockExecuteQuery).toHaveBeenCalledWith(expect.stringContaining('failed.PlotID = ? AND failed.CensusID = ?'), [7, 3]);
+    expect(mockCloseConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a site outside the user scope before querying', async () => {
+    const response = await request('forestgeo_panama');
+
+    expect(response.status).toBe(403);
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['1abc', '3'],
+    ['0', '3'],
+    ['7', '-1']
+  ])('rejects invalid numeric scope values %s/%s', async (plotID, censusID) => {
+    const response = await request('forestgeo_testing', plotID, censusID);
+
+    expect(response.status).toBe(400);
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns a generic error and still closes the connection when the query fails', async () => {
+    mockExecuteQuery.mockRejectedValueOnce(new Error('database details'));
+
+    const response = await request();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Failed to count failed measurements' });
+    expect(mockLoggerError).toHaveBeenCalled();
+    expect(mockCloseConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the database returns an invalid count', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([{ total: -1 }]);
+
+    const response = await request();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Failed to count failed measurements' });
+  });
+});

--- a/frontend/app/api/failedmeasurements/count/[schema]/[plotID]/[censusID]/route.ts
+++ b/frontend/app/api/failedmeasurements/count/[schema]/[plotID]/[censusID]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import ConnectionManager from '@/lib/db/connectionmanager';
+import { HTTPResponses } from '@/config/macros';
+import { buildFailedMeasurementsSelectQuery } from '@/config/measurementerrors';
+import { validateSchemaOrThrow } from '@/lib/db/sqlsecurity';
+import { fromPath, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
+import ailogger from '@/ailogger';
+
+export const runtime = 'nodejs';
+
+function parsePositiveInteger(value: string | string[] | undefined): number | undefined {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+async function handler(_request: NextRequest, context: RouteContext) {
+  const params = await context.params;
+  const schema = params.schema;
+  const plotID = parsePositiveInteger(params.plotID);
+  const censusID = parsePositiveInteger(params.censusID);
+
+  if (typeof schema !== 'string' || !plotID || !censusID) {
+    return NextResponse.json({ error: 'Invalid plotID or censusID' }, { status: HTTPResponses.BAD_REQUEST });
+  }
+
+  // Defense in depth: the authorization wrapper validates the schema before
+  // this handler runs, and this query builder interpolates it as an identifier.
+  try {
+    validateSchemaOrThrow(schema);
+  } catch {
+    return NextResponse.json({ error: 'Invalid schema' }, { status: HTTPResponses.BAD_REQUEST });
+  }
+
+  const connectionManager = ConnectionManager.getInstance();
+
+  try {
+    const rows = await connectionManager.executeQuery(
+      `SELECT COUNT(*) AS total
+       FROM (${buildFailedMeasurementsSelectQuery(schema)}) failed
+       WHERE failed.PlotID = ? AND failed.CensusID = ?`,
+      [plotID, censusID]
+    );
+    const total = Number(rows[0]?.total ?? 0);
+    if (!Number.isSafeInteger(total) || total < 0) {
+      throw new Error('Database returned an invalid failed-measurement count');
+    }
+
+    return NextResponse.json({ recordCount: total }, { status: HTTPResponses.OK });
+  } catch (error: unknown) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    ailogger.error(`Failed to count failed measurements for ${schema}/${plotID}/${censusID}:`, err);
+    return NextResponse.json({ error: 'Failed to count failed measurements' }, { status: HTTPResponses.INTERNAL_SERVER_ERROR });
+  } finally {
+    try {
+      await connectionManager.closeConnection();
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      ailogger.error('Failed to close the failed-measurement count connection:', err);
+    }
+  }
+}
+
+export const GET = withRouteAuthz('failedmeasurements/count/[schema]/[plotID]/[censusID]', handler, { schema: fromPath('schema') });

--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -362,7 +362,9 @@ describe('EditToolbar', () => {
         gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
         gridType="measurementssummary"
         showToolbarActions
-        dynamicButtons={[{ label: 'Fix Failed Rows', tooltip: 'Review rows that failed upload', onClick: onFixFailedRows, badgeCount: 3 }]}
+        dynamicButtons={[
+          { label: 'Fix Failed Rows', tooltip: 'Review rows that failed upload', onClick: onFixFailedRows, badgeCount: 3, prominentWarning: true }
+        ]}
         validationMenu={null}
       />
     );

--- a/frontend/components/client/datagridelements.test.tsx
+++ b/frontend/components/client/datagridelements.test.tsx
@@ -344,4 +344,36 @@ describe('EditToolbar', () => {
 
     expect(screen.getByRole('button', { name: /more actions/i })).toBeInTheDocument();
   });
+
+  it('renders Fix Failed Rows as a visible warning button with its count, not inside the More menu', async () => {
+    const user = userEvent.setup();
+    const onFixFailedRows = vi.fn();
+    render(
+      <EditToolbar
+        handleAddNewRow={handleAddNewRow}
+        handleRefresh={handleRefresh}
+        handleQuickFilterChange={handleQuickFilterChange}
+        filterModel={{
+          items: [],
+          quickFilterValues: [],
+          visible: ['errors', 'valid', 'pending'],
+          tss: ['old tree', 'multi stem', 'new recruit']
+        }}
+        gridColumns={[{ field: 'coreMeasurementID', headerName: 'Measurement ID' }]}
+        gridType="measurementssummary"
+        showToolbarActions
+        dynamicButtons={[{ label: 'Fix Failed Rows', tooltip: 'Review rows that failed upload', onClick: onFixFailedRows, badgeCount: 3 }]}
+        validationMenu={null}
+      />
+    );
+
+    const fixButton = screen.getByRole('button', { name: 'Fix Failed Rows (3)' });
+    expect(fixButton).toBeInTheDocument();
+    // Despite carrying a tooltip, the recovery action must never be relegated
+    // to the More overflow menu.
+    expect(screen.queryByRole('button', { name: /more actions/i })).not.toBeInTheDocument();
+
+    await user.click(fixButton);
+    expect(onFixFailedRows).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -205,7 +205,9 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
 
   const hasAnyExport = typeof handleExport === 'function' || typeof handleExportAll === 'function' || typeof handleExportCSV === 'function';
 
-  const moreMenuButtons = dynamicButtons.filter((button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload' && button.tooltip);
+  const moreMenuButtons = dynamicButtons.filter(
+    (button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload' && button.label !== 'Fix Failed Rows' && button.tooltip
+  );
   const hasMoreMenuItems = moreMenuButtons.length > 0 || Boolean(validationMenu);
 
   // only require add / refresh / quickFilter / model / columns
@@ -480,6 +482,21 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                         render={
                           <Button onClick={button.onClick} variant="soft" color="primary" size="sm" startDecorator={button.icon} sx={{ whiteSpace: 'nowrap' }}>
                             {button.label}
+                          </Button>
+                        }
+                      />
+                    </Tooltip>
+                  ))}
+                {/* Failed-row recovery stays prominent and warning-colored: users must
+                    never have to discover it inside the More menu while rows sit stuck. */}
+                {dynamicButtons
+                  .filter((button: any) => button.label === 'Fix Failed Rows')
+                  .map((button: any, index: number) => (
+                    <Tooltip key={index} title={button.tooltip} placement="top" arrow>
+                      <ToolbarButton
+                        render={
+                          <Button onClick={button.onClick} variant="soft" color="warning" size="sm" startDecorator={button.icon} sx={{ whiteSpace: 'nowrap' }}>
+                            {typeof button.badgeCount === 'number' ? `${button.label} (${button.badgeCount})` : button.label}
                           </Button>
                         }
                       />

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -206,7 +206,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
   const hasAnyExport = typeof handleExport === 'function' || typeof handleExportAll === 'function' || typeof handleExportCSV === 'function';
 
   const moreMenuButtons = dynamicButtons.filter(
-    (button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload' && button.label !== 'Fix Failed Rows' && button.tooltip
+    (button: any) => button.label !== 'Manual Entry Form' && button.label !== 'Upload' && !button.prominentWarning && button.tooltip
   );
   const hasMoreMenuItems = moreMenuButtons.length > 0 || Boolean(validationMenu);
 
@@ -490,7 +490,7 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 {/* Failed-row recovery stays prominent and warning-colored: users must
                     never have to discover it inside the More menu while rows sit stuck. */}
                 {dynamicButtons
-                  .filter((button: any) => button.label === 'Fix Failed Rows')
+                  .filter((button: any) => button.prominentWarning)
                   .map((button: any, index: number) => (
                     <Tooltip key={index} title={button.tooltip} placement="top" arrow>
                       <ToolbarButton

--- a/frontend/components/client/datagridelements.tsx
+++ b/frontend/components/client/datagridelements.tsx
@@ -490,8 +490,8 @@ export const EditToolbar = (props: GridSlotProps['toolbar']) => {
                 {/* Failed-row recovery stays prominent and warning-colored: users must
                     never have to discover it inside the More menu while rows sit stuck. */}
                 {dynamicButtons
-                  .filter((button: any) => button.prominentWarning)
-                  .map((button: any, index: number) => (
+                  .filter((button: DynamicButton) => button.prominentWarning)
+                  .map((button: DynamicButton, index: number) => (
                     <Tooltip key={index} title={button.tooltip} placement="top" arrow>
                       <ToolbarButton
                         render={

--- a/frontend/components/client/modals/failedmeasurementsmodal.test.tsx
+++ b/frontend/components/client/modals/failedmeasurementsmodal.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FailedMeasurementsModal from './failedmeasurementsmodal';
 
+const { sessionState, failedMeasurementsGridMock } = vi.hoisted(() => ({
+  sessionState: { userStatus: 'global' },
+  failedMeasurementsGridMock: vi.fn()
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { userStatus: sessionState.userStatus } } })
+}));
+
 // Mock dependencies - must match actual import path in component
 vi.mock('@/app/contexts/compat-hooks', () => ({
   usePlotContext: () => ({ plotID: 1, plotName: 'Test Plot' }),
@@ -11,7 +20,10 @@ vi.mock('@/app/contexts/compat-hooks', () => ({
 }));
 
 vi.mock('@/components/datagrids/applications/isolated/isolatedfailedmeasurementsdatagrid', () => ({
-  default: () => <div data-testid="failed-measurements-grid">Mock Grid</div>
+  default: (props: Record<string, unknown>) => {
+    failedMeasurementsGridMock(props);
+    return <div data-testid="failed-measurements-grid">Mock Grid</div>;
+  }
 }));
 
 vi.mock('@/ailogger', () => ({
@@ -19,17 +31,16 @@ vi.mock('@/ailogger', () => ({
 }));
 
 describe('FailedMeasurementsModal', () => {
-  const mockSetReingested = vi.fn();
   const mockHandleCloseModal = vi.fn();
 
   const defaultProps = {
     open: true,
-    setReingested: mockSetReingested,
     handleCloseModal: mockHandleCloseModal
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionState.userStatus = 'global';
     global.fetch = vi.fn();
     mockHandleCloseModal.mockResolvedValue(undefined);
   });
@@ -64,8 +75,7 @@ describe('FailedMeasurementsModal', () => {
         expect(mockHandleCloseModal).toHaveBeenCalledTimes(1);
       });
 
-      // Verify no data reingest was triggered
-      expect(mockSetReingested).not.toHaveBeenCalledWith(true);
+      expect(mockHandleCloseModal).toHaveBeenCalledWith({ dataChanged: false });
     });
 
     it('should set reingested flag when Clear Failed is executed', async () => {
@@ -130,7 +140,7 @@ describe('FailedMeasurementsModal', () => {
 
       await waitFor(
         () => {
-          expect(mockSetReingested).toHaveBeenCalledWith(true);
+          expect(mockHandleCloseModal).toHaveBeenCalledWith({ dataChanged: true });
         },
         { timeout: 3000 }
       );
@@ -182,7 +192,7 @@ describe('FailedMeasurementsModal', () => {
       // Wait for the reingestion process to complete
       await waitFor(
         () => {
-          expect(mockSetReingested).toHaveBeenCalledWith(true);
+          expect(mockHandleCloseModal).toHaveBeenCalledWith({ dataChanged: true });
         },
         { timeout: 15000 } // Increased timeout for async operations
       );
@@ -217,8 +227,14 @@ describe('FailedMeasurementsModal', () => {
       render(<FailedMeasurementsModal {...defaultProps} />);
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/admin/clear/failedmeasurements/testschema/1/1'), { method: 'GET' });
-        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/admin/clear/temporarymeasurements/testschema/1/1'), { method: 'GET' });
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/api/failedmeasurements/count/testschema/1/1'),
+          expect.objectContaining({ method: 'GET' })
+        );
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/api/admin/clear/temporarymeasurements/testschema/1/1'),
+          expect.objectContaining({ method: 'GET' })
+        );
       });
     });
 
@@ -240,8 +256,53 @@ describe('FailedMeasurementsModal', () => {
       });
 
       expect(mockHandleCloseModal).not.toHaveBeenCalled();
-      expect(mockSetReingested).not.toHaveBeenCalledWith(true);
       expect(screen.getByText('Failed Measurements')).toBeInTheDocument();
+    });
+
+    it('hides admin-only clear controls from non-admin site users', async () => {
+      sessionState.userStatus = 'field crew';
+      (global.fetch as any).mockResolvedValue({ ok: true, json: async () => ({ recordCount: 2 }) });
+
+      render(<FailedMeasurementsModal {...defaultProps} />);
+
+      await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/failedmeasurements/count/testschema/1/1'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(screen.queryByRole('button', { name: /Clear Failed/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Clear Temp/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Reingest All Rows/i })).toBeInTheDocument();
+    });
+
+    it('keeps recovery controls and the editable grid hidden for pending users', () => {
+      sessionState.userStatus = 'pending';
+
+      render(<FailedMeasurementsModal {...defaultProps} />);
+
+      expect(screen.getByText(/read-only access/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('failed-measurements-grid')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Reingest All Rows/i })).not.toBeInTheDocument();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('reports row-level reingestion to the parent when the user closes a deep-linked modal', async () => {
+      const user = userEvent.setup();
+      (global.fetch as any)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ recordCount: 1 }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ recordCount: 0 }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ recordCount: 0 }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ recordCount: 0 }) });
+
+      render(<FailedMeasurementsModal {...defaultProps} autoCloseWhenEmpty={false} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: /Clear Failed/i })).toHaveTextContent('1'));
+
+      const gridProps = failedMeasurementsGridMock.mock.calls.at(-1)?.[0] as { onRowReingested: () => void };
+      gridProps.onRowReingested();
+      await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(4));
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      expect(mockHandleCloseModal).toHaveBeenCalledWith({ dataChanged: true });
     });
   });
 });

--- a/frontend/components/client/modals/failedmeasurementsmodal.tsx
+++ b/frontend/components/client/modals/failedmeasurementsmodal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -16,7 +17,8 @@ import {
   Typography
 } from '@mui/joy';
 import IsolatedFailedMeasurementsDataGrid from '@/components/datagrids/applications/isolated/isolatedfailedmeasurementsdatagrid';
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
 import { useIsMounted } from '@/app/hooks/useismounted';
 import { useOrgCensusContext, usePlotContext, useSiteContext } from '@/app/contexts/compat-hooks';
 import ailogger from '@/ailogger';
@@ -24,60 +26,112 @@ import { invalidateAfter } from '@/lib/query';
 
 interface FailedMeasurementsModalProps {
   open: boolean;
-  setReingested: Dispatch<SetStateAction<boolean>>;
-  handleCloseModal: () => Promise<void>;
+  handleCloseModal: (options?: { dataChanged?: boolean }) => Promise<void>;
   autoCloseWhenEmpty?: boolean;
 }
 
 export default function FailedMeasurementsModal(props: FailedMeasurementsModalProps) {
-  const { open, setReingested, handleCloseModal, autoCloseWhenEmpty = true } = props;
+  const { open, handleCloseModal, autoCloseWhenEmpty = true } = props;
   const [isReingesting, setIsReingesting] = useState(false);
   const [isClearingFailed, setIsClearingFailed] = useState(false);
   const [isClearingTemp, setIsClearingTemp] = useState(false);
   const [confirmClearFailed, setConfirmClearFailed] = useState(false);
   const [confirmClearTemp, setConfirmClearTemp] = useState(false);
-  const [failedCount, setFailedCount] = useState<number | null>(null);
-  const [tempCount, setTempCount] = useState<number | null>(null);
+  const [countError, setCountError] = useState<string | null>(null);
   const currentPlot = usePlotContext();
   const currentCensus = useOrgCensusContext();
   const currentSite = useSiteContext();
+  const { data: session } = useSession();
+  const canRecoverRecords = Boolean(session?.user?.userStatus && session.user.userStatus !== 'pending');
+  const canClearRecords = session?.user?.userStatus === 'global' || session?.user?.userStatus === 'db admin';
+  const countsAbortControllerRef = useRef<AbortController | null>(null);
+  const wasOpenRef = useRef(false);
+  const hasDataChangesRef = useRef(false);
+  const countScope =
+    currentSite?.schemaName && currentPlot?.plotID && currentCensus?.dateRanges?.[0]?.censusID
+      ? `${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`
+      : '';
+  const [recordCounts, setRecordCounts] = useState<{ scope: string; failed: number | null; temporary: number | null }>({
+    scope: '',
+    failed: null,
+    temporary: null
+  });
+  const failedCount = recordCounts.scope === countScope ? recordCounts.failed : null;
+  const tempCount = recordCounts.scope === countScope ? recordCounts.temporary : null;
 
   // Track mount state to prevent state updates after unmount
   const { isMountedRef } = useIsMounted();
 
   const fetchRecordCounts = useCallback(async () => {
+    countsAbortControllerRef.current?.abort();
+
     if (!currentSite?.schemaName || !currentPlot?.plotID || !currentCensus?.dateRanges?.[0]?.censusID) {
-      return;
+      setRecordCounts({ scope: '', failed: null, temporary: null });
+      setCountError(null);
+      return false;
     }
+
+    const controller = new AbortController();
+    countsAbortControllerRef.current = controller;
+    const scope = `${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`;
 
     try {
-      // Get failed measurements count
-      const failedResponse = await fetch(
-        `/api/admin/clear/failedmeasurements/${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges?.[0].censusID}`,
-        { method: 'GET' }
+      const failedCountRequest = fetch(
+        `/api/failedmeasurements/count/${encodeURIComponent(currentSite.schemaName)}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`,
+        {
+          method: 'GET',
+          signal: controller.signal
+        }
       );
-      if (failedResponse.ok && isMountedRef.current) {
-        const failedData = await failedResponse.json();
-        if (isMountedRef.current) {
-          setFailedCount(failedData.recordCount);
+      const tempCountRequest = canClearRecords
+        ? fetch(
+            `/api/admin/clear/temporarymeasurements/${encodeURIComponent(currentSite.schemaName)}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`,
+            { method: 'GET', signal: controller.signal }
+          )
+        : Promise.resolve(null);
+      const [failedResponse, tempResponse] = await Promise.all([failedCountRequest, tempCountRequest]);
+
+      if (!failedResponse.ok) {
+        throw new Error(`Failed-measurement count request returned ${failedResponse.status}`);
+      }
+      if (tempResponse && !tempResponse.ok) {
+        throw new Error(`Temporary-measurement count request returned ${tempResponse.status}`);
+      }
+
+      const failedData = await failedResponse.json();
+      const parsedFailedCount = failedData.recordCount;
+      if (typeof parsedFailedCount !== 'number' || !Number.isSafeInteger(parsedFailedCount) || parsedFailedCount < 0) {
+        throw new Error('Failed-measurement count response was invalid');
+      }
+
+      let parsedTempCount: number | null = null;
+      if (tempResponse) {
+        const tempData = await tempResponse.json();
+        parsedTempCount = tempData.recordCount;
+        if (typeof parsedTempCount !== 'number' || !Number.isSafeInteger(parsedTempCount) || parsedTempCount < 0) {
+          throw new Error('Temporary-measurement count response was invalid');
         }
       }
 
-      // Get temporary measurements count
-      const tempResponse = await fetch(
-        `/api/admin/clear/temporarymeasurements/${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges?.[0].censusID}`,
-        { method: 'GET' }
-      );
-      if (tempResponse.ok && isMountedRef.current) {
-        const tempData = await tempResponse.json();
-        if (isMountedRef.current) {
-          setTempCount(tempData.recordCount);
-        }
+      if (isMountedRef.current && !controller.signal.aborted && countsAbortControllerRef.current === controller) {
+        setRecordCounts({ scope, failed: parsedFailedCount, temporary: parsedTempCount });
+        setCountError(null);
       }
-    } catch (error: any) {
-      ailogger.error('Failed to fetch record counts:', error);
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'AbortError') return false;
+      const err = error instanceof Error ? error : new Error(String(error));
+      ailogger.error(`Failed to fetch failed-measurement modal counts for ${scope}:`, err);
+      if (isMountedRef.current && !controller.signal.aborted && countsAbortControllerRef.current === controller) {
+        setCountError('Unable to load record counts. Recovery remains available.');
+      }
+      return false;
+    } finally {
+      if (countsAbortControllerRef.current === controller) {
+        countsAbortControllerRef.current = null;
+      }
     }
-  }, [currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges]);
+  }, [canClearRecords, currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges?.[0]?.censusID, isMountedRef]);
 
   const handleClearFailedMeasurements = async () => {
     if (!currentSite?.schemaName || !currentPlot?.plotID || !currentCensus?.dateRanges?.[0]?.censusID) {
@@ -99,7 +153,6 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
       const result = await response.json();
       ailogger.info('Failed measurements cleared:', result);
 
-      setReingested(true);
       setConfirmClearFailed(false);
 
       // Refresh counts
@@ -107,7 +160,7 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
 
       // Close modal if no records remaining
       if (result.recordsCleared > 0) {
-        await handleCloseModal();
+        await handleCloseModal({ dataChanged: true });
       }
     } catch (error: any) {
       ailogger.error('Failed to clear failed measurements:', error);
@@ -175,10 +228,9 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
         censusID: currentCensus.dateRanges?.[0].censusID
       });
 
-      // Close the failed measurements modal
-      await handleCloseModal();
-
-      setReingested(true);
+      // Tell the parent synchronously that its summary view is now stale. A
+      // parent state flag followed by close used to race React's next render.
+      await handleCloseModal({ dataChanged: true });
     } catch (error: any) {
       ailogger.error('Failed to run reingestion:', error);
       // Don't close modal on error so user can see what happened
@@ -189,22 +241,31 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
 
   // Fetch record counts when modal opens
   useEffect(() => {
-    if (open) {
-      fetchRecordCounts();
+    if (open && canRecoverRecords) {
+      if (!wasOpenRef.current) {
+        hasDataChangesRef.current = false;
+      }
+      wasOpenRef.current = true;
+      void fetchRecordCounts();
+    } else {
+      wasOpenRef.current = false;
+      countsAbortControllerRef.current?.abort();
+      setRecordCounts({ scope: '', failed: null, temporary: null });
+      setCountError(null);
     }
-  }, [open, fetchRecordCounts]);
+    return () => countsAbortControllerRef.current?.abort();
+  }, [canRecoverRecords, open, fetchRecordCounts]);
 
   // Auto-close modal when all failed measurements have been resolved
   // Note: Only auto-close when failedCount has been explicitly loaded (not null)
   // and equals 0, to prevent premature closing during initial load
   useEffect(() => {
     if (autoCloseWhenEmpty && open && failedCount !== null && failedCount === 0 && !isReingesting && !isClearingFailed && !isClearingTemp) {
-      ailogger.info('All failed measurements resolved - auto-closing modal and marking as reingested');
-      setReingested(true);
+      ailogger.info('All failed measurements resolved - auto-closing modal');
       // Use void to explicitly ignore the promise - the async close is fire-and-forget
-      void handleCloseModal();
+      void handleCloseModal({ dataChanged: hasDataChangesRef.current });
     }
-  }, [autoCloseWhenEmpty, open, failedCount, isReingesting, isClearingFailed, isClearingTemp, handleCloseModal, setReingested]);
+  }, [autoCloseWhenEmpty, open, failedCount, isReingesting, isClearingFailed, isClearingTemp, handleCloseModal]);
 
   return (
     <Modal open={open} onClose={() => {}}>
@@ -220,26 +281,36 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
         }}
         role="alertdialog"
       >
-        <ModalClose aria-label="Close failed measurements modal" onClick={handleCloseModal} />
+        <ModalClose aria-label="Close failed measurements modal" onClick={() => void handleCloseModal({ dataChanged: hasDataChangesRef.current })} />
         <DialogTitle sx={{ pb: 1 }}>Failed Measurements</DialogTitle>
         <DialogContent sx={{ flex: 1, overflow: 'hidden', p: 0, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
           <Typography level="body-sm" sx={{ px: 3, py: 1, flexShrink: 0 }}>
-            The following measurements failed to be uploaded. You can edit individual measurements in this table, reingest all rows, or clear failed records
-            entirely.
+            {canRecoverRecords
+              ? 'The following measurements failed to be uploaded. You can edit individual measurements in this table or reingest all rows.'
+              : 'Your account has read-only access and cannot recover failed measurements.'}
+            {canRecoverRecords && canClearRecords ? ' Administrators can also permanently clear failed or temporary records.' : ''}
           </Typography>
-          <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', px: 2, pb: 2 }}>
-            <IsolatedFailedMeasurementsDataGrid
-              onRowReingested={() => {
-                ailogger.info('Row successfully reingested - refreshing failed measurement count');
-                fetchRecordCounts();
-              }}
-            />
-          </Box>
+          {countError && (
+            <Alert color="warning" sx={{ mx: 3, mb: 1 }}>
+              {countError} {canClearRecords ? 'Destructive actions are disabled until the counts reload.' : 'Refresh the page to try again.'}
+            </Alert>
+          )}
+          {canRecoverRecords && (
+            <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', px: 2, pb: 2 }}>
+              <IsolatedFailedMeasurementsDataGrid
+                onRowReingested={() => {
+                  ailogger.info('Row successfully reingested - refreshing failed measurement count');
+                  hasDataChangesRef.current = true;
+                  void fetchRecordCounts();
+                }}
+              />
+            </Box>
+          )}
         </DialogContent>
         <DialogActions>
           <Stack spacing={2} sx={{ width: '100%' }}>
             {/* Confirmation dialogs */}
-            {confirmClearFailed && (
+            {canClearRecords && confirmClearFailed && (
               <Sheet variant="soft" color="danger" sx={{ p: 2, borderRadius: 'sm' }}>
                 <Stack spacing={1}>
                   <Typography level="title-sm" color="danger">
@@ -260,7 +331,7 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
               </Sheet>
             )}
 
-            {confirmClearTemp && (
+            {canClearRecords && confirmClearTemp && (
               <Sheet variant="soft" color="warning" sx={{ p: 2, borderRadius: 'sm' }}>
                 <Stack spacing={1}>
                   <Typography level="title-sm" color="warning">
@@ -281,61 +352,67 @@ export default function FailedMeasurementsModal(props: FailedMeasurementsModalPr
               </Sheet>
             )}
 
-            <Stack direction="row" spacing={2} sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <Stack direction="row" spacing={2} sx={{ justifyContent: canClearRecords ? 'space-between' : 'flex-end', alignItems: 'center' }}>
               {/* Reset Controls */}
-              <Stack direction="row" spacing={1}>
-                <Button
-                  variant="soft"
-                  color="danger"
-                  size="sm"
-                  disabled={isReingesting || isClearingFailed || isClearingTemp || failedCount === 0}
-                  onClick={() => {
-                    fetchRecordCounts().then(() => {
-                      if (isMountedRef.current) {
-                        setConfirmClearFailed(true);
-                      }
-                    });
-                  }}
-                >
-                  Clear Failed ({failedCount ?? '?'})
-                </Button>
-                <Button
-                  variant="soft"
-                  color="warning"
-                  size="sm"
-                  disabled={isReingesting || isClearingFailed || isClearingTemp || tempCount === 0}
-                  onClick={() => {
-                    fetchRecordCounts().then(() => {
-                      if (isMountedRef.current) {
-                        setConfirmClearTemp(true);
-                      }
-                    });
-                  }}
-                >
-                  Clear Temp ({tempCount ?? '?'})
-                </Button>
-              </Stack>
+              {canClearRecords && (
+                <>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="soft"
+                      color="danger"
+                      size="sm"
+                      disabled={isReingesting || isClearingFailed || isClearingTemp || failedCount === null || failedCount === 0}
+                      onClick={() => {
+                        fetchRecordCounts().then(loaded => {
+                          if (loaded && isMountedRef.current) {
+                            setConfirmClearFailed(true);
+                          }
+                        });
+                      }}
+                    >
+                      Clear Failed ({failedCount ?? '?'})
+                    </Button>
+                    <Button
+                      variant="soft"
+                      color="warning"
+                      size="sm"
+                      disabled={isReingesting || isClearingFailed || isClearingTemp || tempCount === null || tempCount === 0}
+                      onClick={() => {
+                        fetchRecordCounts().then(loaded => {
+                          if (loaded && isMountedRef.current) {
+                            setConfirmClearTemp(true);
+                          }
+                        });
+                      }}
+                    >
+                      Clear Temp ({tempCount ?? '?'})
+                    </Button>
+                  </Stack>
 
-              <Divider orientation="vertical" />
+                  <Divider orientation="vertical" />
+                </>
+              )}
 
               {/* Main Actions */}
               <Stack direction="row" spacing={2}>
-                <Button
-                  variant="solid"
-                  color="primary"
-                  loading={isReingesting}
-                  loadingPosition="start"
-                  startDecorator={isReingesting ? <CircularProgress size="sm" /> : null}
-                  onClick={handleReingestAll}
-                  disabled={isReingesting || isClearingFailed || isClearingTemp}
-                  sx={{ minWidth: 160 }}
-                >
-                  {isReingesting ? 'Reingesting...' : 'Reingest All Rows'}
-                </Button>
+                {canRecoverRecords && (
+                  <Button
+                    variant="solid"
+                    color="primary"
+                    loading={isReingesting}
+                    loadingPosition="start"
+                    startDecorator={isReingesting ? <CircularProgress size="sm" /> : null}
+                    onClick={handleReingestAll}
+                    disabled={isReingesting || isClearingFailed || isClearingTemp || failedCount === 0}
+                    sx={{ minWidth: 160 }}
+                  >
+                    {isReingesting ? 'Reingesting...' : 'Reingest All Rows'}
+                  </Button>
+                )}
                 <Button
                   variant="soft"
                   color="neutral"
-                  onClick={handleCloseModal}
+                  onClick={() => void handleCloseModal({ dataChanged: hasDataChangesRef.current })}
                   disabled={isReingesting || isClearingFailed || isClearingTemp}
                   sx={{ minWidth: 100 }}
                 >

--- a/frontend/components/datagrids/applications/msvdatagrid.test.tsx
+++ b/frontend/components/datagrids/applications/msvdatagrid.test.tsx
@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MeasurementsSummaryViewDataGrid from './msvdatagrid';
 import MeasurementsCommons from '@/components/datagrids/measurementscommons';
 
+const { routerReplaceMock, sessionState } = vi.hoisted(() => ({
+  routerReplaceMock: vi.fn(),
+  sessionState: { userStatus: 'global' }
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { userStatus: sessionState.userStatus } } })
+}));
+
 vi.mock('@/lib/db/definitions/core', async importOriginal => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return actual;
@@ -15,7 +24,7 @@ vi.mock('@/lib/db/definitions/views', async importOriginal => {
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
-    replace: vi.fn()
+    replace: routerReplaceMock
   })
 }));
 
@@ -43,7 +52,7 @@ vi.mock('@/components/datagrids/measurementscommons', () => ({
   default: vi.fn(() => <div data-testid="measurements-commons" />)
 }));
 
-const failedMeasurementsModalMock = vi.fn(() => null);
+const failedMeasurementsModalMock = vi.fn((_props: Record<string, any>) => null);
 vi.mock('@/components/client/modals/failedmeasurementsmodal', () => ({
   default: (props: any) => failedMeasurementsModalMock(props)
 }));
@@ -57,7 +66,7 @@ function mockFailedRowCount(recordCount: number) {
     'fetch',
     vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/api/admin/clear/failedmeasurements/')) {
+      if (url.includes('/api/failedmeasurements/count/')) {
         return { ok: true, json: async () => ({ recordCount }) } as Response;
       }
       return { ok: true, json: async () => ({}) } as Response;
@@ -78,6 +87,7 @@ describe('MeasurementsSummaryViewDataGrid', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    sessionState.userStatus = 'global';
     // Default: no failed rows, so pre-existing tests see no recovery button.
     mockFailedRowCount(0);
   });
@@ -113,6 +123,7 @@ describe('MeasurementsSummaryViewDataGrid', () => {
 
     const fixButton = (latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>).find(button => button.label === 'Fix Failed Rows');
     expect(fixButton?.badgeCount).toBe(3);
+    expect(fixButton?.prominentWarning).toBe(true);
     expect(latestModalProps()?.open).toBe(false);
 
     act(() => {
@@ -133,11 +144,45 @@ describe('MeasurementsSummaryViewDataGrid', () => {
     expect(buttons.some(button => button.label === 'Fix Failed Rows')).toBe(false);
   });
 
+  it('does not offer failed-row recovery to pending users', async () => {
+    sessionState.userStatus = 'pending';
+    mockFailedRowCount(3);
+    render(<MeasurementsSummaryViewDataGrid />);
+
+    const buttons = latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>;
+    expect(buttons.some(button => button.label === 'Fix Failed Rows')).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('opens the failed-measurements modal on mount when autoOpenFailedMeasurements is set', async () => {
     render(<MeasurementsSummaryViewDataGrid autoOpenFailedMeasurements />);
 
     await waitFor(() => {
       expect(latestModalProps()?.open).toBe(true);
     });
+  });
+
+  it('closes and strips a deep-link query without waiting on another count request', async () => {
+    render(<MeasurementsSummaryViewDataGrid autoOpenFailedMeasurements failedMeasurementsCloseRedirectHref="/measurementshub/summary" />);
+    await waitFor(() => expect(latestModalProps()?.open).toBe(true));
+    await waitFor(() => expect(vi.mocked(global.fetch)).toHaveBeenCalled());
+    const callsBeforeClose = vi.mocked(global.fetch).mock.calls.length;
+
+    await act(async () => {
+      await latestModalProps()?.handleCloseModal();
+    });
+
+    expect(latestModalProps()?.open).toBe(false);
+    expect(routerReplaceMock).toHaveBeenCalledWith('/measurementshub/summary');
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(callsBeforeClose);
+  });
+
+  it('surfaces an invalid count response instead of rendering a misleading badge', async () => {
+    mockFailedRowCount(-2);
+    render(<MeasurementsSummaryViewDataGrid />);
+
+    await waitFor(() => expect(screen.getByText(/unable to load the failed-measurement count/i)).toBeInTheDocument());
+    const buttons = latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>;
+    expect(buttons.some(button => button.label === 'Fix Failed Rows')).toBe(false);
   });
 });

--- a/frontend/components/datagrids/applications/msvdatagrid.test.tsx
+++ b/frontend/components/datagrids/applications/msvdatagrid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MeasurementsSummaryViewDataGrid from './msvdatagrid';
 import MeasurementsCommons from '@/components/datagrids/measurementscommons';
@@ -43,17 +43,43 @@ vi.mock('@/components/datagrids/measurementscommons', () => ({
   default: vi.fn(() => <div data-testid="measurements-commons" />)
 }));
 
+const failedMeasurementsModalMock = vi.fn(() => null);
 vi.mock('@/components/client/modals/failedmeasurementsmodal', () => ({
-  default: () => null
+  default: (props: any) => failedMeasurementsModalMock(props)
 }));
 
 vi.mock('@/ailogger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
+function mockFailedRowCount(recordCount: number) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/admin/clear/failedmeasurements/')) {
+        return { ok: true, json: async () => ({ recordCount }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    })
+  );
+}
+
+function latestCommonsProps(): Record<string, any> | undefined {
+  const mockedMeasurementsCommons = vi.mocked(MeasurementsCommons);
+  return mockedMeasurementsCommons.mock.calls.at(-1)?.[0] as Record<string, any> | undefined;
+}
+
+function latestModalProps(): Record<string, any> | undefined {
+  return failedMeasurementsModalMock.mock.calls.at(-1)?.[0] as Record<string, any> | undefined;
+}
+
 describe('MeasurementsSummaryViewDataGrid', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    // Default: no failed rows, so pre-existing tests see no recovery button.
+    mockFailedRowCount(0);
   });
 
   it('renders the summary grid without a pre-applied visible filter by default', () => {
@@ -74,5 +100,44 @@ describe('MeasurementsSummaryViewDataGrid', () => {
     const renderedProps = mockedMeasurementsCommons.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
 
     expect(renderedProps?.initialVisibleFilters).toEqual(['errors']);
+  });
+
+  it('offers a Fix Failed Rows button when failed measurements exist, and clicking it opens the modal', async () => {
+    mockFailedRowCount(3);
+    render(<MeasurementsSummaryViewDataGrid />);
+
+    await waitFor(() => {
+      const buttons = latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>;
+      expect(buttons.some(button => button.label === 'Fix Failed Rows')).toBe(true);
+    });
+
+    const fixButton = (latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>).find(button => button.label === 'Fix Failed Rows');
+    expect(fixButton?.badgeCount).toBe(3);
+    expect(latestModalProps()?.open).toBe(false);
+
+    act(() => {
+      fixButton?.onClick();
+    });
+
+    expect(latestModalProps()?.open).toBe(true);
+  });
+
+  it('hides the Fix Failed Rows button when there are no failed measurements', async () => {
+    render(<MeasurementsSummaryViewDataGrid />);
+
+    // Allow the count fetch to settle before asserting absence.
+    await waitFor(() => {
+      expect(vi.mocked(global.fetch)).toHaveBeenCalled();
+    });
+    const buttons = latestCommonsProps()?.dynamicButtons as Array<Record<string, any>>;
+    expect(buttons.some(button => button.label === 'Fix Failed Rows')).toBe(false);
+  });
+
+  it('opens the failed-measurements modal on mount when autoOpenFailedMeasurements is set', async () => {
+    render(<MeasurementsSummaryViewDataGrid autoOpenFailedMeasurements />);
+
+    await waitFor(() => {
+      expect(latestModalProps()?.open).toBe(true);
+    });
   });
 });

--- a/frontend/components/datagrids/applications/msvdatagrid.tsx
+++ b/frontend/components/datagrids/applications/msvdatagrid.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useOrgCensusContext, usePlotContext, useSiteContext } from '@/app/contexts/compat-hooks';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { GridRowModes, GridRowModesModel, GridRowsProp } from '@mui/x-data-grid';
 import { randomId } from '@mui/x-data-grid-generator';
 import { Snackbar, Typography } from '@mui/joy';
@@ -15,7 +15,7 @@ import MultilineModal from '@/components/datagrids/applications/multiline/multil
 import { Alert, AlertProps, AlertTitle, Collapse } from '@mui/material';
 import { useLoading } from '@/app/contexts/loadingprovider';
 import FailedMeasurementsModal from '@/components/client/modals/failedmeasurementsmodal';
-import { AssignmentOutlined, CachedOutlined, UploadFileOutlined } from '@mui/icons-material';
+import { AssignmentOutlined, BuildCircleOutlined, CachedOutlined, UploadFileOutlined } from '@mui/icons-material';
 import ailogger from '@/ailogger';
 import { useRouter } from 'next/navigation';
 import { VisibleFilter } from '@/config/datagridhelpers';
@@ -95,6 +95,31 @@ export default function MeasurementsSummaryViewDataGrid({
   const [isNewRowAdded, setIsNewRowAdded] = useState<boolean>(false);
   const [shouldAddRowAfterFetch, setShouldAddRowAfterFetch] = useState(false);
   const hasAutoOpenedFailedMeasurementsRef = useRef(false);
+  const [failedRowCount, setFailedRowCount] = useState(0);
+
+  // Same endpoint the Failed Measurements modal uses for its own count; keeps
+  // the toolbar badge and the modal's "Clear Failed (N)" in agreement.
+  const fetchFailedRowCount = useCallback(async () => {
+    if (!currentSite?.schemaName || !currentPlot?.plotID || !currentCensus?.dateRanges?.[0]?.censusID) {
+      return;
+    }
+    try {
+      const response = await fetch(
+        `/api/admin/clear/failedmeasurements/${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`,
+        { method: 'GET' }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setFailedRowCount(Number(data.recordCount) || 0);
+      }
+    } catch (error: any) {
+      ailogger.error('Failed to fetch failed-measurement count:', error);
+    }
+  }, [currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges]);
+
+  useEffect(() => {
+    fetchFailedRowCount();
+  }, [fetchFailedRowCount]);
 
   useEffect(() => {
     // Guard: only call if FSM is open AND schemaName is defined
@@ -161,6 +186,9 @@ export default function MeasurementsSummaryViewDataGrid({
     } finally {
       setLoading(false);
       setRefresh(true);
+      // Uploads and reingestion runs both land here; either can change how
+      // many rows are stuck as failed.
+      void fetchFailedRowCount();
     }
   }
 
@@ -171,6 +199,7 @@ export default function MeasurementsSummaryViewDataGrid({
     }
 
     setOpenFSM(false);
+    await fetchFailedRowCount();
 
     if (failedMeasurementsCloseRedirectHref) {
       router.replace(failedMeasurementsCloseRedirectHref);
@@ -271,6 +300,17 @@ export default function MeasurementsSummaryViewDataGrid({
             icon: <AssignmentOutlined />
           },
           { label: 'Upload', onClick: () => setIsUploadModalOpen(true), tooltip: 'Submit data by uploading a CSV file', icon: <UploadFileOutlined /> },
+          ...(failedRowCount > 0
+            ? [
+                {
+                  label: 'Fix Failed Rows',
+                  onClick: () => setOpenFSM(true),
+                  tooltip: 'Review rows that failed upload, correct them, and reingest',
+                  icon: <BuildCircleOutlined />,
+                  badgeCount: failedRowCount
+                }
+              ]
+            : []),
           {
             label: 'Import ArcGIS',
             onClick: () => setIsArcgisUploadOpen(true),

--- a/frontend/components/datagrids/applications/msvdatagrid.tsx
+++ b/frontend/components/datagrids/applications/msvdatagrid.tsx
@@ -20,6 +20,7 @@ import ailogger from '@/ailogger';
 import { useRouter } from 'next/navigation';
 import { VisibleFilter } from '@/config/datagridhelpers';
 import { getPersistedGridPageSize } from '@/components/datagrids/customgridpagination';
+import { useSession } from 'next-auth/react';
 
 // Identity under which CustomGridPagination persists the rows-per-page choice;
 // the initializer below must read the same key.
@@ -70,6 +71,8 @@ export default function MeasurementsSummaryViewDataGrid({
   const currentSite = useSiteContext();
   const { setLoading } = useLoading();
   const router = useRouter();
+  const { data: session } = useSession();
+  const canRecoverFailedRows = Boolean(session?.user?.userStatus && session.user.userStatus !== 'pending');
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [isArcgisUploadOpen, setIsArcgisUploadOpen] = useState(false);
   const [isManualEntryFormOpen, setIsManualEntryFormOpen] = useState(false);
@@ -78,7 +81,6 @@ export default function MeasurementsSummaryViewDataGrid({
   const [openAlert, setOpenAlert] = useState(false);
   const [openViewResetAlert, setOpenViewResetAlert] = useState(false);
   const [openFSM, setOpenFSM] = useState(false);
-  const [dataReingested, setDataReingested] = useState(false);
   const [isReingesting, setIsReingesting] = useState(false);
   const [uploadCompleted, setUploadCompleted] = useState(false);
   const [manualEntryCompleted, setManualEntryCompleted] = useState(false);
@@ -95,40 +97,69 @@ export default function MeasurementsSummaryViewDataGrid({
   const [isNewRowAdded, setIsNewRowAdded] = useState<boolean>(false);
   const [shouldAddRowAfterFetch, setShouldAddRowAfterFetch] = useState(false);
   const hasAutoOpenedFailedMeasurementsRef = useRef(false);
-  const [failedRowCount, setFailedRowCount] = useState(0);
+  const failedCountAbortControllerRef = useRef<AbortController | null>(null);
+  const failedMeasurementsScope =
+    currentSite?.schemaName && currentPlot?.plotID && currentCensus?.dateRanges?.[0]?.censusID
+      ? `${currentSite.schemaName}:${currentPlot.plotID}:${currentCensus.dateRanges[0].censusID}`
+      : '';
+  const [failedRowCountState, setFailedRowCountState] = useState({ scope: '', count: 0 });
+  const failedRowCount = failedRowCountState.scope === failedMeasurementsScope ? failedRowCountState.count : 0;
 
-  // Same endpoint the Failed Measurements modal uses for its own count; keeps
-  // the toolbar badge and the modal's "Clear Failed (N)" in agreement.
+  // Use a site-scoped read endpoint. The similarly named /api/admin/clear
+  // endpoint is deliberately admin-only, while failed-row recovery is
+  // available to every role that may edit measurements for this site.
   const fetchFailedRowCount = useCallback(async () => {
-    if (!currentSite?.schemaName || !currentPlot?.plotID || !currentCensus?.dateRanges?.[0]?.censusID) {
+    failedCountAbortControllerRef.current?.abort();
+
+    if (!canRecoverFailedRows || !currentSite?.schemaName || !currentPlot?.plotID || !currentCensus?.dateRanges?.[0]?.censusID || !failedMeasurementsScope) {
+      setFailedRowCountState({ scope: '', count: 0 });
       return;
     }
+
+    const controller = new AbortController();
+    failedCountAbortControllerRef.current = controller;
+    const requestScope = failedMeasurementsScope;
+
     try {
       const response = await fetch(
-        `/api/admin/clear/failedmeasurements/${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`,
-        { method: 'GET' }
+        `/api/failedmeasurements/count/${encodeURIComponent(currentSite.schemaName)}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`,
+        { method: 'GET', signal: controller.signal }
       );
-      if (response.ok) {
-        const data = await response.json();
-        setFailedRowCount(Number(data.recordCount) || 0);
+      if (!response.ok) {
+        throw new Error(`Failed-measurement count request returned ${response.status}`);
       }
-    } catch (error: any) {
-      ailogger.error('Failed to fetch failed-measurement count:', error);
+
+      const data = await response.json();
+      const recordCount = data.recordCount;
+      if (typeof recordCount !== 'number' || !Number.isSafeInteger(recordCount) || recordCount < 0) {
+        throw new Error('Failed-measurement count response was invalid');
+      }
+
+      if (!controller.signal.aborted && failedCountAbortControllerRef.current === controller) {
+        setFailedRowCountState({ scope: requestScope, count: recordCount });
+        setGlobalError(null);
+        setTriggerGlobalError(false);
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'AbortError') return;
+      const err = error instanceof Error ? error : new Error(String(error));
+      ailogger.error(`Failed to fetch failed-measurement count for ${requestScope}:`, err);
+      if (!controller.signal.aborted && failedCountAbortControllerRef.current === controller) {
+        setFailedRowCountState({ scope: requestScope, count: 0 });
+        setGlobalError('Unable to load the failed-measurement count. Refresh the page to try again.');
+        setTriggerGlobalError(true);
+      }
+    } finally {
+      if (failedCountAbortControllerRef.current === controller) {
+        failedCountAbortControllerRef.current = null;
+      }
     }
-  }, [currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges]);
+  }, [canRecoverFailedRows, currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges?.[0]?.censusID, failedMeasurementsScope]);
 
   useEffect(() => {
-    fetchFailedRowCount();
+    void fetchFailedRowCount();
+    return () => failedCountAbortControllerRef.current?.abort();
   }, [fetchFailedRowCount]);
-
-  useEffect(() => {
-    // Guard: only call if FSM is open AND schemaName is defined
-    if (openFSM && currentSite?.schemaName && currentPlot?.plotID && currentCensus?.dateRanges?.[0]?.censusID) {
-      fetch(`/api/validatefailed/${currentSite.schemaName}/${currentPlot.plotID}/${currentCensus.dateRanges[0].censusID}`, { method: 'GET' }).catch(
-        ailogger.error
-      );
-    }
-  }, [openFSM, currentSite?.schemaName, currentPlot?.plotID, currentCensus?.dateRanges]);
 
   useEffect(() => {
     if (!autoOpenFailedMeasurements || hasAutoOpenedFailedMeasurementsRef.current) {
@@ -192,14 +223,16 @@ export default function MeasurementsSummaryViewDataGrid({
     }
   }
 
-  const handleCloseFailedMeasurementsModal = async () => {
-    if (dataReingested) {
-      await reloadMSV();
-      setDataReingested(false);
-    }
-
+  const handleCloseFailedMeasurementsModal = async ({ dataChanged = false }: { dataChanged?: boolean } = {}) => {
+    // Close immediately; refreshing the summary must not trap the user behind
+    // the modal while a network request is in flight.
     setOpenFSM(false);
-    await fetchFailedRowCount();
+
+    if (dataChanged) {
+      await reloadMSV();
+    } else if (!failedMeasurementsCloseRedirectHref) {
+      void fetchFailedRowCount();
+    }
 
     if (failedMeasurementsCloseRedirectHref) {
       router.replace(failedMeasurementsCloseRedirectHref);
@@ -264,12 +297,7 @@ export default function MeasurementsSummaryViewDataGrid({
         formType={'measurements'}
         onSubmitComplete={() => setManualEntryCompleted(true)}
       />
-      <FailedMeasurementsModal
-        open={openFSM}
-        setReingested={setDataReingested}
-        handleCloseModal={handleCloseFailedMeasurementsModal}
-        autoCloseWhenEmpty={!autoOpenFailedMeasurements}
-      />
+      <FailedMeasurementsModal open={openFSM} handleCloseModal={handleCloseFailedMeasurementsModal} autoCloseWhenEmpty={!autoOpenFailedMeasurements} />
       <MeasurementsCommons
         gridType={MEASUREMENTS_SUMMARY_GRID_TYPE}
         gridColumns={MeasurementsSummaryViewGridColumns}
@@ -300,14 +328,15 @@ export default function MeasurementsSummaryViewDataGrid({
             icon: <AssignmentOutlined />
           },
           { label: 'Upload', onClick: () => setIsUploadModalOpen(true), tooltip: 'Submit data by uploading a CSV file', icon: <UploadFileOutlined /> },
-          ...(failedRowCount > 0
+          ...(canRecoverFailedRows && failedRowCount > 0
             ? [
                 {
                   label: 'Fix Failed Rows',
                   onClick: () => setOpenFSM(true),
                   tooltip: 'Review rows that failed upload, correct them, and reingest',
                   icon: <BuildCircleOutlined />,
-                  badgeCount: failedRowCount
+                  badgeCount: failedRowCount,
+                  prominentWarning: true
                 }
               ]
             : []),

--- a/frontend/components/errors/errorsexplorer.test.tsx
+++ b/frontend/components/errors/errorsexplorer.test.tsx
@@ -441,6 +441,45 @@ describe('ErrorsExplorer — row edit via shared preview flow', () => {
     });
   });
 
+  it('links ingestion failures to the failed-measurement recovery modal', async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/api/errors/explorer/query')) {
+        return {
+          ok: true,
+          json: async () => ({
+            rows: [{ ...GRID_ROW, errorSources: ['ingestion'], isFailedRow: true }],
+            totalRows: 1,
+            summary: { total: 1, validation: 0, ingestion: 1, contradictions: 0, duplicateTagStem: 0, sameBatchConflict: 0 }
+          })
+        } as Response;
+      }
+      if (url.includes('/api/errors/explorer/facets')) {
+        return {
+          ok: true,
+          json: async () => ({
+            messages: [],
+            fields: [],
+            sourceCounts: { validation: 0, ingestion: 1 },
+            contradictionCounts: { duplicateTagStem: 0, sameBatchConflict: 0 }
+          })
+        } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+
+    const { unmount } = await mountExplorer();
+
+    const recoveryLink = await screen.findByRole('link', { name: /fix failed uploads/i });
+    expect(recoveryLink).toHaveAttribute('href', '/measurementshub/summary?openFailed=1');
+
+    unmount();
+    mockSessionUserStatus = 'pending';
+    await mountExplorer();
+    await waitFor(() => expect(screen.getByTestId('row-state').textContent).toContain('"coreMeasurementID":101'));
+    expect(screen.queryByRole('link', { name: /fix failed uploads/i })).not.toBeInTheDocument();
+  });
+
   it('does not call the legacy PATCH endpoint when a row is saved', async () => {
     mockBeginEdit.mockResolvedValue({
       updatedIDs: { coreMeasurementID: TEST_CORE_MEASUREMENT_ID },

--- a/frontend/components/errors/errorsexplorer.tsx
+++ b/frontend/components/errors/errorsexplorer.tsx
@@ -37,6 +37,8 @@ import SaveIcon from '@mui/icons-material/Save';
 import CancelIcon from '@mui/icons-material/Close';
 import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
+import BuildCircleOutlinedIcon from '@mui/icons-material/BuildCircleOutlined';
+import Link from 'next/link';
 import {
   ContradictionType,
   CONTRADICTION_LABELS,
@@ -1004,6 +1006,22 @@ export default function ErrorsExplorer() {
             <CircularProgress size="sm" aria-label="Loading ingestion count" />
           ) : (
             <Typography level="h3">{results.summary.ingestion}</Typography>
+          )}
+          {/* Ingestion errors cannot be cleared by editing or rerunning
+              validations here — the row must be corrected and reingested via
+              the Failed Measurements workflow. */}
+          {!loadingRows && results.summary.ingestion > 0 && (
+            <Button
+              component={Link}
+              href="/measurementshub/summary?openFailed=1"
+              size="sm"
+              variant="solid"
+              color="warning"
+              startDecorator={<BuildCircleOutlinedIcon />}
+              data-testid="errorsexplorer-fix-failed-link"
+            >
+              Fix failed uploads
+            </Button>
           )}
         </Card>
         <Card variant="soft" color="danger" sx={{ minWidth: 160 }}>

--- a/frontend/components/errors/errorsexplorer.tsx
+++ b/frontend/components/errors/errorsexplorer.tsx
@@ -1010,7 +1010,7 @@ export default function ErrorsExplorer() {
           {/* Ingestion errors cannot be cleared by editing or rerunning
               validations here — the row must be corrected and reingested via
               the Failed Measurements workflow. */}
-          {!loadingRows && results.summary.ingestion > 0 && (
+          {canEditRows && !loadingRows && results.summary.ingestion > 0 && (
             <Button
               component={Link}
               href="/measurementshub/summary?openFailed=1"

--- a/frontend/components/uploadsystem/uploadparent.tsx
+++ b/frontend/components/uploadsystem/uploadparent.tsx
@@ -638,14 +638,10 @@ function UploadParentInner(props: UploadParentProps) {
       <>
         <FailedMeasurementsModal
           open={showFailedMeasurementsModal}
-          setReingested={reingested => {
-            if (reingested) {
+          handleCloseModal={async ({ dataChanged = false } = {}) => {
+            if (dataChanged) {
               ailogger.info('Failed measurements were reingested successfully');
-              // Close modal and return to start for reingestion processing
-              setShowFailedMeasurementsModal(false);
             }
-          }}
-          handleCloseModal={async () => {
             ailogger.info('Closing failed measurements modal');
             setShowFailedMeasurementsModal(false);
           }}

--- a/frontend/config/datagridhelpers.ts
+++ b/frontend/config/datagridhelpers.ts
@@ -21,6 +21,8 @@ export interface DynamicButton {
   onClick: () => void | Promise<void>;
   tooltip?: string;
   icon?: ReactElement;
+  /** Count appended to the visible label, e.g. "Fix Failed Rows (3)". */
+  badgeCount?: number;
 }
 
 export interface FieldTemplate {

--- a/frontend/config/datagridhelpers.ts
+++ b/frontend/config/datagridhelpers.ts
@@ -23,6 +23,8 @@ export interface DynamicButton {
   icon?: ReactElement;
   /** Count appended to the visible label, e.g. "Fix Failed Rows (3)". */
   badgeCount?: number;
+  /** Keep a recovery action visible as a warning button instead of overflowing it. */
+  prominentWarning?: boolean;
 }
 
 export interface FieldTemplate {

--- a/frontend/lib/route-policy.ts
+++ b/frontend/lib/route-policy.ts
@@ -137,6 +137,7 @@ export const ROUTE_POLICIES = {
   'validations/validationerrordisplay': 'site-scoped',
   'validations/validationlist': 'site-scoped',
   // Failed measurement management
+  'failedmeasurements/count/[schema]/[plotID]/[censusID]': 'site-scoped',
   'validatefailed/[schema]/[plotID]/[censusID]': 'site-scoped',
   'reingest/[schema]/[plotID]/[censusID]': 'site-scoped',
   'reingestsinglefailure/[schema]/[targetRowID]': 'site-scoped',


### PR DESCRIPTION
## Summary

The Failed Measurements modal (per-row editing, single-row and bulk reingestion) has been fully built since the failed-measurements storage redesign, but nothing in the app ever opened it — `autoOpenFailedMeasurements` had no callers and no button set `openFSM`. The only recovery for rejected upload rows (`StemGUID NULL`) was re-uploading the source file or deleting the rows, even though the reingestion APIs were complete and tested.

Three entry points now reach it:

- The measurements grid toolbar shows a warning-colored **Fix Failed Rows (N)** button whenever the census has failed rows, opening the modal directly. It renders as a dedicated visible button, never inside the More overflow menu.
- `/measurementshub/summary?openFailed=1` lands with the modal already open (via the previously dead `autoOpenFailedMeasurements` prop) and strips the query on close so refreshes do not re-open it.
- The Errors Explorer's Ingestion card links there with a **Fix failed uploads** button when ingestion errors exist — those errors cannot be cleared by editing or revalidating in the explorer itself.

Hardening on top of the wiring:

- New site-scoped `GET /api/failedmeasurements/count/...` endpoint (withRouteAuthz, route-policy registered) feeds the counts; the admin-only `/api/admin/clear` endpoints previously used would have 403'd non-admin users out of the recovery flow entirely.
- Role gating: pending users see no recovery surface; destructive Clear Failed / Clear Temp actions render only for global and db admin roles, matching the endpoints they call.
- Counts are scope-keyed to site/plot/census and abortable; invalid or failed responses fail closed with a visible alert instead of a wrong badge.
- Modal close passes `dataChanged` synchronously, replacing the `setReingested` parent-flag pattern that raced the next render; the modal closes immediately rather than trapping the user behind the summary refresh.