### PR TITLE
ci(nightly): pin every checkout to forestgeo-app-development

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,12 @@ jobs:
           --health-retries=10
 
     steps:
+      # The schedule fires on the default branch (main), but the nightly's job is to
+      # regression-test the integration branch where work lands first. Pin every
+      # checkout to forestgeo-app-development so the suite exercises dev, not main.
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -128,6 +133,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -221,6 +228,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -276,6 +285,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -338,6 +349,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: forestgeo-app-development
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- The Nightly Regression workflow is schedule-triggered, so it fires on the default branch (`main`), and all five jobs did a bare `actions/checkout@v4` — meaning the nightly has been regression-testing **main**, not the integration branch where work lands first. This morning's failing nightly (the one the remediation series was written from) ran against main; none of the ten fixes merged to dev today would be exercised by tonight's run.
- Every checkout in the workflow's five jobs (full-cypress, realdb-full, component, stress, coverage) is now pinned with `ref: forestgeo-app-development`. Nothing else in the workflow references `github.sha`/`github.ref` in a way affected by the pin (the concurrency group keys on the triggering ref, which is unchanged behavior).

Two deliberate behavior notes for reviewers:
- **This change is inert until it reaches `main`**: scheduled workflows always execute the workflow file from the default branch. Landing it on dev routes it through the normal dev→main promotion; if the nightly should test dev *before* the next promotion, the same commit needs to reach main directly — maintainer's call.
- **`workflow_dispatch` runs now always test dev**: previously a manual dispatch tested whichever branch it was run from; with the pin, any dispatch checks out `forestgeo-app-development` regardless.