### PR TITLE
fix(upload): open revision review on the correct tab once matching completes

### DIFF
--- a/frontend/components/uploadsystem/segments/uploadrevisionmatch.defaulttab.test.ts
+++ b/frontend/components/uploadsystem/segments/uploadrevisionmatch.defaulttab.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDefaultTabValue } from './uploadrevisionmatch';
+
+// The original chain was:
+//   changes > 0 ? 'changes' : duplicates > 0 ? 'duplicates' : 'changes'
+// which can never yield 'new'. A revision upload of only new rows therefore opened on
+// an empty Changes tab, leaving "Confirm new row insertion" on a tab the user had to
+// find, with the action reading "Apply 0 Revisions" and disabled. The same pattern
+// would strand invalid-only and unchanged-only uploads, so those fall through too.
+
+const NONE = { changes: 0, duplicates: 0, newRows: 0, invalid: 0, unchanged: 0 };
+
+describe('resolveDefaultTabValue', () => {
+  it('prefers changes when rows need updating', () => {
+    expect(resolveDefaultTabValue({ ...NONE, changes: 3, duplicates: 2, newRows: 1 })).toBe('changes');
+  });
+
+  it('falls back to duplicates when there are no changes', () => {
+    expect(resolveDefaultTabValue({ ...NONE, duplicates: 2, newRows: 1 })).toBe('duplicates');
+  });
+
+  it('opens on new rows when they are the only actionable content', () => {
+    expect(resolveDefaultTabValue({ ...NONE, newRows: 1 })).toBe('new');
+  });
+
+  it('opens on invalid rows when nothing else is present', () => {
+    expect(resolveDefaultTabValue({ ...NONE, invalid: 4 })).toBe('invalid');
+  });
+
+  it('opens on unchanged rows when that is all there is', () => {
+    expect(resolveDefaultTabValue({ ...NONE, unchanged: 9 })).toBe('unchanged');
+  });
+
+  it('returns changes as the genuine empty state', () => {
+    expect(resolveDefaultTabValue(NONE)).toBe('changes');
+  });
+
+  it('never selects a tab whose panel would not be rendered', () => {
+    // Every non-'changes' tab is conditionally rendered on its own count being > 0.
+    const shapes = [
+      { ...NONE, newRows: 2, unchanged: 5 },
+      { ...NONE, duplicates: 1, invalid: 3 },
+      { ...NONE, invalid: 1, unchanged: 1 }
+    ];
+
+    for (const shape of shapes) {
+      const resolved = resolveDefaultTabValue(shape);
+      const countForResolved = {
+        changes: shape.changes,
+        duplicates: shape.duplicates,
+        new: shape.newRows,
+        invalid: shape.invalid,
+        unchanged: shape.unchanged
+      }[resolved];
+
+      expect(resolved === 'changes' || countForResolved > 0, `${resolved} panel would not render`).toBe(true);
+    }
+  });
+});

--- a/frontend/components/uploadsystem/segments/uploadrevisionmatch.tsx
+++ b/frontend/components/uploadsystem/segments/uploadrevisionmatch.tsx
@@ -70,6 +70,33 @@ function hasDuplicateCleanup(row: RevisionMatchedRow): boolean {
   return (row.duplicateMeasurementIDsToDelete?.length ?? 0) > 0;
 }
 
+export type RevisionTabValue = 'changes' | 'duplicates' | 'new' | 'invalid' | 'unchanged';
+
+export interface RevisionRowCounts {
+  changes: number;
+  duplicates: number;
+  newRows: number;
+  invalid: number;
+  unchanged: number;
+}
+
+/**
+ * Selects the tab to open the revision review on. Every tab except 'changes' is
+ * conditionally rendered (its Tab/TabPanel only exist when that count is > 0), so this
+ * must only ever return a tab whose panel actually exists — otherwise MUI Joy's Tabs
+ * (uncontrolled, defaultValue read once at mount) locks onto a tab with no visible
+ * content and the review screen looks empty. 'changes' renders unconditionally and is
+ * therefore the only safe choice for the genuine all-empty case.
+ */
+export function resolveDefaultTabValue(counts: RevisionRowCounts): RevisionTabValue {
+  if (counts.changes > 0) return 'changes';
+  if (counts.duplicates > 0) return 'duplicates';
+  if (counts.newRows > 0) return 'new';
+  if (counts.invalid > 0) return 'invalid';
+  if (counts.unchanged > 0) return 'unchanged';
+  return 'changes';
+}
+
 export default function UploadRevisionMatch(props: Readonly<UploadRevisionMatchProps>) {
   const { matchedRows, newRows, invalidRows, counts, bulkPlan, preflightWarning, onApply, handleReturnToStart } = props;
 
@@ -94,7 +121,13 @@ export default function UploadRevisionMatch(props: Readonly<UploadRevisionMatchP
   const otherBlockingErrors = blockingErrors.filter(error => error.kind !== 'RoleForbiddenField');
   const planBlocked = bulkPlan?.canApply === false || blockingErrors.length > 0;
   const canApply = !planBlocked && (actionableMatchedRowCount > 0 || (confirmNewRows && newRows.length > 0));
-  const defaultTabValue = rowsWithChanges.length > 0 ? 'changes' : rowsWithDuplicateCleanupOnly.length > 0 ? 'duplicates' : 'changes';
+  const defaultTabValue = resolveDefaultTabValue({
+    changes: rowsWithChanges.length,
+    duplicates: rowsWithDuplicateCleanupOnly.length,
+    newRows: newRows.length,
+    invalid: invalidRows.length,
+    unchanged: rowsNoChanges.length
+  });
 
   return (
     <Stack spacing={3} sx={{ p: 3 }}>

--- a/frontend/components/uploadsystem/uploadparent.test.tsx
+++ b/frontend/components/uploadsystem/uploadparent.test.tsx
@@ -9,12 +9,13 @@
  * Verifies integration between hooks and component logic
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UploadParent from './uploadparent';
 import { FormType } from '@/config/macros/formdetails';
 import { ReviewStates } from '@/config/macros/uploadsystemmacros';
+import { UploadMode } from '@/config/uploadmodes';
 import React from 'react';
 
 // Mock AttributeStatusOptions and HC functions
@@ -181,7 +182,12 @@ vi.mock('@/components/uploadsystem/segments/uploadparsefiles', () => ({
       ))}
       <button
         onClick={() => {
-          const mockFile = { name: 'test.csv', path: '/test.csv' };
+          // A real File (not a plain object) so that revision-mode's parseRevisionFiles,
+          // which runs Papa.parse over the file's content via jsdom's FileReader, has
+          // something to actually read. Non-revision tests only ever assert on
+          // file.name/file count, so this content is inert for them.
+          const mockFile = new File(['tag,stemtag,quadrat,dbh,date\nT001,S1,Q1,10,2024-01-01\n'], 'test.csv', { type: 'text/csv' });
+          Object.assign(mockFile, { path: '/test.csv' });
           handleAddFile(mockFile as any);
         }}
       >
@@ -521,5 +527,183 @@ describe('UploadParent - Hook Integration Tests', () => {
         expect(screen.getByTestId('upload-reingestion')).toBeInTheDocument();
       });
     });
+  });
+});
+
+describe('UploadParent - Revision Upload Default Tab Selection', () => {
+  const mockOnReset = vi.fn();
+
+  // /api/revisionupload and /api/revisionupload/apply are real, unmocked routes here --
+  // UploadRevisionMatch and UploadRevisionApply are NOT mocked above, so this exercises
+  // the actual review + apply UI, not a stand-in. Only fetch is intercepted.
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  interface MockRevisionFetchOptions {
+    matchResponse: unknown;
+    applyResponse?: unknown;
+    /** Hold the match response until resolveMatch() is called, to observe the interstitial loading state. */
+    deferMatch?: boolean;
+  }
+
+  function mockRevisionUploadFetch(options: MockRevisionFetchOptions) {
+    const applyRequestBodies: Array<Record<string, unknown>> = [];
+    let releaseMatch: (() => void) | undefined;
+    const matchReady = options.deferMatch
+      ? new Promise<void>(resolve => {
+          releaseMatch = resolve;
+        })
+      : Promise.resolve();
+
+    const jsonResponse = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: new Headers({ 'content-type': 'application/json' }) });
+
+    const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (url === '/api/revisionupload/apply') {
+        applyRequestBodies.push(init?.body ? JSON.parse(init.body as string) : {});
+        return jsonResponse(options.applyResponse ?? {});
+      }
+
+      if (url === '/api/revisionupload') {
+        await matchReady;
+        return jsonResponse(options.matchResponse);
+      }
+
+      throw new Error(`Unexpected fetch call to ${url} in revision upload test`);
+    });
+
+    global.fetch = impl as unknown as typeof global.fetch;
+
+    return { applyRequestBodies, resolveMatch: () => releaseMatch?.() };
+  }
+
+  async function driveToRevisionMatch(user: ReturnType<typeof userEvent.setup>) {
+    render(<UploadParent onReset={mockOnReset} overrideUploadForm={FormType.measurements} overrideUploadMode={UploadMode.REVISIONS} />);
+
+    await user.click(screen.getByText('Add File'));
+    await waitFor(() => expect(screen.getByTestId('file-count')).toHaveTextContent('1'));
+
+    await user.click(screen.getByText('Continue Upload'));
+  }
+
+  it('opens on the New Rows tab for a new-only revision upload, and requires explicit confirmation before applying', async () => {
+    const user = userEvent.setup();
+
+    const newRowCsvRow = { tag: 'T001', stemtag: 'S1', quadrat: 'Q1', dbh: '10', date: '2024-01-01', spcode: null };
+    const matchResponse = {
+      matchedRows: [],
+      newRows: [{ csvRow: newRowCsvRow, csvIndex: 0, reason: 'no-match-key-in-db' }],
+      invalidRows: [],
+      counts: { matched: 0, matchedWithChanges: 0, new: 1, invalid: 0, total: 1 }
+    };
+    const applyResponse = {
+      updatedCount: 0,
+      skippedCount: 0,
+      insertedCount: 1,
+      deletedDuplicateCount: 0,
+      applyErrors: [],
+      validationPending: false
+    };
+    const { applyRequestBodies, resolveMatch } = mockRevisionUploadFetch({ matchResponse, applyResponse, deferMatch: true });
+
+    await driveToRevisionMatch(user);
+
+    // UploadRevisionMatch must not mount until the match response exists -- while the
+    // request is in flight, a matching-in-progress state should be visible instead.
+    await waitFor(() => expect(screen.getByText(/matching revision rows/i)).toBeInTheDocument());
+    expect(screen.queryByText('Confirm new row insertion')).not.toBeInTheDocument();
+
+    resolveMatch();
+
+    // This is the defect under test: UploadRevisionMatch used to mount with `?? []`
+    // empties before the match response existed, and MUI Joy's Tabs reads
+    // defaultValue only once (it is uncontrolled). With every count at zero on that
+    // first render, the tab-selection ternary (and now resolveDefaultTabValue) both
+    // land on 'changes' -- which locks the Tabs selection there permanently. Once the
+    // real newRows-only response lands, the New Rows tab exists in the TabList but its
+    // panel is never the selected one, so this text never renders and the wait below
+    // times out.
+    await waitFor(() => expect(screen.getByText('Confirm new row insertion')).toBeInTheDocument(), { timeout: 3000 });
+
+    const applyButton = screen.getByTestId('revision-match-apply');
+    expect(applyButton).toBeDisabled();
+
+    await user.click(screen.getByText('Confirm new row insertion'));
+    expect(applyButton).not.toBeDisabled();
+
+    await user.click(applyButton);
+
+    await waitFor(() => expect(applyRequestBodies).toHaveLength(1));
+    expect(applyRequestBodies[0].confirmNewRows).toBe(true);
+    expect(applyRequestBodies[0].newRows).toHaveLength(1);
+
+    await waitFor(() => expect(screen.getByText('Revisions Applied')).toBeInTheDocument());
+  });
+
+  it('opens on the Invalid tab for an invalid-only revision upload, and keeps Apply disabled', async () => {
+    const user = userEvent.setup();
+
+    const invalidCsvRow = { tag: 'T404', stemtag: 'S1', quadrat: 'Q1', dbh: '10', date: '2024-01-01' };
+    const matchResponse = {
+      matchedRows: [],
+      newRows: [],
+      invalidRows: [{ csvRow: invalidCsvRow, csvIndex: 0, reason: 'No matching identity found in the active census' }],
+      counts: { matched: 0, matchedWithChanges: 0, new: 0, invalid: 1, total: 1 }
+    };
+    mockRevisionUploadFetch({ matchResponse });
+
+    await driveToRevisionMatch(user);
+
+    // The Invalid tab has no intro copy of its own -- its row-level reason text is the
+    // signal that its panel (not Changes) is the one actually selected.
+    await waitFor(() => expect(screen.getByText('No matching identity found in the active census')).toBeInTheDocument(), { timeout: 3000 });
+    // MUI Joy's TabPanel omits its children entirely (not just CSS-hides them) when
+    // it isn't the selected tab, so the Changes panel's empty-state copy shouldn't
+    // exist in the DOM at all if Changes is not the tab that ended up selected.
+    expect(screen.queryByText('No rows with changes were found.')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('revision-match-apply')).toBeDisabled();
+  });
+
+  it('opens on the Unchanged tab for an unchanged-only revision upload, and keeps Apply disabled', async () => {
+    const user = userEvent.setup();
+
+    const unchangedCsvRow = { tag: 'T900', stemtag: 'S1', quadrat: 'Q1', dbh: '10', date: '2024-01-01' };
+    const matchResponse = {
+      matchedRows: [
+        {
+          csvIndex: 0,
+          csvRow: unchangedCsvRow,
+          coreMeasurementID: 900,
+          changes: {},
+          existingValues: { measuredDBH: 10, measuredHOM: null, measurementDate: '2024-01-01', rawCodes: null, description: null }
+        }
+      ],
+      newRows: [],
+      invalidRows: [],
+      counts: { matched: 1, matchedWithChanges: 0, new: 0, invalid: 0, total: 1 }
+    };
+    mockRevisionUploadFetch({ matchResponse });
+
+    await driveToRevisionMatch(user);
+
+    await waitFor(() => expect(screen.getByText('1 matched row had no field differences and will be skipped during apply.')).toBeInTheDocument(), {
+      timeout: 3000
+    });
+    // MUI Joy's TabPanel omits its children entirely (not just CSS-hides them) when
+    // it isn't the selected tab, so the Changes panel's empty-state copy shouldn't
+    // exist in the DOM at all if Changes is not the tab that ended up selected.
+    expect(screen.queryByText('No rows with changes were found.')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('revision-match-apply')).toBeDisabled();
   });
 });

--- a/frontend/components/uploadsystem/uploadparent.tsx
+++ b/frontend/components/uploadsystem/uploadparent.tsx
@@ -5,7 +5,7 @@ import { FileCollectionRowSet, FileRow, FormType, RequiredTableHeadersByFormType
 import { FileWithPath } from 'react-dropzone';
 import { useOrgCensusContext, usePlotContext, useSiteContext } from '@/app/contexts/compat-hooks';
 import { useSession } from 'next-auth/react';
-import { Box, Typography } from '@mui/joy';
+import { Box, CircularProgress, Stack, Typography } from '@mui/joy';
 import ContextValidationGuard from '@/components/shared/ContextValidationGuard';
 import UploadParseFiles from '@/components/uploadsystem/segments/uploadparsefiles';
 import UploadAsyncJob from '@/components/uploadsystem/segments/uploadasyncjob';
@@ -30,7 +30,7 @@ import { useErrorHandling } from '@/app/hooks/useerrorhandling';
 import { ErrorBoundary } from '@/components/errorboundary';
 import { UploadMode } from '@/config/uploadmodes';
 import { canonicalizeRevisionRow, normalizeRevisionHeader } from '@/components/uploadsystemhelpers/revisionfileparse';
-import { EMPTY_REVISION_MATCH_COUNTS, RevisionInvalidRow, RevisionMatchedRow, RevisionUploadResponse } from '@/config/revisionuploadtypes';
+import { RevisionInvalidRow, RevisionMatchedRow, RevisionUploadResponse } from '@/config/revisionuploadtypes';
 import { BulkEditPlan } from '@/config/editplan/types';
 import type { ArcgisImportReference } from '@/lib/arcgis/types';
 import type { QuadratOverlapAcknowledgment } from '@/lib/provisioning/types';
@@ -548,13 +548,25 @@ function UploadParentInner(props: UploadParentProps) {
           />
         );
       case ReviewStates.REVISION_MATCH:
+        // UploadRevisionMatch chooses its opening tab from row counts, and MUI Joy
+        // reads Tabs.defaultValue only on the uncontrolled mount. Mounting with the
+        // `?? []` empties while the match request is still in flight would lock the
+        // selection to the empty-state tab, so wait for the response instead.
+        if (!revisionMatchResult) {
+          return (
+            <Stack spacing={2} alignItems="center" sx={{ p: 3 }}>
+              <CircularProgress />
+              <Typography level="body-md">Matching revision rows&hellip;</Typography>
+            </Stack>
+          );
+        }
         return (
           <UploadRevisionMatch
-            matchedRows={revisionMatchResult?.matchedRows ?? []}
-            newRows={revisionMatchResult?.newRows ?? []}
-            invalidRows={revisionMatchResult?.invalidRows ?? []}
-            counts={revisionMatchResult?.counts ?? EMPTY_REVISION_MATCH_COUNTS}
-            bulkPlan={revisionMatchResult?.bulkPlan}
+            matchedRows={revisionMatchResult.matchedRows}
+            newRows={revisionMatchResult.newRows}
+            invalidRows={revisionMatchResult.invalidRows}
+            counts={revisionMatchResult.counts}
+            bulkPlan={revisionMatchResult.bulkPlan}
             schema={currentSite?.schemaName || ''}
             plotID={currentPlotID ?? 0}
             censusID={currentCensusID ?? 0}


### PR DESCRIPTION
## Summary
The only production-facing defect in this remediation series: a revision upload containing only new rows opened on an empty **Changes** tab with "Apply 0 Revisions" disabled, stranding the user — the confirm-new-rows control sat on a tab they had to find by hand. Two defects compounded:

- `uploadrevisionmatch.tsx`'s default-tab ternary (`changes : duplicates : changes`) could never yield `new` — the same fall-through also stranded invalid-only and unchanged-only uploads. Extracted an exported pure `resolveDefaultTabValue()` (changes → duplicates → new → invalid → unchanged → changes-as-empty-state) whose priority mirrors the conditional render gates, so it can never select a tab whose panel doesn't exist.
- `uploadparent.tsx` mounted `UploadRevisionMatch` with `?? []` empties while the match request was still in flight; MUI Joy's `Tabs` reads `defaultValue` only on its first uncontrolled render, so the later response could not move the selection. The `REVISION_MATCH` case now shows a matching progress state until the response exists.

Coverage, written red-first (the parent-level new-only case was captured failing on the empty-Changes selection before the production edit): a 7-case pure-function suite (`uploadrevisionmatch.defaulttab.test.ts` — named to avoid a same-basename TypeScript include collision with the pre-existing `uploadrevisionmatch.test.tsx`), plus three parent-level jsdom cases proving the new-only flow end to end (`confirmNewRows: true` through the apply boundary), and invalid-only/unchanged-only panels with Apply disabled.

Verification: 29/29 across the three test files; full unit suite 259 files green; `npm run build` green; Cypress `revision-upload-segments` test 1 now passes unweakened (test 2's `startValidation` failure is the next branch's scope).