### PR TITLE
fix(upload): widen measurement FileID contract to 50

### DIFF
--- a/frontend/app/api/arcgis/preflight/route.test.ts
+++ b/frontend/app/api/arcgis/preflight/route.test.ts
@@ -83,9 +83,9 @@ if (typeof File.prototype.arrayBuffer !== 'function') {
   };
 }
 
-function formRequest(fields: Record<string, string>, withFile = true) {
+function formRequest(fields: Record<string, string>, withFile = true, fileName = 'x.xlsx') {
   const fd = new FormData();
-  if (withFile) fd.append('file', new File([new Uint8Array([1, 2, 3])], 'x.xlsx'));
+  if (withFile) fd.append('file', new File([new Uint8Array([1, 2, 3])], fileName));
   for (const [k, v] of Object.entries(fields)) fd.append(k, v);
   const request = new Request('http://t/api/arcgis/preflight', { method: 'POST' });
   // jsdom's Request does not round-trip multipart bodies; stub formData() like the other route tests.
@@ -101,6 +101,16 @@ describe('POST /api/arcgis/preflight mapping', () => {
     mocks.isValidSchema.mockReturnValue(true);
     mocks.auth.mockResolvedValue({ user: { email: 'user@example.com' } });
     mocks.readArcgisSheetMetadata.mockResolvedValue(DESCRIBED_SHEETS);
+  });
+
+  it('rejects filenames longer than 50 characters before reading the workbook', async () => {
+    const fileName = `${'a'.repeat(46)}.xlsx`;
+    const res = await POST(formRequest({ schema: 'forestgeo_testing', plotID: '1', censusID: '1' }, true, fileName) as any);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ code: 'MEASUREMENT_FILE_NAME_TOO_LONG' });
+    expect(mocks.readArcgisWorkbookDetailed).not.toHaveBeenCalled();
+    expect(mocks.createArcgisImportSession).not.toHaveBeenCalled();
   });
 
   it('returns mapping_required status when detection fails and no mapping was provided', async () => {

--- a/frontend/app/api/arcgis/preflight/route.ts
+++ b/frontend/app/api/arcgis/preflight/route.ts
@@ -15,6 +15,7 @@ import { canonicalFieldsFor } from '@/lib/column-mapping/fields';
 import { isColumnMappingShape, mappingMatchesSource, seedMapping, validateMapping } from '@/lib/column-mapping/mapping';
 import { ArcgisMappingRequiredResponse, PREFLIGHT_STATUS_MAPPING_REQUIRED } from '@/lib/arcgis/types';
 import type { ArcgisSourceMetadata, ColumnMapping } from '@/lib/column-mapping/types';
+import { measurementFileIDValidationError } from '@/lib/uploads/file-names';
 
 export const runtime = 'nodejs';
 
@@ -71,6 +72,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   if (!file.name.toLowerCase().endsWith('.xlsx')) {
     return NextResponse.json({ error: 'ArcGIS import requires a single .xlsx workbook' }, { status: HTTPResponses.INVALID_REQUEST });
+  }
+  const fileIDError = measurementFileIDValidationError(file.name);
+  if (fileIDError) {
+    return NextResponse.json({ error: fileIDError, code: 'MEASUREMENT_FILE_NAME_TOO_LONG' }, { status: HTTPResponses.INVALID_REQUEST });
   }
   if (file.size > MAX_ARCGIS_FILE_SIZE) {
     return NextResponse.json(

--- a/frontend/app/api/files/[operation]/route.test.ts
+++ b/frontend/app/api/files/[operation]/route.test.ts
@@ -288,6 +288,23 @@ describe('/api/files/[operation]', () => {
     );
   });
 
+  it('rejects measurement filenames longer than 50 characters before uploading the blob', async () => {
+    const fileName = `${'a'.repeat(47)}.csv`;
+    const formData = new FormData();
+    const file = new File(['TreeTag\n1'], fileName, { type: 'text/csv' });
+    formData.append(fileName, file);
+    const request = makeRequest(`http://localhost/api/files/upload?schema=forestgeo_testing&plotID=1&census=2&fileName=${fileName}&formType=measurements`, {
+      method: 'POST'
+    }) as any;
+    request.formData = vi.fn(async () => formData);
+
+    const response = await POST(request, props('upload'));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'MEASUREMENT_FILE_NAME_TOO_LONG' });
+    expect(mocks.uploadValidFileAsBufferWithMetadata).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for malformed fileRowErrors metadata', async () => {
     const formData = new FormData();
     const file = new File(['TreeTag\n1'], 'measurements.csv', { type: 'text/csv' });

--- a/frontend/app/api/files/[operation]/route.ts
+++ b/frontend/app/api/files/[operation]/route.ts
@@ -8,7 +8,12 @@ import { auth } from '@/auth';
 import { getSessionUserId } from '@/lib/auth-helpers';
 import { isValidSchema } from '@/lib/db/sqlsecurity';
 import { fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
-import { attemptScopedBlobName, isValidUploadAttemptID, sanitizeUploadFileName as sanitizeFileName } from '@/lib/uploads/file-names';
+import {
+  attemptScopedBlobName,
+  isValidUploadAttemptID,
+  measurementFileIDValidationError,
+  sanitizeUploadFileName as sanitizeFileName
+} from '@/lib/uploads/file-names';
 import path from 'path';
 import type { Session } from 'next-auth';
 import { FormType, normalizeSourceFormat, SourceFormat } from '@/config/macros/formdetails';
@@ -266,6 +271,13 @@ async function handleUpload(request: NextRequest, context: RouteContext) {
   const sanitizedFileName = sanitizeFileName(fileName);
   if (sanitizedFileName !== fileName) {
     ailogger.warn(`File name sanitized: ${fileName} -> ${sanitizedFileName}`);
+  }
+
+  if (formType === FormType.measurements) {
+    const fileIDError = measurementFileIDValidationError(sanitizedFileName);
+    if (fileIDError) {
+      return NextResponse.json({ error: fileIDError, code: 'MEASUREMENT_FILE_NAME_TOO_LONG' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
   }
 
   if (attemptID !== undefined && !isValidUploadAttemptID(attemptID)) {

--- a/frontend/app/api/sqlpacketload/route.test.ts
+++ b/frontend/app/api/sqlpacketload/route.test.ts
@@ -320,6 +320,15 @@ describe('sqlpacketload measurement scope validation', () => {
     expect(insertCall[1].slice(0, 6)).toEqual([TEST_FILE_NAME, TEST_BATCH_ID, TEST_SESSION_ID, 'csv', TEST_PLOT_ID, TEST_CENSUS_ID]);
   });
 
+  it('rejects measurement filenames longer than 50 characters before querying or staging', async () => {
+    const res = (await POST(makeMeasurementRequest({ fileName: `${'a'.repeat(47)}.csv` })))!;
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ code: 'MEASUREMENT_FILE_NAME_TOO_LONG' });
+    expect(mockConnectionManager.executeQuery).not.toHaveBeenCalled();
+    expect(mockConnectionManager.beginTransaction).not.toHaveBeenCalled();
+  });
+
   it('rejects measurement uploads when the upload session does not own the scope', async () => {
     requireUploadSessionOwnershipMock.mockRejectedValueOnce(new MockUploadSessionOwnershipError('Upload session expired before measurement chunk upload', 409));
 

--- a/frontend/app/api/sqlpacketload/route.ts
+++ b/frontend/app/api/sqlpacketload/route.ts
@@ -31,6 +31,7 @@ import {
   upsertAttributeRows,
   upsertSpeciesRows
 } from '@/lib/uploads/reference-data-writers';
+import { measurementFileIDValidationError } from '@/lib/uploads/file-names';
 
 /**
  * Generate idempotency key for a batch of data
@@ -479,6 +480,18 @@ export async function POST(request: NextRequest) {
   let retryCount = 0;
   const sessionId = request.headers.get('x-upload-session-id');
   if (formType === 'measurements') {
+    if (typeof fileName !== 'string' || fileName.length === 0) {
+      return NextResponse.json(
+        { error: 'Measurement file name is required.', code: 'MEASUREMENT_FILE_NAME_REQUIRED' },
+        { status: HTTPResponses.INVALID_REQUEST }
+      );
+    }
+
+    const fileIDError = measurementFileIDValidationError(fileName);
+    if (fileIDError) {
+      return NextResponse.json({ error: fileIDError, code: 'MEASUREMENT_FILE_NAME_TOO_LONG' }, { status: HTTPResponses.INVALID_REQUEST });
+    }
+
     const batchID = body.batchID || generateShortBatchID();
     let scopeValidation: Awaited<ReturnType<typeof validateMeasurementUploadScope>>;
     try {

--- a/frontend/app/api/uploadjobs/route.test.ts
+++ b/frontend/app/api/uploadjobs/route.test.ts
@@ -401,6 +401,17 @@ describe('POST /api/uploadjobs', () => {
     expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
   });
 
+  it('rejects measurement filenames longer than 50 characters before creating a job', async () => {
+    const fileName = `${'a'.repeat(47)}.csv`;
+    const file = { ...makeCreateBody().files[0], fileName, blobName: `${TEST_ATTEMPT_ID}/${fileName}` };
+    const response = await callPost(makeCreateRequest(makeCreateBody({ files: [file] })));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.errors).toEqual(expect.arrayContaining([expect.objectContaining({ field: 'files.0.fileName' })]));
+    expect(mocks.createUploadBackgroundJob).not.toHaveBeenCalled();
+  });
+
   it('rejects more than 100 files', async () => {
     const file = makeCreateBody().files[0];
     const files = Array.from({ length: 101 }, (_, index) => ({ ...file, fileName: `file-${index}.csv`, blobName: `uploads/file-${index}.csv` }));

--- a/frontend/app/api/uploadjobs/route.ts
+++ b/frontend/app/api/uploadjobs/route.ts
@@ -18,7 +18,7 @@ import { BackgroundJobScopeUnavailableError, IdempotencyKeyConflictError } from 
 import { isPrivilegedSession, MAX_UPLOAD_JOB_REQUEST_BYTES, parseOptionalPositiveInteger } from '@/lib/background-jobs/route-helpers';
 import { runJobIfClaimable } from '@/lib/background-jobs/worker';
 import { fromBody, fromQuery, withRouteAuthz, type RouteContext } from '@/lib/route-authz';
-import { attemptScopedBlobName, isValidUploadAttemptID, sanitizeUploadFileName } from '@/lib/uploads/file-names';
+import { attemptScopedBlobName, isValidUploadAttemptID, measurementFileIDValidationError, sanitizeUploadFileName } from '@/lib/uploads/file-names';
 import { getContainerClient } from '@/config/macros/azurestorage';
 import { getContainerName, SchemaContainerNameError } from '@/config/macros/containernames';
 import ailogger from '@/ailogger';
@@ -81,8 +81,17 @@ function validateSelectedDelimiters(value: unknown, ctx: z.RefinementCtx): void 
   }
 }
 
+const MeasurementFileNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .superRefine((fileName, ctx) => {
+    const error = measurementFileIDValidationError(fileName);
+    if (error) ctx.addIssue({ code: z.ZodIssueCode.custom, message: error });
+  });
+
 const UploadJobFileSchema = z.object({
-  fileName: z.string().trim().min(1).max(512),
+  fileName: MeasurementFileNameSchema,
   blobContainer: z.string().trim().min(1).max(255),
   blobName: z.string().trim().min(1).max(1024),
   contentType: z.string().trim().max(255).nullable().optional(),
@@ -100,7 +109,7 @@ const UploadJobFileSchema = z.object({
 
 const ArcgisImportSessionSchema = z.object({
   importSessionId: z.string().trim().min(1).max(255),
-  fileName: z.string().trim().min(1).max(512),
+  fileName: MeasurementFileNameSchema,
   rowCount: z.number().int().nonnegative().max(MYSQL_SIGNED_INT_MAX)
 });
 

--- a/frontend/components/uploadsystem/segments/uploadparsefiles.test.tsx
+++ b/frontend/components/uploadsystem/segments/uploadparsefiles.test.tsx
@@ -237,6 +237,56 @@ describe('mapping rescue is wording-independent (code-based eligibility)', () =>
   });
 });
 
+// temporarymeasurements.FileID is varchar(50). Before this gate existed the upload ran to the
+// staging INSERT and died on ER_DATA_TOO_LONG, which the UI surfaced as a hang — so the block must
+// happen at selection time, and it must hold even when the file itself is otherwise perfectly valid.
+describe('measurement file name length gate', () => {
+  const overLengthName = `${'a'.repeat(47)}.csv`;
+
+  it('blocks an otherwise-valid file whose name exceeds the FileID contract', () => {
+    expect(overLengthName.length).toBeGreaterThan(50);
+    fileValidationEvents.clear();
+    fileValidationEvents.set(overLengthName, { isValid: true, issues: [], headers: CANONICAL_HEADERS });
+
+    act(() => {
+      renderUploadParseFiles([buildFile(overLengthName)], vi.fn());
+    });
+
+    // allFilesValid false swaps the CTA label, so assert the blocked state by its own wording.
+    expect(screen.getByRole('button', { name: /fix validation errors to continue/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /continue upload/i })).toBeNull();
+    expect(screen.getByText(/50 characters or fewer/i)).toBeDefined();
+  });
+
+  it('allows a name exactly at the limit, so the gate is not off by one', () => {
+    const atLimitName = `${'a'.repeat(46)}.csv`;
+    expect(atLimitName).toHaveLength(50);
+    fileValidationEvents.clear();
+    fileValidationEvents.set(atLimitName, { isValid: true, issues: [], headers: CANONICAL_HEADERS });
+
+    act(() => {
+      renderUploadParseFiles([buildFile(atLimitName)], vi.fn());
+    });
+
+    expect(screen.getByRole('button', { name: /continue upload/i })).not.toBeDisabled();
+    expect(screen.queryByText(/50 characters or fewer/i)).toBeNull();
+  });
+
+  it('blocks a short raw name whose sanitized storage identity exceeds the limit', () => {
+    const fileName = `${'🌳'.repeat(25)}.csv`;
+    expect(Array.from(fileName)).toHaveLength(29);
+    fileValidationEvents.clear();
+    fileValidationEvents.set(fileName, { isValid: true, issues: [], headers: CANONICAL_HEADERS });
+
+    act(() => {
+      renderUploadParseFiles([buildFile(fileName)], vi.fn());
+    });
+
+    expect(screen.getByRole('button', { name: /fix validation errors to continue/i })).toBeDisabled();
+    expect(screen.getByText(/stored file name would be 54 characters/i)).toBeDefined();
+  });
+});
+
 // When a confirmed mapping covers the header-coverage gap but a real STRUCTURAL issue still blocks
 // the file, the issue panel must not keep showing the resolved coverage message beside the blocker.
 describe('issue-list masking when a mapping resolves coverage gaps (M6)', () => {

--- a/frontend/components/uploadsystem/segments/uploadparsefiles.tsx
+++ b/frontend/components/uploadsystem/segments/uploadparsefiles.tsx
@@ -23,6 +23,7 @@ import { FileListEnhanced } from '@/components/uploadsystemhelpers/filelistenhan
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FileWithPath } from 'react-dropzone';
 import { FileRow, FormType, RequiredTableHeadersByFormType, SourceFormat, TableHeadersByFormType } from '@/config/macros/formdetails';
+import { MAX_MEASUREMENT_FILE_ID_LENGTH, measurementFileIDLength, measurementFileIDValidationError, sanitizeUploadFileName } from '@/lib/uploads/file-names';
 import InfoIcon from '@mui/icons-material/Info';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -445,6 +446,27 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
     return issues;
   }, [acceptedFiles, sourceFormat]);
 
+  // temporarymeasurements.FileID is varchar(50) and every server write boundary
+  // rejects longer names. Surface it at selection time so the user is not told
+  // only after uploading, and so it blocks both the CSV and ArcGIS paths.
+  const fileNameLengthIssues = useMemo(() => {
+    if (uploadForm !== 'measurements') return [];
+    const issues: { fileName: string; issues: string[] }[] = [];
+    acceptedFiles.forEach(file => {
+      const rawError = measurementFileIDValidationError(file.name);
+      const storedFileName = sanitizeUploadFileName(file.name);
+      const storedError = measurementFileIDValidationError(storedFileName);
+      const error =
+        rawError ??
+        (storedError
+          ? `After unsupported characters are replaced, the stored file name would be ${measurementFileIDLength(storedFileName)} characters. ` +
+            `Measurement file names must be ${MAX_MEASUREMENT_FILE_ID_LENGTH} characters or fewer.`
+          : null);
+      if (error) issues.push({ fileName: file.name, issues: [error] });
+    });
+    return issues;
+  }, [acceptedFiles, uploadForm]);
+
   // A file passes when its own header validation succeeded, or when a confirmed column mapping
   // covers its header-coverage gaps (structural issues like inconsistent column counts still block).
   const fileEffectivelyValid = useCallback(
@@ -460,10 +482,11 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
   // Check if all files have been validated and are valid
   const allFilesValid = useMemo(() => {
     if (acceptedFiles.length === 0) return false;
+    if (fileNameLengthIssues.length > 0) return false;
     // ArcGIS .xlsx uploads bypass CSV header validation; the workbook contents are validated at pre-flight.
     if (sourceFormat === SourceFormat.arcgis_xlsx) return arcgisValidationIssues.length === 0;
     return acceptedFiles.every(file => fileEffectivelyValid(file.name));
-  }, [acceptedFiles, arcgisValidationIssues.length, fileEffectivelyValid, sourceFormat]);
+  }, [acceptedFiles, arcgisValidationIssues.length, fileEffectivelyValid, fileNameLengthIssues.length, sourceFormat]);
 
   // Get all validation issues across all files
   const allValidationIssues = useMemo(() => {
@@ -479,8 +502,9 @@ export default function UploadParseFiles(props: Readonly<UploadParseFilesProps>)
         }
       }
     });
-    return sourceFormat === SourceFormat.arcgis_xlsx ? [...arcgisValidationIssues, ...issues] : issues;
-  }, [acceptedFiles, arcgisValidationIssues, fileEffectivelyValid, fileValidationStatuses, mappingValidForFile, sourceFormat]);
+    const base = sourceFormat === SourceFormat.arcgis_xlsx ? [...arcgisValidationIssues, ...issues] : issues;
+    return [...fileNameLengthIssues, ...base];
+  }, [acceptedFiles, arcgisValidationIssues, fileEffectivelyValid, fileNameLengthIssues, fileValidationStatuses, mappingValidForFile, sourceFormat]);
 
   // Check if any file is still being analyzed (no validation status yet)
   const isAnalyzing = useMemo(() => {

--- a/frontend/db/migrations/manifest.ts
+++ b/frontend/db/migrations/manifest.ts
@@ -79,5 +79,9 @@ export const SCHEMA_MIGRATION_MANIFEST: readonly MigrationManifestEntry[] = [
   {
     id: '2026-08-19-02-repair-error-log-prior-snapshot-columns',
     file: 'schema-contract-repair/2026-08-19-02-repair-error-log-prior-snapshot-columns.sql'
+  },
+  {
+    id: '2026-08-26-01-widen-temporarymeasurements-fileid',
+    file: 'schema-contract-repair/2026-08-26-01-widen-temporarymeasurements-fileid.sql'
   }
 ] as const;

--- a/frontend/db/migrations/schema-contract-repair/2026-08-26-01-widen-temporarymeasurements-fileid.sql
+++ b/frontend/db/migrations/schema-contract-repair/2026-08-26-01-widen-temporarymeasurements-fileid.sql
@@ -1,0 +1,47 @@
+-- =====================================================================================
+-- Migration 2026-08-26-01: widen temporarymeasurements.FileID to varchar(50)
+-- =====================================================================================
+-- FileID carries the canonical upload filename. The former varchar(36) contract
+-- rejected otherwise-valid uploads before their rows could be evaluated.
+--
+-- BatchID deliberately remains varchar(36) NOT NULL: generated base IDs and
+-- their __subNNN children fit within that independent identifier contract.
+
+SET @fileid_length := (
+    SELECT CHARACTER_MAXIMUM_LENGTH
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'FileID'
+);
+SET @fileid_column_type := (
+    SELECT COLUMN_TYPE
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'FileID'
+);
+SET @fileid_nullable := (
+    SELECT IS_NULLABLE
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'temporarymeasurements'
+      AND COLUMN_NAME = 'FileID'
+);
+
+-- Never silently narrow a schema that is already wider than the new contract.
+-- The post-migration contract requires exactly varchar(50), so an operator must
+-- inspect such a schema and decide how to handle any over-length staged rows.
+SET @ddl := CASE
+    WHEN @fileid_length IS NULL THEN
+        'CALL mig_2026_08_26_01_missing_temporarymeasurements_fileid()'
+    WHEN @fileid_length > 50 THEN
+        'CALL mig_2026_08_26_01_fileid_wider_than_contract()'
+    WHEN @fileid_column_type = 'varchar(50)' AND @fileid_nullable = 'YES' THEN
+        'SELECT ''temporarymeasurements.FileID already varchar(50) NULL'' AS Status'
+    ELSE
+        'ALTER TABLE `temporarymeasurements` MODIFY COLUMN `FileID` varchar(50) NULL'
+END;
+PREPARE stmt FROM @ddl; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration 2026-08-26-01 complete: temporarymeasurements.FileID is varchar(50) NULL.' AS Status;

--- a/frontend/db/sql/performance_improvements.sql
+++ b/frontend/db/sql/performance_improvements.sql
@@ -46,7 +46,7 @@ SET SESSION innodb_change_buffering = all;
 DROP PROCEDURE IF EXISTS bulkingestionprocess_monitored;
 
 DELIMITER $$
-CREATE PROCEDURE bulkingestionprocess_monitored(IN vFileID varchar(36), IN vBatchID varchar(36))
+CREATE PROCEDURE bulkingestionprocess_monitored(IN vFileID varchar(50), IN vBatchID varchar(36))
 BEGIN
     DECLARE start_time TIMESTAMP DEFAULT NOW(6);
     DECLARE end_time TIMESTAMP;

--- a/frontend/db/sql/storedprocedures.sql
+++ b/frontend/db/sql/storedprocedures.sql
@@ -1553,7 +1553,7 @@ DELIMITER ;
 DROP PROCEDURE IF EXISTS bulkingestionprocess;
 DELIMITER $$
 
-CREATE PROCEDURE bulkingestionprocess(IN vFileID varchar(36), IN vBatchID varchar(36))
+CREATE PROCEDURE bulkingestionprocess(IN vFileID varchar(50), IN vBatchID varchar(36))
 SQL SECURITY DEFINER
 main_proc:
 BEGIN

--- a/frontend/db/sql/tablestructures.sql
+++ b/frontend/db/sql/tablestructures.sql
@@ -626,7 +626,7 @@ create table if not exists temporarymeasurements
 (
     id              bigint unsigned auto_increment
         primary key,
-    FileID          varchar(36)                         null,
+    FileID          varchar(50)                         null,
     BatchID         varchar(36)                         not null,
     SessionID       varchar(64)                         null,
     SourceFormat    varchar(32) default 'csv'           not null,

--- a/frontend/lib/uploads/arcgis-commit.ts
+++ b/frontend/lib/uploads/arcgis-commit.ts
@@ -34,6 +34,7 @@ import {
   insertTemporaryMeasurementsInBatches,
   type DroppedMeasurementRow
 } from '@/lib/ingestion/temporary-measurements';
+import { measurementFileIDValidationError } from '@/lib/uploads/file-names';
 
 const ARCGIS_COMMIT_INSERT_FAILURE_FALLBACK = 'Unknown error during insert';
 const CHANGELOG_TABLE_NAME = 'file_upload';
@@ -91,6 +92,16 @@ export async function commitArcgisImport(connectionManager: ConnectionManager, p
       insertedCount = staged.rowCount;
       alreadyCommitted = true;
       return;
+    }
+
+    // The committed name comes from the stored session, not params.fileName, and
+    // arcgis_import_sessions.file_id is varchar(255) — wider than the FileID
+    // chain this row set is about to enter. Re-check at the write boundary so a
+    // session captured before the length contract existed fails with a readable
+    // error instead of ER_DATA_TOO_LONG mid-transaction.
+    const fileIDError = measurementFileIDValidationError(fileName);
+    if (fileIDError) {
+      throw new ArcgisImportSessionError(fileIDError, HTTPResponses.INVALID_REQUEST);
     }
 
     if (staged.rows.length === 0) {

--- a/frontend/lib/uploads/file-names.test.ts
+++ b/frontend/lib/uploads/file-names.test.ts
@@ -12,6 +12,9 @@ import {
   describeUploadFileNameCollisions,
   findUploadFileNameCollisions,
   isValidUploadAttemptID,
+  MAX_MEASUREMENT_FILE_ID_LENGTH,
+  measurementFileIDLength,
+  measurementFileIDValidationError,
   sanitizeUploadFileName
 } from './file-names';
 
@@ -42,6 +45,22 @@ describe('sanitizeUploadFileName', () => {
   it('is idempotent — sanitizing a canonical name changes nothing', () => {
     const once = sanitizeUploadFileName('a b(1).csv');
     expect(sanitizeUploadFileName(once)).toBe(once);
+  });
+});
+
+describe('measurement FileID length contract', () => {
+  it('accepts 50 characters and rejects 51 with an actionable message', () => {
+    expect(measurementFileIDValidationError('a'.repeat(MAX_MEASUREMENT_FILE_ID_LENGTH))).toBeNull();
+
+    const error = measurementFileIDValidationError('a'.repeat(MAX_MEASUREMENT_FILE_ID_LENGTH + 1));
+    expect(error).toContain('50 characters or fewer');
+    expect(error).toContain('received 51');
+  });
+
+  it('counts Unicode characters rather than UTF-16 code units', () => {
+    expect(measurementFileIDLength('🌳'.repeat(25))).toBe(25);
+    expect(measurementFileIDValidationError('🌳'.repeat(50))).toBeNull();
+    expect(measurementFileIDLength('e\u0301')).toBe(2);
   });
 });
 

--- a/frontend/lib/uploads/file-names.ts
+++ b/frontend/lib/uploads/file-names.ts
@@ -1,6 +1,26 @@
 import path from 'path';
 
 /**
+ * Maximum canonical filename carried through the measurement-ingestion FileID
+ * chain. Keep this synchronized with temporarymeasurements.FileID,
+ * bulkingestionprocess.vFileID, uploadmetrics.fileID, and
+ * uploadintegrityalerts.fileID.
+ */
+export const MAX_MEASUREMENT_FILE_ID_LENGTH = 50;
+
+/** MySQL VARCHAR length is measured in characters, not UTF-16 code units. */
+export function measurementFileIDLength(fileName: string): number {
+  return Array.from(fileName).length;
+}
+
+export function measurementFileIDValidationError(fileName: string): string | null {
+  const length = measurementFileIDLength(fileName);
+  return length <= MAX_MEASUREMENT_FILE_ID_LENGTH
+    ? null
+    : `Measurement file names must be ${MAX_MEASUREMENT_FILE_ID_LENGTH} characters or fewer (received ${length}).`;
+}
+
+/**
  * Canonical blob-safe form of an uploaded file's name.
  *
  * `/api/files/upload` stores the blob under this name and echoes it back, so it

--- a/frontend/lib/uploads/ingest-batch.ts
+++ b/frontend/lib/uploads/ingest-batch.ts
@@ -23,6 +23,7 @@
  * loop moves the remaining rows to unresolved coremeasurements.
  */
 
+import crypto from 'crypto';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import ailogger from '@/ailogger';
 import { safeFormatQuery } from '@/lib/db/sqlsecurity';
@@ -90,6 +91,21 @@ const MYSQL_ERRNO_DEADLOCK = 1213; // ER_LOCK_DEADLOCK
  * ECONNRESET and CR_SERVER_LOST/2013 (network-layer loss) stay retryable.
  */
 const PROTOCOL_CONNECTION_LOST_CODE = 'PROTOCOL_CONNECTION_LOST';
+
+/**
+ * MySQL GET_LOCK names may not exceed 64 characters. Hash the full logical
+ * scope so a long filename cannot make lock acquisition fail, and include the
+ * schema so equivalent file/plot/census values at different sites do not
+ * serialize one another in the server-global advisory-lock namespace.
+ */
+export function buildIngestionLockName(schema: string, fileID: string, plotID: number, censusID: number): string {
+  const digest = crypto
+    .createHash('sha256')
+    .update(JSON.stringify([schema, fileID, plotID, censusID]))
+    .digest('hex')
+    .slice(0, 40);
+  return `upload:file:${digest}`;
+}
 
 /**
  * Thrown when the caller's isAborted probe fires between sub-batches.
@@ -614,7 +630,7 @@ export async function ingestBatch(connectionManager: ConnectionManager, params: 
       const totalRows = family.totalRows;
 
       // Acquire lock for setup phase
-      const lockKey = `upload:file:${fileID}:plot:${currentPlotID}:census:${currentCensusID}`;
+      const lockKey = buildIngestionLockName(schema, fileID, currentPlotID, currentCensusID);
       const lockAcquired = await connectionManager.acquireApplicationLock(lockKey, tx.id, lockTimeoutMs);
       if (!lockAcquired) {
         throw new Error(`Failed to acquire application lock for file ${fileID}. Another upload may be in progress.`);

--- a/frontend/lib/uploads/ingestion-lock.test.ts
+++ b/frontend/lib/uploads/ingestion-lock.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildIngestionLockName } from './ingest-batch';
+
+describe('buildIngestionLockName', () => {
+  it("stays below MySQL GET_LOCK's 64-character limit for maximum-length filenames", () => {
+    const name = buildIngestionLockName('forestgeo_cooksbranch', 'f'.repeat(50), 1, 2);
+
+    expect(name).toHaveLength(52);
+    expect(name).toMatch(/^upload:file:[a-f0-9]{40}$/);
+  });
+
+  it('is stable and scopes otherwise-identical uploads by schema', () => {
+    const first = buildIngestionLockName('forestgeo_alpha', 'measurements.csv', 1, 2);
+
+    expect(buildIngestionLockName('forestgeo_alpha', 'measurements.csv', 1, 2)).toBe(first);
+    expect(buildIngestionLockName('forestgeo_beta', 'measurements.csv', 1, 2)).not.toBe(first);
+  });
+});

--- a/frontend/lib/uploads/stage-measurements.ts
+++ b/frontend/lib/uploads/stage-measurements.ts
@@ -36,6 +36,7 @@ import {
   uploadSessionHasReplacedCensus,
   type DroppedMeasurementRow
 } from '@/lib/ingestion/temporary-measurements';
+import { measurementFileIDValidationError } from '@/lib/uploads/file-names';
 
 const CHANGELOG_TABLE_NAME = 'file_upload';
 const MEASUREMENTS_FORM_TYPE = 'measurements';
@@ -148,6 +149,11 @@ function buildIngestionFailurePayload(droppedRows: DroppedMeasurementRow[], plot
 }
 
 export async function stageMeasurementChunk(connectionManager: ConnectionManager, params: StageMeasurementChunkParams): Promise<StageMeasurementChunkResult> {
+  const fileIDError = measurementFileIDValidationError(params.fileName);
+  if (fileIDError) {
+    throw new Error(fileIDError);
+  }
+
   const {
     schema,
     fileName,

--- a/frontend/tests/integration/arcgis-import.integration.test.ts
+++ b/frontend/tests/integration/arcgis-import.integration.test.ts
@@ -132,6 +132,7 @@ vi.mock('@/config/uploadsessiontracker', async () => {
 import { POST as commitPOST } from '@/app/api/arcgis/commit/route';
 import ConnectionManager from '@/lib/db/connectionmanager';
 import { commitArcgisImport } from '@/lib/uploads/arcgis-commit';
+import { MAX_MEASUREMENT_FILE_ID_LENGTH } from '@/lib/uploads/file-names';
 import { createArcgisImportSession } from '@/lib/arcgis/import-session';
 import { UploadMode } from '@/config/uploadmodes';
 import { HTTPResponses } from '@/config/macros';
@@ -484,7 +485,7 @@ describe('ArcGIS xlsx import (end-to-end)', () => {
     });
     const result = transformArcgisWorkbook(await readArcgisWorkbook(buffer));
 
-    // FileID is varchar(36); keep the generated name within that width.
+    // Keep the generated name within the canonical FileID width.
     const fileName = `arcgis-psid-${Date.now()}.xlsx`;
     const importReference = await createArcgisImportSession({ schema, plotID, censusID, userId: AUTH_USER_EMAIL, fileName, result });
     const batchID = `arcgis_psid_${Date.now()}`;
@@ -559,7 +560,7 @@ describe('ArcGIS xlsx import (end-to-end)', () => {
   // auth/ownership guards — commitArcgisImport is invoked exactly as the
   // background worker will invoke it, and a same-batch retry must be a no-op.
   it('commitArcgisImport called directly twice: second call returns alreadyCommitted with the preserved rowCount and stages no new rows', async () => {
-    // temporarymeasurements.FileID is varchar(36); keep the fixture name short
+    // Keep the fixture name within temporarymeasurements.FileID's canonical width
     // or INSERT IGNORE silently truncates it and count-by-FileID finds nothing.
     const seeded = await seedValidStagedSession({ fileName: `arc-direct-${Date.now()}.xlsx` });
     const batchID = `arcgis_direct_idem_${Date.now()}`;
@@ -590,6 +591,41 @@ describe('ArcGIS xlsx import (end-to-end)', () => {
     expect(sessionRow.state).toBe('committed');
     expect(sessionRow.committed_batch_id).toBe(batchID);
     expect(Number(sessionRow.committed_row_count)).toBe(seeded.stagedRowCount);
+  });
+
+  // arcgis_import_sessions.file_id is varchar(255), wider than the varchar(50)
+  // FileID chain the commit stages into. A session captured before the length
+  // contract existed must fail with a readable error at the write boundary
+  // rather than ER_DATA_TOO_LONG part-way through the commit transaction.
+  it('commitArcgisImport refuses a stored session whose file name exceeds the FileID contract, staging nothing', async () => {
+    const overLengthName = `${'a'.repeat(47)}.xlsx`;
+    expect(overLengthName.length).toBeGreaterThan(MAX_MEASUREMENT_FILE_ID_LENGTH);
+
+    const seeded = await seedValidStagedSession({ fileName: overLengthName });
+    const batchID = `arcgis_too_long_${Date.now()}`;
+    const connectionManager = ConnectionManager.getInstance();
+
+    await expect(
+      commitArcgisImport(connectionManager, {
+        schema: seeded.schema,
+        plotID: seeded.plotID,
+        censusID: seeded.censusID,
+        importSessionId: seeded.importSessionId,
+        fileName: seeded.fileName,
+        batchID,
+        uploadMode: UploadMode.REVISIONS,
+        userId: AUTH_USER_EMAIL,
+        uploadSessionID: 'worker-session-too-long'
+      })
+    ).rejects.toThrow(/50 characters or fewer/);
+
+    // The refusal must leave no partially staged rows behind.
+    expect(await countStagedRows(seeded.fileName, batchID)).toBe(0);
+
+    // ...and the transaction rollback must leave the session uploadable so the
+    // user can run a fresh preflight after renaming the file.
+    const sessionRow = await getImportSession(seeded.importSessionId);
+    expect(sessionRow.state).toBe('preflight');
   });
 
   it('rejects a committed ArcGIS import session when replayed with a different BatchID', async () => {

--- a/frontend/tests/integration/ingest-batch.test.ts
+++ b/frontend/tests/integration/ingest-batch.test.ts
@@ -224,11 +224,11 @@ describe('ingestBatch — integration', () => {
   // Helpers
   // -------------------------------------------------------------------------
 
-  async function stageFixtureRows(): Promise<void> {
+  async function stageFixtureRows(fileName: string = FILE_NAME): Promise<void> {
     const transactionID = await connectionManager.beginTransaction();
     const params: StageMeasurementChunkParams = {
       schema,
-      fileName: FILE_NAME,
+      fileName,
       batchID: BATCH_ID,
       plotID,
       censusID,
@@ -248,8 +248,8 @@ describe('ingestBatch — integration', () => {
     expect(result.invalidRows).toHaveLength(0);
   }
 
-  async function runIngestBatch(): Promise<IngestBatchResult> {
-    const result = await ingestBatch(connectionManager, { schema, fileID: FILE_NAME, batchID: BATCH_ID });
+  async function runIngestBatch(fileName: string = FILE_NAME): Promise<IngestBatchResult> {
+    const result = await ingestBatch(connectionManager, { schema, fileID: fileName, batchID: BATCH_ID });
     console.log(
       `[ingestBatch] processedSubBatches=${result.processedSubBatches} totalRows=${result.totalRows} recovered=${result.recovered} ` +
         `noDataFound=${result.noDataFound} totalDurationMs=${result.totalDurationMs}`
@@ -262,14 +262,14 @@ describe('ingestBatch — integration', () => {
     return result;
   }
 
-  async function fetchBatchMeasurements(): Promise<RowDataPacket[]> {
+  async function fetchBatchMeasurements(fileName: string = FILE_NAME): Promise<RowDataPacket[]> {
     const [rows] = await connection.query<RowDataPacket[]>(
       `SELECT CoreMeasurementID, StemGUID, CensusID, UploadFileID, UploadBatchID,
               CAST(MeasuredDBH AS CHAR) AS DBHText, CAST(MeasurementDate AS CHAR) AS MeasurementDateText
        FROM coremeasurements
        WHERE UploadFileID = ? AND UploadBatchID = ?
        ORDER BY CoreMeasurementID`,
-      [FILE_NAME, BATCH_ID]
+      [fileName, BATCH_ID]
     );
     return rows;
   }
@@ -500,6 +500,18 @@ describe('ingestBatch — integration', () => {
       [FILE_NAME]
     );
     expect(Number(unresolvedRows[0].count)).toBe(0);
+  }, 60000);
+
+  it('ingests a 50-character filename through the real hashed GET_LOCK and stored procedure path', async () => {
+    const fileName = `${'f'.repeat(46)}.csv`;
+    expect(fileName).toHaveLength(50);
+    await stageFixtureRows(fileName);
+
+    const result = await runIngestBatch(fileName);
+
+    expect(result.noDataFound).toBe(false);
+    expect(result.subBatchResults[0].batchFailedButHandled).toBe(false);
+    expect(await fetchBatchMeasurements(fileName)).toHaveLength(EXPECTED_ROW_COUNT);
   }, 60000);
 
   // -------------------------------------------------------------------------

--- a/frontend/tests/integration/schema-migration-contract.integration.test.ts
+++ b/frontend/tests/integration/schema-migration-contract.integration.test.ts
@@ -222,7 +222,8 @@ describe('Stale-schema migrate + verify pipeline', () => {
   });
 
   it('(5) a production keyed insert + one-row bulkingestionprocess succeed against the repaired schema', async () => {
-    const fileID = 'schema-repair-f1';
+    const fileID = `${'f'.repeat(46)}.csv`;
+    expect(fileID).toHaveLength(50);
     const batchID = 'schema-repair-b1';
     const plotID = testData.plots[0].plotID;
     const censusID = testData.census[0].censusID;


### PR DESCRIPTION
## Summary

- widen `temporarymeasurements.FileID` and ingestion procedure parameters from 36 to 50 characters while keeping `BatchID` at 36
- add a manifest migration and update the canonical schema contract
- reject over-length measurement filenames at selection, blob upload, job creation, staging, and ArcGIS commit boundaries
- hash the schema/file/plot/census advisory-lock scope so MySQL `GET_LOCK` names remain below 64 characters
- cover the exact 50-character boundary, canonicalized Unicode names, migration idempotency, and real stored-procedure ingestion

## Verification

- `npm run build` — passed
- `npm run build:check` — passed, no lint warnings
- `npm run test:unit` — 256 files, 3,852 passed, 0 failed, 4 skipped
- `npm run test:integration` — 123 files, 1,063 passed, 0 failed
- focused ArcGIS integration rerun after the final rollback assertion — 13 passed
- `check-cycles` — 33 / 33
- `check-any-count` — 488 / 489
- `graphify update .` — completed

## Deployment notes

The migration is intentionally conservative: it refuses to silently narrow a schema whose existing `FileID` is wider than 50. The deployment workflow applies the table migration before republishing `storedprocedures.sql`, so existing schemas receive the widened procedure parameter in the same gated job.


Closes #441
