### PR TITLE
fix: harden the e2e warmup gate and make revision matching cancellable

### DIFF
--- a/frontend/components/uploadsystem/uploadparent.test.tsx
+++ b/frontend/components/uploadsystem/uploadparent.test.tsx
@@ -586,13 +586,48 @@ describe('UploadParent - Revision Upload Default Tab Selection', () => {
     return { applyRequestBodies, resolveMatch: () => releaseMatch?.() };
   }
 
+  /**
+   * Mocks /api/revisionupload as a request that never resolves on its own -- it only
+   * settles by rejecting with the same AbortError DOMException real fetch() produces
+   * when the request's signal aborts (verified against Node's real fetch: a manual
+   * AbortController.abort() surfaces as `DOMException` named 'AbortError'). This lets
+   * the cancel-button and unmount tests observe the abort without a real timeout.
+   */
+  function mockNeverSettlingRevisionMatchFetch() {
+    const signals: AbortSignal[] = [];
+
+    const impl = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url !== '/api/revisionupload') {
+        throw new Error(`Unexpected fetch call to ${url} in never-settling revision match test`);
+      }
+
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        if (!signal) return;
+        signals.push(signal);
+        const rejectWithAbortError = () => reject(new DOMException('This operation was aborted', 'AbortError'));
+        if (signal.aborted) {
+          rejectWithAbortError();
+          return;
+        }
+        signal.addEventListener('abort', rejectWithAbortError);
+      });
+    });
+
+    global.fetch = impl as unknown as typeof global.fetch;
+    return { signals };
+  }
+
   async function driveToRevisionMatch(user: ReturnType<typeof userEvent.setup>) {
-    render(<UploadParent onReset={mockOnReset} overrideUploadForm={FormType.measurements} overrideUploadMode={UploadMode.REVISIONS} />);
+    const renderResult = render(<UploadParent onReset={mockOnReset} overrideUploadForm={FormType.measurements} overrideUploadMode={UploadMode.REVISIONS} />);
 
     await user.click(screen.getByText('Add File'));
     await waitFor(() => expect(screen.getByTestId('file-count')).toHaveTextContent('1'));
 
     await user.click(screen.getByText('Continue Upload'));
+
+    return renderResult;
   }
 
   it('opens on the New Rows tab for a new-only revision upload, and requires explicit confirmation before applying', async () => {
@@ -705,5 +740,41 @@ describe('UploadParent - Revision Upload Default Tab Selection', () => {
     expect(screen.queryByText('No rows with changes were found.')).not.toBeInTheDocument();
 
     expect(screen.getByTestId('revision-match-apply')).toBeDisabled();
+  });
+
+  it('cancels the in-flight revision match request and returns to start without showing an error', async () => {
+    const user = userEvent.setup();
+    const { signals } = mockNeverSettlingRevisionMatchFetch();
+
+    await driveToRevisionMatch(user);
+
+    await waitFor(() => expect(screen.getByText(/matching revision rows/i)).toBeInTheDocument());
+    const cancelButton = screen.getByText('Cancel and return to start');
+    expect(cancelButton).toBeInTheDocument();
+
+    await user.click(cancelButton);
+
+    // Returns to the start screen (UploadStart, mocked above) rather than staying on
+    // the loading state or falling through to the error screen.
+    await waitFor(() => expect(screen.getByTestId('upload-start')).toBeInTheDocument());
+    expect(screen.queryByTestId('upload-error')).not.toBeInTheDocument();
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it('aborts the in-flight revision match request on unmount', async () => {
+    const user = userEvent.setup();
+    const { signals } = mockNeverSettlingRevisionMatchFetch();
+
+    const { unmount } = await driveToRevisionMatch(user);
+
+    await waitFor(() => expect(screen.getByText(/matching revision rows/i)).toBeInTheDocument());
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.aborted).toBe(false);
+
+    unmount();
+
+    expect(signals[0]?.aborted).toBe(true);
   });
 });

--- a/frontend/components/uploadsystem/uploadparent.tsx
+++ b/frontend/components/uploadsystem/uploadparent.tsx
@@ -5,7 +5,7 @@ import { FileCollectionRowSet, FileRow, FormType, RequiredTableHeadersByFormType
 import { FileWithPath } from 'react-dropzone';
 import { useOrgCensusContext, usePlotContext, useSiteContext } from '@/app/contexts/compat-hooks';
 import { useSession } from 'next-auth/react';
-import { Box, CircularProgress, Stack, Typography } from '@mui/joy';
+import { Box, Button, CircularProgress, Stack, Typography } from '@mui/joy';
 import ContextValidationGuard from '@/components/shared/ContextValidationGuard';
 import UploadParseFiles from '@/components/uploadsystem/segments/uploadparsefiles';
 import UploadAsyncJob from '@/components/uploadsystem/segments/uploadasyncjob';
@@ -36,6 +36,11 @@ import type { ArcgisImportReference } from '@/lib/arcgis/types';
 import type { QuadratOverlapAcknowledgment } from '@/lib/provisioning/types';
 import type { QuadratOverlapSummary } from '@/lib/provisioning/quadrat-collection-validation';
 import { useAsyncUploadFeature } from '@/app/hooks/useasyncuploadfeature';
+
+// Revision matching can hang indefinitely on a stalled connection; this bounds how long
+// the UI waits before treating the request as failed rather than leaving the user on the
+// loading state forever.
+const REVISION_MATCH_TIMEOUT_MS = 120_000;
 
 export interface CMIDRow {
   coreMeasurementID: number;
@@ -170,6 +175,11 @@ function UploadParentInner(props: UploadParentProps) {
 
   // Track if we've already initialized reingestion to prevent re-triggering
   const reingestionInitializedRef = useRef(false);
+
+  // The in-flight /api/revisionupload request's controller, so the cancel button and
+  // unmount cleanup can abort it explicitly rather than leaving it to resolve into a
+  // component that no longer wants the result.
+  const revisionMatchAbortControllerRef = useRef<AbortController | null>(null);
 
   // Context and session
   const _currentPlot = usePlotContext();
@@ -374,11 +384,19 @@ function UploadParentInner(props: UploadParentProps) {
     }
   }
 
+  function cancelRevisionMatch() {
+    revisionMatchAbortControllerRef.current?.abort();
+  }
+
   async function handleRevisionMatch() {
     const files = Object.entries(parsedData).map(([fileName, fileRows]) => ({
       fileName,
       rows: Object.values(fileRows)
     }));
+
+    const controller = new AbortController();
+    revisionMatchAbortControllerRef.current = controller;
+    const signal = AbortSignal.any([controller.signal, AbortSignal.timeout(REVISION_MATCH_TIMEOUT_MS)]);
 
     try {
       const response = await fetch('/api/revisionupload', {
@@ -389,7 +407,8 @@ function UploadParentInner(props: UploadParentProps) {
           plotID: currentPlotID,
           censusID: currentCensusID,
           schema: currentSite?.schemaName
-        })
+        }),
+        signal
       });
 
       if (!response.ok) {
@@ -400,6 +419,19 @@ function UploadParentInner(props: UploadParentProps) {
       const result: RevisionUploadResponse = await response.json();
       setRevisionMatchResult(result);
     } catch (err: unknown) {
+      // A manual abort (cancel button or unmount) means the user has already navigated
+      // away -- surfacing an error here would fight that. AbortSignal.timeout's own
+      // abort carries a distinct DOMException name, so it still reports as a failure.
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return;
+      }
+
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        errorHandling.setError(new Error(`Revision matching timed out after ${REVISION_MATCH_TIMEOUT_MS / 1000}s`));
+        uploadState.setReviewState(ReviewStates.ERRORS);
+        return;
+      }
+
       const errorObj = err instanceof Error ? err : new Error(String(err));
       errorHandling.setError(errorObj);
       uploadState.setReviewState(ReviewStates.ERRORS);
@@ -420,6 +452,14 @@ function UploadParentInner(props: UploadParentProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [parsedData, revisionMatchResult, uploadState.state.reviewState]);
+
+  // Abort any in-flight revision-match request on unmount so it doesn't resolve into a
+  // component that no longer exists.
+  useEffect(() => {
+    return () => {
+      revisionMatchAbortControllerRef.current?.abort();
+    };
+  }, []);
 
   // Check if we should start with reingestion processing (only once on mount)
   useEffect(() => {
@@ -557,6 +597,16 @@ function UploadParentInner(props: UploadParentProps) {
             <Stack spacing={2} alignItems="center" sx={{ p: 3 }}>
               <CircularProgress />
               <Typography level="body-md">Matching revision rows&hellip;</Typography>
+              <Button
+                variant="outlined"
+                color="neutral"
+                onClick={() => {
+                  cancelRevisionMatch();
+                  void handleReturnToStart();
+                }}
+              >
+                Cancel and return to start
+              </Button>
             </Stack>
           );
         }

--- a/frontend/scripts/warm-e2e-routes.mjs
+++ b/frontend/scripts/warm-e2e-routes.mjs
@@ -12,20 +12,49 @@
 // Deliberately NOT a route inventory: discovering every route and fan-out API would
 // couple this fix to unrelated application growth. Deliberately NOT non-fatal: a
 // warmup that can silently skip cannot guarantee the goal and would leave the race.
+//
+// Each route has its own accepted status set rather than accepting any status: a 404
+// (route renamed) or 500 must fail the warmup loudly instead of logging "done" and
+// letting Cypress start with the race unfixed. /api/uploadjobs accepts 401 alongside
+// 200 because the measured no-session response IS a 401 -- it still proves the route
+// compiled AND executed -- while an auth-bypassing e2e environment would see 200. The
+// page route has no such no-session variant, so only 200 is accepted for it.
+//
+// Redirects are followed manually (redirect: 'manual') so a redirect to a login/error
+// page surfaces as its own 3xx status -- which is not in any accepted set and throws --
+// instead of silently resolving as a 200 warmup of the wrong page.
 
 const BASE_URL = process.env.WARMUP_BASE_URL ?? 'http://localhost:3000';
 
 // Order matters. The API compile is what held the compiler while the page waited.
-const ROUTES = ['/api/uploadjobs?schema=luquillo&plotID=1&censusID=5&activeOnly=false&limit=25', '/measurementshub/summary'];
+const ROUTES = [
+  { path: '/api/uploadjobs?schema=luquillo&plotID=1&censusID=5&activeOnly=false&limit=25', acceptedStatuses: [200, 401] },
+  { path: '/measurementshub/summary', acceptedStatuses: [200] }
+];
 
 const REQUEST_TIMEOUT_MS = 120_000;
 
-for (const route of ROUTES) {
+for (const { path, acceptedStatuses } of ROUTES) {
   const startedAt = Date.now();
-  // Any HTTP status means the route compiled -- a 401 from /api/uploadjobs is enough.
-  // Only a network failure or timeout indicates the server never got there.
-  const response = await fetch(`${BASE_URL}${route}`, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
-  console.log(`[warmup] ${String(response.status).padEnd(3)} ${String(Date.now() - startedAt).padStart(6)}ms  ${route}`);
+  const signal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const response = await fetch(`${BASE_URL}${path}`, { signal, redirect: 'manual' });
+
+  // Consume the body under the same signal/timeout: fetch resolves on headers alone,
+  // and App Router pages can stream, so an unread body can leave Cypress starting
+  // mid-render and pins the HTTP resource open. Reading it here also makes the logged
+  // duration reflect the full render, matching the server-side timings that motivated
+  // this script.
+  await response.arrayBuffer();
+
+  const duration = Date.now() - startedAt;
+
+  if (!acceptedStatuses.includes(response.status)) {
+    const location = response.headers.get('location');
+    const locationDetail = location ? ` (redirected to ${location})` : '';
+    throw new Error(`[warmup] ${path} returned status ${response.status}${locationDetail}, expected one of [${acceptedStatuses.join(', ')}]`);
+  }
+
+  console.log(`[warmup] ${String(response.status).padEnd(3)} ${String(duration).padStart(6)}ms  ${path}`);
 }
 
 console.log('[warmup] done');


### PR DESCRIPTION
## Summary
Addresses four post-merge review findings on #446 and #447. Two commits, one per concern.

**`scripts/warm-e2e-routes.mjs` (#446 findings):**
- The warmup accepted any HTTP status, so a 404 (renamed route) or 500 still printed `[warmup] done` and launched Cypress with the race unfixed. Each route now has an explicit accepted-status set — `[200, 401]` for `/api/uploadjobs` (401 is the measured no-session response and proves the route compiled and executed; 200 covers an auth-bypassing environment) and `[200]` for `/measurementshub/summary` — and any other status throws, naming the route, status, and accepted set.
- Response bodies are now consumed (`arrayBuffer()`) under the same 120s signal before logging, so App Router streaming can't let Cypress start mid-render, unread bodies no longer pin HTTP resources, and logged durations reflect the full render.
- `redirect: 'manual'`: a redirect to a login/error page now surfaces as its 3xx status (with the `location` header in the error) and fails the gate instead of masquerading as a 200 warmup of the requested route.

Verified live: 401/200 warm runs, 404 → throw with exit 1, 302 → throw naming the redirect target, dead server → exit 1.

**`uploadparent.tsx` (#447 finding):**
- The revision-match request had no timeout or abort signal, and the loading state added in #447 had no escape hatch — a request that never settled trapped the user on the spinner indefinitely. The fetch now runs under `AbortSignal.any` of a per-request `AbortController` and a named 120s timeout; unmount aborts any in-flight request; and the loading state gained a "Cancel and return to start" action wired through the existing `handleReturnToStart` path.
- A user cancel (AbortError) returns silently; a timeout (TimeoutError) surfaces a clear error through the existing ERRORS state; other failures behave exactly as before. First-abort-wins latching of the combined signal was verified empirically against this runtime, so a late timeout cannot misclassify a user cancel.
- Two new signal-observing regression tests (cancel path, unmount path) in `uploadparent.test.tsx`.

Verification: unit suite 259 files / 3878 tests green (15 in the touched file), revision Cypress spec 3/3 unchanged, `npm run build` exit 0.