### PR TITLE
fix(e2e): apply catalog migrations when seeding the e2e database

### DIFF
--- a/frontend/tests/setup/e2e-seed.ts
+++ b/frontend/tests/setup/e2e-seed.ts
@@ -23,6 +23,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { applyCatalogMigrationsForTests } from './catalog-migrations';
 import { DEFAULT_TEST_CONFIG, log, setupTestDatabase, type TestDatabaseConfig } from './local-db-setup';
 
 /** Schema name the e2e spec documents as its backing site schema. */
@@ -84,6 +85,16 @@ async function seedE2EDatabase(): Promise<void> {
 
   try {
     await seedCatalog(connection);
+
+    // background_jobs/background_job_files/background_job_events come from a
+    // catalog migration, not from catalog-provisioning-tables.sql, so the seed
+    // drifted out from under that migration and every e2e run logged
+    // upload.sweeper.pass_failed warnings. Run the full ordered manifest through
+    // the same harness the integration suites use rather than naming one
+    // migration file here: the seed owns fixture data, the migration harness
+    // owns catalog schema evolution.
+    await applyCatalogMigrationsForTests();
+
     log.info('E2E fixture seeded successfully.');
   } finally {
     // Close the live connection but keep the seeded schemas — the app reads them.


### PR DESCRIPTION
## Summary
- `background_jobs`, `background_job_files` and `background_job_events` come from a catalog migration, not from `catalog-provisioning-tables.sql`, so the e2e seed drifted when that migration landed and every e2e run logged `upload.sweeper.pass_failed` — noise that buried the genuine 14.9s timing signal the warmup branch (#446) fixed.
- `tests/setup/e2e-seed.ts` now calls `applyCatalogMigrationsForTests()` immediately after the base catalog seed, running the whole ordered `CATALOG_MIGRATION_MANIFEST` through the production migration runner with its ledger. The seed names no migration files and copies no DDL — the seed owns fixture data; the migration harness owns catalog schema evolution, so future manifest entries can't re-drift.
- Re-seeding is idempotent (ledger skips applied migrations; verified across three consecutive runs).

Acceptance verified A/B against a local dev server on the seeded database: with `background_jobs` renamed away, `upload.sweeper.pass_failed` fires within one 60s sweeper tick; with the migrated catalog, zero sweeper warnings across multiple ticks.