### PR TITLE
fix(cypress): stop compiling node_modules as Next pages in component tests

### DIFF
--- a/frontend/next.config.cypress-pagesdir.test.ts
+++ b/frontend/next.config.cypress-pagesdir.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+// @cypress/webpack-dev-server's findPagesDir() falls back to the PROJECT ROOT when a
+// project has no pages/ or src/pages/ (this app is app-router only). next-swc-loader
+// then computes `isPageFile = filename.startsWith(pagesDir)`, so every file under the
+// repo -- node_modules included -- is compiled as a Next page and rejected for using
+// `export * from '...'`, which MUI's esm barrels do. Next itself never sets pagesDir to
+// the project root (find-pages-dir returns a real subdirectory or undefined), so
+// `pagesDir === dir` identifies the Cypress-only value exactly and the fix is inert in
+// dev and build.
+
+const PROJECT_ROOT = '/repo/frontend';
+const REAL_PAGES_DIR = '/repo/frontend/pages';
+const SWC_LOADER = '/repo/frontend/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js';
+const OTHER_LOADER = '/repo/frontend/node_modules/css-loader/dist/cjs.js';
+
+type LoaderUse = { loader: string; options?: Record<string, unknown> };
+type Rule = { use?: LoaderUse[]; oneOf?: Rule[]; rules?: Rule[] };
+type FakeConfig = {
+  resolve: { fallback: Record<string, unknown>; alias: Record<string, string> };
+  module: { rules: Rule[] };
+};
+
+function swcRule(pagesDir: string | undefined): Rule {
+  return { use: [{ loader: SWC_LOADER, options: { pagesDir, appDir: undefined } }] };
+}
+
+// Mirrors the shape Next produces: swc loaders live inside `oneOf`, and the walk must
+// also descend into nested `rules` arrays.
+function makeConfig(pagesDir: string | undefined): FakeConfig {
+  return {
+    resolve: { fallback: {}, alias: {} },
+    module: {
+      rules: [{ oneOf: [swcRule(pagesDir), swcRule(pagesDir)] }, { rules: [swcRule(pagesDir)] }, { use: [{ loader: OTHER_LOADER, options: { pagesDir } }] }]
+    }
+  };
+}
+
+async function applyWebpackHook(config: FakeConfig, dir: string): Promise<FakeConfig> {
+  const mod = (await import('./next.config.js')) as unknown as {
+    default: { webpack: (c: FakeConfig, o: { isServer: boolean; dev: boolean; dir: string }) => FakeConfig };
+  };
+  return mod.default.webpack(config, { isServer: false, dev: true, dir });
+}
+
+function collectLoaderPagesDirs(config: FakeConfig, loaderPath: string): unknown[] {
+  const found: unknown[] = [];
+  const visit = (rules: Rule[] | undefined) => {
+    for (const rule of rules ?? []) {
+      for (const use of rule.use ?? []) {
+        if (use.loader === loaderPath) found.push(use.options?.pagesDir);
+      }
+      visit(rule.oneOf);
+      visit(rule.rules);
+    }
+  };
+  visit(config.module.rules);
+  return found;
+}
+
+describe('next.config.js webpack hook — Cypress pagesDir neutralisation', () => {
+  it('clears pagesDir on every next-swc-loader entry when it equals the project root', async () => {
+    const result = await applyWebpackHook(makeConfig(PROJECT_ROOT), PROJECT_ROOT);
+    const pagesDirs = collectLoaderPagesDirs(result, SWC_LOADER);
+
+    expect(pagesDirs).toHaveLength(3);
+    expect(pagesDirs.every(value => value === undefined)).toBe(true);
+  });
+
+  it('preserves a real pagesDir subdirectory so real builds are unaffected', async () => {
+    const result = await applyWebpackHook(makeConfig(REAL_PAGES_DIR), PROJECT_ROOT);
+
+    expect(collectLoaderPagesDirs(result, SWC_LOADER)).toEqual([REAL_PAGES_DIR, REAL_PAGES_DIR, REAL_PAGES_DIR]);
+  });
+
+  it('leaves non-swc loaders untouched', async () => {
+    const result = await applyWebpackHook(makeConfig(PROJECT_ROOT), PROJECT_ROOT);
+
+    expect(collectLoaderPagesDirs(result, OTHER_LOADER)).toEqual([PROJECT_ROOT]);
+  });
+
+  it('no longer injects the inert @mui esm aliases', async () => {
+    const result = await applyWebpackHook(makeConfig(PROJECT_ROOT), PROJECT_ROOT);
+
+    expect(result.resolve.alias).not.toHaveProperty('@mui/material/esm');
+    expect(result.resolve.alias).not.toHaveProperty('@mui/utils/esm');
+  });
+});

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -35,6 +35,37 @@ const SECURITY_CSP_REPORT_ONLY = [
   "form-action 'self'"
 ].join('; ');
 
+// Cypress component testing builds this webpack config through Next's own
+// getNextJsBaseWebpackConfig, but @cypress/webpack-dev-server's findPagesDir()
+// falls back to the PROJECT ROOT when a project has no pages/ or src/pages/
+// (this app is app-router only). next-swc-loader then computes
+// `isPageFile = filename.startsWith(pagesDir)`, so every file under the repo --
+// all of node_modules included -- is compiled as a Next page and rejected for
+// using `export * from '...'`, which MUI's esm barrels do.
+//
+// Next itself never sets pagesDir to the project root: find-pages-dir returns a
+// real subdirectory or undefined. So `pagesDir === dir` identifies the
+// Cypress-only value unambiguously, and this is a no-op during dev and build.
+function neutralizeCypressPagesDir(config, dir) {
+  if (!dir) return;
+
+  const visit = rules => {
+    for (const rule of rules || []) {
+      if (!rule || typeof rule === 'string') continue;
+      for (const use of [].concat(rule.use || [])) {
+        const isSwcLoader = use && typeof use === 'object' && String(use.loader || '').includes('next-swc-loader');
+        if (isSwcLoader && use.options && use.options.pagesDir === dir) {
+          use.options.pagesDir = undefined;
+        }
+      }
+      if (rule.oneOf) visit(rule.oneOf);
+      if (rule.rules) visit(rule.rules);
+    }
+  };
+
+  visit(config.module && config.module.rules);
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = withBundleAnalyzer({
   experimental: {
@@ -61,16 +92,18 @@ const nextConfig = withBundleAnalyzer({
     // Use timestamp for cache busting only when needed
     return process.env.BUILD_ID || `build-${Date.now()}`;
   },
-  webpack: (config, { isServer, dev }) => {
+  webpack: (config, { isServer, dev, dir }) => {
     if (!isServer) {
       config.resolve.fallback = { fs: false };
     }
     config.resolve.mainFields = ['main', 'module', 'browser'];
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '@mui/material/esm': '@mui/material',
-      '@mui/utils/esm': '@mui/utils'
-    };
+    // The `@mui/material/esm` -> `@mui/material` aliases that used to sit here were a
+    // previous attempt at the `export *` build failure and were provably inert:
+    // aliases match the REQUEST specifier, but source imports `@mui/material/utils`
+    // and the `esm/` segment is introduced downstream by the package exports map,
+    // which the alias never sees. MUI also sets `exports["./esm"] = null`, blocking
+    // the aliased specifier outright. The real fix is neutralizeCypressPagesDir below.
+    neutralizeCypressPagesDir(config, dir);
     config.module.rules.push({
       test: /\.cy.(js|ts|tsx|jsx)$/,
       exclude: /node_modules/


### PR DESCRIPTION
## Summary
- `@cypress/webpack-dev-server`'s `findPagesDir()` falls back to the project root in this app-router-only project, so `next-swc-loader` computed `isPageFile = filename.startsWith(pagesDir)` as true for every file in the repo — all of `node_modules` was compiled as a Next page and rejected for MUI's `export * from '...'` esm barrels, breaking every component spec at build.
- Adds `neutralizeCypressPagesDir(config, dir)` to `next.config.js`: walks `module.rules` (including nested `oneOf`/`rules`) and clears `options.pagesDir` on `next-swc-loader` entries where it strictly equals the project root — a value Next's own `find-pages-dir` never produces, so the change is inert in dev and production builds.
- Removes the `@mui/material/esm` / `@mui/utils/esm` resolve aliases, a previous attempt at this symptom that was provably inert (aliases match the request specifier; the `esm/` segment is introduced by the package exports map, which the alias never sees).
- New `next.config.cypress-pagesdir.test.ts` covers the nested-rule walk, real-pagesDir preservation, non-swc loaders, and alias removal (4/4 passing).

Component suite now executes its real tests: 150 tests, 145 passing, with the 4 remaining spec failures being the known WS3/WS4/WS5 defects fixed in follow-up PRs. `npm run build` and the full unit suite (257 files / 3856 tests) are green.