### PR TITLE
ci(pr-gate): run the Cypress component suite on every pull request

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -79,3 +79,53 @@ jobs:
           TEST_DB_PORT: "3306"
           TEST_DB_USER: root
           TEST_DB_PASSWORD: testpassword
+
+  # Until 2026-08-26 no workflow but the nightly ran the Cypress component suite, so 14
+  # specs had zero coverage on any branch and accumulated a production defect, a spec
+  # asserting removed copy, a spec that never satisfied a shipped confirmation gate, and
+  # a harness that silently no-ops. This job is also the recurrence guard for the
+  # case-sensitivity defect in cypress/support/shared-config.cjs: it runs on Linux.
+  # Needs no database and completes in roughly three minutes.
+  component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Install Cypress binary
+        run: npx cypress install
+        working-directory: frontend
+
+      # `cypress run --component` exits non-zero when no specs are found, so the runner
+      # already fails closed on a rename or a moved directory. No preflight step.
+      - name: Cypress component tests
+        run: npm run test:component
+        working-directory: frontend
+
+      - name: Upload component screenshots on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: pr-gate-component-screenshots
+          path: frontend/cypress/screenshots
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload component videos
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pr-gate-component-videos
+          path: frontend/cypress/videos
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Until this series, no workflow but the nightly ran the Cypress component suite: 14 specs had zero coverage on any branch and silently accumulated a webpack-layer build failure, a production defect, two stale specs, and a harness that no-op'd. With the suite now 14/14 (152 tests) green on dev, this closes the loop so component regressions surface on the pull request that introduces them instead of in the next morning's nightly.
- Adds a `component` job to `pr-gate.yml` mirroring the nightly component job's proven shape: Node 24, `npm ci`, explicit Cypress binary install, `npm run test:component`; no database service. Deliberately no spec-discovery preflight — `cypress run --component` exits non-zero when no specs are found (verified empirically, exit 1).
- Because it runs on Linux, this job is also the recurrence guard for the case-sensitive mock-alias defect fixed in #443.
- Screenshots are retained on failure and videos on every run, with `pr-gate-` artifact prefixes so they cannot be confused with the nightly's `nightly-*` artifacts. Timeout (20m vs 30m) and retention (7d vs 14d) are deliberately tighter than the nightly's, matching PR-gate cadence — not an oversight.

This PR is its own acceptance test: the `component` job runs here for the first time.