### PR TITLE
test(cypress): seed the app store and stub ValidationRunner.start directly

### DIFF
--- a/frontend/cypress/components/revision-upload-segments.cy.tsx
+++ b/frontend/cypress/components/revision-upload-segments.cy.tsx
@@ -2,23 +2,34 @@ import React from 'react';
 import UploadRevisionApply from '@/components/uploadsystem/segments/uploadrevisionapply';
 import UploadRevisionMatch from '@/components/uploadsystem/segments/uploadrevisionmatch';
 import { ReviewStates } from '@/config/macros/uploadsystemmacros';
-import * as compatHooks from '@/app/contexts/compat-hooks';
-import * as backgroundValidationHooks from '@/app/hooks/usebackgroundvalidation';
+import { useAppStore } from '@/config/store/appstore';
+import { ValidationRunner } from '@/config/validation-runner';
+
+const TEST_PLOT = { plotID: 1, plotName: 'Test Plot' } as never;
+const TEST_CENSUS = { plotCensusNumber: 1, dateRanges: [{ censusID: 2 }] } as never;
 
 describe('Revision Upload Segments', () => {
   beforeEach(() => {
-    cy.stub(compatHooks, 'usePlotContext').returns({
-      plotID: 1,
-      plotName: 'Test Plot'
-    } as any);
-    cy.stub(compatHooks, 'useOrgCensusContext').returns({
-      plotCensusNumber: 1,
-      dateRanges: [{ censusID: 2 }]
-    } as any);
+    // cy.stub() on a webpack ES-module namespace silently no-ops -- it does not throw,
+    // so the stubs that used to sit here looked correct while the component read the
+    // real zustand store, got undefined plotID/censusID, and skipped startValidation.
+    // Seed the store through its own actions instead (prior art: sidebar.test.tsx:398).
+    // Use the actions, not raw setState: appstore.ts carries a persistence guard that
+    // trips when an empty selection overwrites a persisted one.
+    useAppStore.getState().clearSelections();
+    useAppStore.getState().setPlot(TEST_PLOT);
+    useAppStore.getState().setCensus(TEST_CENSUS);
   });
 
   afterEach(() => {
-    Cypress.sinon.restore();
+    useAppStore.getState().clearSelections();
+  });
+
+  it('seeds plot and census context into the store', () => {
+    // Guards the exact failure mode being fixed: a context mechanism that no-ops in
+    // silence. If this fails, every other assertion in this spec is untrustworthy.
+    expect(useAppStore.getState().currentPlot).to.deep.equal(TEST_PLOT);
+    expect(useAppStore.getState().currentCensus).to.deep.equal(TEST_CENSUS);
   });
 
   it('requires explicit confirmation before new rows can be applied', () => {
@@ -66,11 +77,12 @@ describe('Revision Upload Segments', () => {
   it('shows recovery actions on apply conflict and retries successfully', () => {
     const setReviewState = cy.stub().as('setReviewState');
     const setIsDataUnsaved = cy.stub().as('setIsDataUnsaved');
-    const startValidation = cy.stub().as('startValidation');
 
-    cy.stub(backgroundValidationHooks, 'useBackgroundValidation').returns({
-      startValidation
-    } as any);
+    // ValidationRunner is a plain object literal, so `start` is a writable property --
+    // unlike an ES-module namespace binding. The hook delegates to it at call time, so
+    // this observes the exact contract without launching the module-level singleton's
+    // multi-request workflow inside a component test.
+    cy.stub(ValidationRunner, 'start').as('startValidation');
 
     cy.clock();
 


### PR DESCRIPTION
## Summary
- `cy.stub()` on a webpack ES-module namespace silently no-ops — it does not throw. The revision-upload spec's stubs of the compat-hook and background-validation modules looked correct while the component read the real (empty) zustand store, got undefined `plotID`/`censusID`, and correctly skipped `startValidation`: the app behaved properly, the harness misreported.
- Context is now seeded through `useAppStore`'s own actions (`clearSelections`/`setPlot`/`setCensus`, cleared in teardown) — the actions, not raw `setState`, because `clearSelections` carries the explicit-clear flag that the store's persistence guard requires (prior art: `sidebar.test.tsx`). A leading guard test asserts the seeded context is readable before any behavioural test depends on it, so a silently-broken context mechanism now fails fast.
- `ValidationRunner.start` is stubbed directly — it is a plain-object writable property that the `useBackgroundValidation` hook delegates to at call time — and observed receiving `{ schema: 'forestgeo_testing', plotID: 1, censusID: 2 }` unweakened, without launching a real background validation run.

With this branch the component suite is **14/14 specs, 152/152 tests, 0 failing** locally — the precondition for gating the suite on every pull request (the final branch in this series). No production code touched.