### PR TITLE
test(cypress): realign three component specs with shipping behaviour

### DIFF
--- a/frontend/cypress/components/editplan-preview-dialog.cy.tsx
+++ b/frontend/cypress/components/editplan-preview-dialog.cy.tsx
@@ -100,8 +100,12 @@ describe('PreviewDialog (Cypress component)', () => {
     cy.get('[data-testid="edit-effect-rowcount-destructive-duplicate-merge"]').should('contain.text', '3 rows');
     cy.get('[data-testid="edit-effect-rowcount-warn-reparenting-stems"]').should('contain.text', '1 row');
 
-    // Apply calls onConfirm.
-    cy.get('[data-testid="edit-preview-apply"]').click();
+    // Apply is gated behind the typed-confirm token on destructive plans -- assert the
+    // gate holds before satisfying it. That is the property worth verifying at browser
+    // level; the vitest sibling (previewdialog.test.tsx:232) covers the jsdom path.
+    cy.get('[data-testid="edit-preview-apply"]').should('be.disabled');
+    cy.get('[data-testid="edit-preview-typed-confirm-input"]').type('APPLY');
+    cy.get('[data-testid="edit-preview-apply"]').should('not.be.disabled').click();
     cy.get('@onConfirm').should('have.been.calledOnce');
     cy.get('@onCancel').should('not.have.been.called');
   });

--- a/frontend/cypress/components/loginlogout.cy.tsx
+++ b/frontend/cypress/components/loginlogout.cy.tsx
@@ -67,13 +67,40 @@ describe('<LoginLogout />', () => {
       cy.get('button').first().should('contain', 'JQP');
     });
 
-    it('shows disabled settings button (settings menu functionality is disabled)', () => {
-      // The settings button is disabled in the component
-      cy.get('button').eq(1).should('be.disabled');
+    it('enables the settings button for a global user', () => {
+      cy.get('[aria-label="Settings menu"]').should('not.be.disabled');
     });
 
     it('shows logout button that can be clicked', () => {
       cy.get('button[aria-label="Logout button"]').should('be.visible').and('not.be.disabled');
+    });
+  });
+
+  context('when signed in without administrative rights', () => {
+    const standardSession = {
+      user: {
+        name: 'Sam Field',
+        email: 'sam.field@example.com',
+        userStatus: 'field crew'
+      },
+      expires: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    };
+
+    beforeEach(() => {
+      setMockSession({
+        data: standardSession,
+        status: 'authenticated'
+      });
+
+      mount(
+        <SessionProvider session={standardSession as unknown as any}>
+          <LoginLogout />
+        </SessionProvider>
+      );
+    });
+
+    it('disables the settings button for a non-administrative user', () => {
+      cy.get('[aria-label="Settings menu"]').should('be.disabled');
     });
   });
 });

--- a/frontend/cypress/components/pages.cy.tsx
+++ b/frontend/cypress/components/pages.cy.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import HomePage from '@/app/page';
 import LoginFailedPage from '@/app/loginfailed/page';
-import * as nextAuthReact from 'next-auth/react';
-import * as nextNavigation from 'next/navigation';
 
 describe('Mounting Home Page', () => {
   it('renders', () => {
@@ -14,10 +12,6 @@ describe('Login failure page test', () => {
   beforeEach(() => {
     cy.stub(window.sessionStorage, 'clear').as('sessionStorageClear');
     cy.stub(window.localStorage, 'clear').as('localStorageClear');
-
-    cy.stub(nextAuthReact, 'signOut').resolves();
-
-    cy.stub(nextNavigation, 'useSearchParams').returns(() => new URLSearchParams('?reason=Invalid Credentials'));
   });
 
   it('renders the login failure message', () => {
@@ -25,8 +19,10 @@ describe('Login failure page test', () => {
     cy.contains('Oops! Login Failed').should('be.visible');
   });
 
-  it('displays a default failure reason if none is provided', () => {
+  it('displays the default failure reason when no reason is provided', () => {
     cy.mount(<LoginFailedPage />);
-    cy.contains('Failure caused due to Login failure triggered without reason. Please speak to an administrator').should('be.visible');
+    // Asserted literally, not imported from the component: this is the user-visible
+    // contract, and importing the rendered value would make the test tautological.
+    cy.contains('Login failure triggered without reason. Please speak to an administrator.').should('be.visible');
   });
 });


### PR DESCRIPTION
## Summary
Three component specs asserted behaviour the application no longer ships; with the webpack fix (#442) letting the suite execute its real tests again, these become visible failures. One commit per spec:

- **loginlogout.cy.tsx** — the spec asserted the settings button disabled, but `loginlogout.tsx` gates it by role (`disabled` unless `userStatus` is `global`/`db admin`) and the fixture is `global`. Now covers both sides of the gate — enabled for a global user, disabled for a `field crew` user — selected by `aria-label` instead of positional `.eq(1)`.
- **pages.cy.tsx** — the spec expected the `Failure caused due to ` prefix removed by `bd4d622c`, behind two inert module-namespace stubs. The stubs and their imports are gone (the module-wide Cypress mocks already provide the empty-searchParams case), and the test asserts the current default message literally; `DEFAULT_MESSAGE` stays private so the assertion cannot become tautological.
- **editplan-preview-dialog.cy.tsx** — the fixture plan is `maxSeverity: 'destructive'`, so Apply is gated behind the typed-confirm token. The spec now asserts the gate holds (Apply disabled), types `APPLY`, asserts enabled, clicks, and verifies `onConfirm`/`onCancel`.

Suite state after this branch: 13 of 14 specs / 149 of 151 tests passing, with `revision-upload-segments.cy.tsx` the sole remaining failure (fixed by the WS3/WS4 branches in this series). No production code changed. Unit suite and `npm run build` green.