### PR TITLE
fix(tests): stop provisioning integration tests deadlocking the shared catalog

### DIFF
--- a/frontend/tests/integration/admin-provision/_shared.ts
+++ b/frontend/tests/integration/admin-provision/_shared.ts
@@ -9,6 +9,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import mysql, { type Pool } from 'mysql2/promise';
+import { vi } from 'vitest';
 
 export const TEST_SCHEMA_PREFIX = 'forestgeo_routetest_';
 
@@ -30,6 +31,22 @@ export interface SeedStep {
   startedAtSecondsAgo?: number;
   finishedAt?: Date | null;
   errorMessage?: string | null;
+}
+
+/**
+ * Suppresses the orchestrator's background `dispatchRun` kickoff by stubbing
+ * `setImmediate` to a no-op, so the caller observes only the synchronous catalog
+ * writes that startRun/retryRun perform inline.
+ *
+ * MUST be called from beforeEach, never beforeAll. vitest.integration.config.mts
+ * sets `restoreMocks`, which tears a beforeAll spy down after the FIRST test.
+ * With the seam dead from test 2 onward, dispatchRun ran real provisioning —
+ * CREATE DATABASE and schema DDL — and started a 10-second heartbeat interval
+ * that outlived the file and deadlocked the next test's catalog cleanup
+ * (ER_LOCK_DEADLOCK on DELETE FROM catalog.provisioning_runs).
+ */
+export function suppressBackgroundDispatch() {
+  return vi.spyOn(globalThis, 'setImmediate').mockImplementation((() => 0) as never);
 }
 
 export function createTestPool(): Pool {

--- a/frontend/tests/integration/admin-provision/_shared.ts
+++ b/frontend/tests/integration/admin-provision/_shared.ts
@@ -71,21 +71,56 @@ export async function seedCatalogTables(pool: Pool): Promise<void> {
   await pool.query(`CREATE TABLE IF NOT EXISTS catalog.usersiterelations (UserID INT, SiteID INT)`);
 }
 
+/** Escapes the LIKE metacharacters in a schema name so `_` matches a literal underscore. */
+function likePrefix(schemaName: string): string {
+  return schemaName.replace(/([\\%_])/g, '\\$1') + '%';
+}
+
 /**
- * Cleans all rows in the provisioning catalog tables. If a `schemaName` is
- * provided, the matching site row is removed and the schema dropped — otherwise
- * any sites whose name starts with TEST_SCHEMA_PREFIX are removed.
+ * Cleans the provisioning catalog rows owned by one test file.
+ *
+ * `catalog` is shared by every integration file (only the per-site
+ * `forestgeo_test_*` schemas are isolated), so this used to delete whole tables.
+ * An unqualified `DELETE FROM catalog.provisioning_runs` locks every row and
+ * cascades into provisioning_steps, which deadlocks against the worker's
+ * heartbeat `UPDATE ... WHERE RunID = ?` — see the ER_LOCK_DEADLOCK in
+ * start.integration.test.ts. Scoping each delete to the caller's own schema
+ * keeps the lock footprint on rows this file actually owns.
+ *
+ * The match is a PREFIX: worker.integration.test.ts seeds derived schemas
+ * (`<TEST_SCHEMA>_c`, `_f`, `_a`, `_fresh`) that must be cleared alongside their
+ * parent. No two files' schemas prefix one another, so this cannot reach across
+ * files. Only the exact schema is dropped as a database.
+ *
+ * Omitting `schemaName` keeps the table-wide wipe, which list.integration.test.ts
+ * needs because it asserts the route returns an empty array when NO runs exist.
  */
 export async function clearProvisioningState(pool: Pool, schemaName?: string): Promise<void> {
+  if (schemaName) {
+    const owned = likePrefix(schemaName);
+    // Single-table DELETE with a subquery, NOT the multi-table `DELETE t FROM t JOIN u`
+    // form: createTestPool() intentionally selects no default database, and the
+    // multi-table form needs one even when every table is schema-qualified
+    // (ER_NO_DB_ERROR 1046).
+    await pool.query(
+      `DELETE FROM catalog.provisioning_steps
+        WHERE RunID IN (SELECT RunID FROM catalog.provisioning_runs WHERE SchemaName LIKE ?)`,
+      [owned]
+    );
+    await pool.query(`DELETE FROM catalog.provisioning_runs WHERE SchemaName LIKE ?`, [owned]);
+    await pool.query(
+      `DELETE FROM catalog.usersiterelations
+        WHERE SiteID IN (SELECT SiteID FROM catalog.sites WHERE SchemaName LIKE ?)`,
+      [owned]
+    );
+    await pool.query(`DELETE FROM catalog.sites WHERE SchemaName LIKE ?`, [owned]);
+    await pool.query(`DROP DATABASE IF EXISTS \`${schemaName}\``);
+    return;
+  }
   await pool.query(`DELETE FROM catalog.provisioning_steps`);
   await pool.query(`DELETE FROM catalog.provisioning_runs`);
   await pool.query(`DELETE FROM catalog.usersiterelations`);
-  if (schemaName) {
-    await pool.query(`DELETE FROM catalog.sites WHERE SchemaName = ?`, [schemaName]);
-    await pool.query(`DROP DATABASE IF EXISTS \`${schemaName}\``);
-  } else {
-    await pool.query(`DELETE FROM catalog.sites WHERE SchemaName LIKE ?`, [TEST_SCHEMA_PREFIX + '%']);
-  }
+  await pool.query(`DELETE FROM catalog.sites WHERE SchemaName LIKE ?`, [TEST_SCHEMA_PREFIX + '%']);
 }
 
 /**

--- a/frontend/tests/integration/admin-provision/retry.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/retry.integration.test.ts
@@ -12,6 +12,7 @@ import {
   createTestPool,
   seedCatalogTables,
   clearProvisioningState,
+  suppressBackgroundDispatch,
   seedRun,
   seedSteps,
   makeRequest,
@@ -39,16 +40,16 @@ const TEST_SCHEMA = TEST_SCHEMA_PREFIX + 'retry';
 const URL_FOR = (runId: string) => `http://test/api/admin/provision/${runId}/retry`;
 
 describe('POST /api/admin/provision/[runId]/retry (integration)', () => {
-  let setImmediateSpy: ReturnType<typeof vi.spyOn>;
+  let setImmediateSpy: ReturnType<typeof suppressBackgroundDispatch>;
 
   beforeAll(async () => {
     testPool = createTestPool();
     await seedCatalogTables(testPool);
-    setImmediateSpy = vi.spyOn(globalThis, 'setImmediate').mockImplementation(((_cb: any) => 0) as any);
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    setImmediateSpy = suppressBackgroundDispatch();
     await clearProvisioningState(testPool, TEST_SCHEMA);
   });
 

--- a/frontend/tests/integration/admin-provision/start.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/start.integration.test.ts
@@ -13,6 +13,7 @@ import {
   createTestPool,
   seedCatalogTables,
   clearProvisioningState,
+  suppressBackgroundDispatch,
   makeRequest,
   GLOBAL_SESSION,
   DB_ADMIN_SESSION,
@@ -71,20 +72,16 @@ function buildValidInput(schemaName: string) {
 }
 
 describe('POST /api/admin/provision (integration)', () => {
-  let setImmediateSpy: ReturnType<typeof vi.spyOn>;
+  let setImmediateSpy: ReturnType<typeof suppressBackgroundDispatch>;
 
   beforeAll(async () => {
     testPool = createTestPool();
     await seedCatalogTables(testPool);
-    // Prevent the orchestrator's background runProvisioning kickoff from
-    // actually executing — we only need to verify the synchronous catalog
-    // insertions that startRun performs inline before `dispatchRun` schedules
-    // the real work through setImmediate.
-    setImmediateSpy = vi.spyOn(globalThis, 'setImmediate').mockImplementation(((_cb: any) => 0) as any);
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    setImmediateSpy = suppressBackgroundDispatch();
     await clearProvisioningState(testPool, TEST_SCHEMA);
   });
 
@@ -147,6 +144,11 @@ describe('POST /api/admin/provision (integration)', () => {
 
   it('inserts the run row, all step rows, and returns 202 with runId for a global admin', async () => {
     mocks.auth.mockResolvedValue(GLOBAL_SESSION);
+    // The step assertions below only hold while background dispatch is suppressed;
+    // otherwise runProvisioning races them and advances the steps past 'pending'.
+    // Asserted on the stub rather than on the resulting DB state because the
+    // background work lands a tick later, which makes any DB-based check a race.
+    expect(vi.isMockFunction(globalThis.setImmediate), 'setImmediate stub was not active: restoreMocks tore down a beforeAll spy').toBe(true);
 
     const res = await POST(makeRequest(POST_URL, { method: 'POST', body: buildValidInput(TEST_SCHEMA) }));
 

--- a/frontend/tests/integration/admin-provision/worker.integration.test.ts
+++ b/frontend/tests/integration/admin-provision/worker.integration.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import type { Pool } from 'mysql2/promise';
-import { createTestPool, seedCatalogTables, clearProvisioningState, seedRun, TEST_SCHEMA_PREFIX } from './_shared';
+import { createTestPool, seedCatalogTables, clearProvisioningState, seedRun, suppressBackgroundDispatch, TEST_SCHEMA_PREFIX } from './_shared';
 
 vi.mock('@/ailogger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
 
@@ -27,18 +27,16 @@ const STALE_HEARTBEAT_AGE_SECONDS = 600;
 
 describe('provisioning worker (integration)', () => {
   let testPool: Pool;
-  let setImmediateSpy: ReturnType<typeof vi.spyOn>;
+  let setImmediateSpy: ReturnType<typeof suppressBackgroundDispatch>;
 
   beforeAll(async () => {
     testPool = createTestPool();
     await seedCatalogTables(testPool);
-    // Suppress the actual provisioning kickoff that `dispatchRun` triggers
-    // through setImmediate. We only need to verify selection logic.
-    setImmediateSpy = vi.spyOn(globalThis, 'setImmediate').mockImplementation(((_cb: any) => 0) as any);
   });
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    setImmediateSpy = suppressBackgroundDispatch();
     _resetForTests();
     await clearProvisioningState(testPool, TEST_SCHEMA);
   });


### PR DESCRIPTION
Integration runs have been failing intermittently on `start.integration.test.ts` with `ER_LOCK_DEADLOCK` raised from `beforeEach`, not from any assertion — most recently killing the gate on #452, whose diff touches nothing in this area. Two separate defects combine to cause it.

## The concurrent writer

`vitest.integration.config.mts` sets `restoreMocks`, which restores spies before each test. `start`, `retry`, and `worker` installed their `setImmediate` stub in `beforeAll`, so the seam meant to suppress `dispatchRun` was dead from the second test onward. Those files' comments claim the background kickoff is suppressed; it was not.

MySQL's general log for one 290ms run of `start.integration.test.ts` showed what actually happened: 4 `isRunOwnedByCurrentWorker` selects, a heartbeat `UPDATE`, a real `CREATE DATABASE`, and schema DDL — genuine background provisioning plus a 10-second heartbeat interval that outlived the file. That interval is the writer the cleanup deadlocked against.

The stub now installs in `beforeEach`, behind a shared `suppressBackgroundDispatch()` helper so the rule and its reason live in one place. Same log after the change: zero `isRunOwned` selects, zero `CREATE DATABASE`.

## The lock footprint

`clearProvisioningState` deleted whole tables. `catalog` is shared by every integration file — only the per-site `forestgeo_test_*` schemas are isolated — so an unqualified `DELETE FROM catalog.provisioning_runs` locked every row and cascaded into `provisioning_steps`.

Deletes are now scoped to the calling file's own schema. The match is a prefix because `worker.integration.test.ts` seeds derived schemas (`_c`/`_f`/`_a`/`_fresh`); no two files' schemas prefix one another, so it cannot reach across files. LIKE metacharacters are escaped, since schema names are full of underscores. Callers passing no schema keep the table-wide wipe, which `list.integration.test.ts` needs because it asserts the route returns an empty array when no runs exist.

They use single-table subquery form rather than multi-table `DELETE ... JOIN`, which needs a default database even when every table is schema-qualified (`ER_NO_DB_ERROR` 1046) and `createTestPool` selects none.

## Regression guard

The success case in `start.integration.test.ts` now asserts the stub is live before the POST that depends on it. Reverting the seam fails that test deterministically.

The assertion is on the stub rather than on resulting DB state deliberately: the background work lands a tick after the route returns, so a first attempt that checked `information_schema` passed with the bug reintroduced. The same race also silently weakened the existing step-status assertion, which could observe steps advanced past `pending` by the background run.

## Scope

Test-only. No application code changes, no schema changes, no behavioural difference in the app.