### PR TITLE
ci(e2e): warm the uploadjobs and summary routes before the Cypress suite

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "test:integration:azure": "dotenv -e .env.testing.azure -- node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run --config vitest.integration.config.mts",
     "test:component": "cypress run --component",
     "test:e2e": "dotenv -v NEXT_PUBLIC_E2E_TESTING=true -- start-server-and-test dev http://localhost:3000 \"cypress run --e2e\"",
-    "test:e2e:ci": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true next dev --turbo' http://localhost:3000 \"cypress run --e2e --headless --browser chrome\"",
+    "test:e2e:ci": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true next dev --turbo' http://localhost:3000 \"node ./scripts/warm-e2e-routes.mjs && cypress run --e2e --headless --browser chrome\"",
     "test:e2e:demo": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true next dev --turbo' http://localhost:3000 \"cypress run --e2e --headed --browser electron --spec 'cypress/e2e/demo/**/*.cy.ts' --env demoMode=true,demoDelayMs=1400\"",
     "test:e2e:demo:headless": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true next dev --turbo' http://localhost:3000 \"cypress run --e2e --headless --browser electron --spec 'cypress/e2e/demo/**/*.cy.ts' --env demoMode=true,demoDelayMs=400\"",
     "test:e2e:realdb": "NEXT_PUBLIC_E2E_TESTING=true start-server-and-test 'NEXT_PUBLIC_E2E_TESTING=true AZURE_SQL_SERVER=127.0.0.1 AZURE_SQL_USER=root AZURE_SQL_PASSWORD=testpassword AZURE_SQL_PORT=3306 AUTH_FUNCTIONS_POLL_URL=http://localhost:3000/api/e2e-auth-poll next dev --turbo' http://localhost:3000 \"cypress run --config-file cypress.realdb.config.cjs --headless --browser electron\"",

--- a/frontend/scripts/warm-e2e-routes.mjs
+++ b/frontend/scripts/warm-e2e-routes.mjs
@@ -1,0 +1,31 @@
+// The nightly starts `next dev --turbo` and runs Cypress immediately, so routes compile
+// on demand and the first spec races the compiler. Measured 2026-08-26:
+//
+//   07:20:56.101  Compiling /api/uploadjobs ...
+//   07:21:11.576  Compiled /api/uploadjobs in 16s
+//   07:21:11.685  GET /measurementshub/summary 200 in 14873ms   <- 15000ms budget
+//   07:21:17.505  GET /measurementshub/summary 200 in 428ms
+//
+// a11y-responsive missed its navigation budget by 127ms because the page request queued
+// behind the API compile. Warming exactly that pair removes the contention.
+//
+// Deliberately NOT a route inventory: discovering every route and fan-out API would
+// couple this fix to unrelated application growth. Deliberately NOT non-fatal: a
+// warmup that can silently skip cannot guarantee the goal and would leave the race.
+
+const BASE_URL = process.env.WARMUP_BASE_URL ?? 'http://localhost:3000';
+
+// Order matters. The API compile is what held the compiler while the page waited.
+const ROUTES = ['/api/uploadjobs?schema=luquillo&plotID=1&censusID=5&activeOnly=false&limit=25', '/measurementshub/summary'];
+
+const REQUEST_TIMEOUT_MS = 120_000;
+
+for (const route of ROUTES) {
+  const startedAt = Date.now();
+  // Any HTTP status means the route compiled -- a 401 from /api/uploadjobs is enough.
+  // Only a network failure or timeout indicates the server never got there.
+  const response = await fetch(`${BASE_URL}${route}`, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+  console.log(`[warmup] ${String(response.status).padEnd(3)} ${String(Date.now() - startedAt).padStart(6)}ms  ${route}`);
+}
+
+console.log('[warmup] done');


### PR DESCRIPTION
## Summary
- The nightly starts `next dev --turbo` and runs Cypress immediately, so routes compile on demand and the first spec races the compiler. Measured 2026-08-26: `GET /measurementshub/summary` took 14873ms against the 15000ms navigation budget because it queued behind a 16s cold compile of `/api/uploadjobs`; the next hit of the same route took 428ms. `a11y-responsive` missed its budget by 127ms.
- Adds `scripts/warm-e2e-routes.mjs`, which requests exactly that route pair — `/api/uploadjobs` (any HTTP status proves the route compiled; 401 is expected) then `/measurementshub/summary` — against the server `start-server-and-test` already owns, chained immediately before `cypress run` in `test:e2e:ci`'s test phase. Status and duration are logged for both; a network failure or timeout fails the command before Cypress starts.
- Deliberately not a route inventory (that would couple the fix to unrelated app growth) and deliberately fatal on failure (a warmup that can silently skip cannot guarantee the goal). The 15000ms budget in `test-data-helpers.ts` is unchanged.

Verified locally: cold run logs 1466ms / 4384ms, immediate second run logs 257ms / 77ms; a dead server exits non-zero (`ECONNREFUSED`, exit 1). Acceptance signal per the spec: three consecutive nightly runs with `a11y-responsive` green.