### PR TITLE
fix(cypress): correct next/navigation mock alias filename case

### DIFF
--- a/frontend/cypress/support/shared-config.cjs
+++ b/frontend/cypress/support/shared-config.cjs
@@ -15,7 +15,7 @@ function getSharedWebpackConfig(dirname, envVars = {}) {
       alias: {
         '@/': path.resolve(dirname, './'),
         'next-auth/react': path.resolve(dirname, 'cypress/mocks/nextauthmock.js'),
-        'next/navigation': path.resolve(dirname, 'cypress/mocks/nextNavMock.js'),
+        'next/navigation': path.resolve(dirname, 'cypress/mocks/nextnavmock.js'),
         '@/ailogger': path.resolve(dirname, 'cypress/mocks/ailoggerMock.js'),
         '@/config/utils': path.resolve(dirname, 'cypress/mocks/utilsMock.js')
       },


### PR DESCRIPTION
## Summary
- The `next/navigation` webpack alias in `cypress/support/shared-config.cjs` pointed at `cypress/mocks/nextNavMock.js`, but the tracked file is `cypress/mocks/nextnavmock.js`. macOS APFS resolves the mismatch case-insensitively; Linux ext4 does not, so the alias silently missed in the nightly and `provisioning-run-status.cy.tsx` failed there.
- One-line case correction; the mock file is not renamed and no alias-validation layer is added — the Linux component CI gate added later in this series is the recurrence guard.

Local verification: `provisioning-run-status.cy.tsx` 2/2 passing, full unit suite and `npm run build` green. This spec already passed on macOS, so the Linux nightly/PR-gate run is the real acceptance signal.